### PR TITLE
Add recurring reminders (daily, weekly, biweekly, monthly, quarterly,…

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -731,6 +731,15 @@ async function deleteOutreach(id) {
 
 const REMINDER_TYPES = ['Follow-up', 'Delivery', 'Payment', 'Order', 'Tasting', 'Event', 'Other'];
 const PRIORITIES = ['High', 'Medium', 'Low'];
+const RECURRENCE_OPTIONS = [
+  { value: 'none',      label: 'None' },
+  { value: 'daily',     label: 'Daily' },
+  { value: 'weekly',    label: 'Weekly' },
+  { value: 'biweekly',  label: 'Every Other Week' },
+  { value: 'monthly',   label: 'Monthly' },
+  { value: 'quarterly', label: 'Quarterly' },
+  { value: 'yearly',    label: 'Yearly' },
+];
 
 function reminderForm(reminder = {}) {
   return `
@@ -765,12 +774,20 @@ function reminderForm(reminder = {}) {
         </select>
       </div>
     </div>
-    <div class="form-group">
-      <label>Assign To</label>
-      <select class="form-control" id="f-staff">
-        <option value="">-- Unassigned --</option>
-        ${staffOptions(reminder.StaffID)}
-      </select>
+    <div class="form-row">
+      <div class="form-group">
+        <label>Assign To</label>
+        <select class="form-control" id="f-staff">
+          <option value="">-- Unassigned --</option>
+          ${staffOptions(reminder.StaffID)}
+        </select>
+      </div>
+      <div class="form-group">
+        <label>Recurrence</label>
+        <select class="form-control" id="f-recurrence">
+          ${RECURRENCE_OPTIONS.map(o => `<option value="${o.value}" ${(reminder.Recurrence || 'none') === o.value ? 'selected' : ''}>${o.label}</option>`).join('')}
+        </select>
+      </div>
     </div>
     <div class="form-group">
       <label>Notes</label>
@@ -834,7 +851,7 @@ async function loadReminders() {
             filtered.map(r => `<tr>
               <td>${formatDate(r.DueDate)}</td>
               <td>${urgencyBadge(r.DueDate, r.Completed)}</td>
-              <td class="fw-600">${esc(r.Title)}</td>
+              <td class="fw-600">${esc(r.Title)}${r.Recurrence && r.Recurrence !== 'none' ? ` <span class="badge badge-recurrence" title="${esc(RECURRENCE_OPTIONS.find(o => o.value === r.Recurrence)?.label || r.Recurrence)}">↻</span>` : ''}</td>
               <td class="text-sm">${esc(r.AccountName) || '—'}</td>
               <td class="text-sm">${esc(r.Type)}</td>
               <td class="text-sm">${esc(r.StaffName) || '<span class="text-muted">—</span>'}</td>
@@ -869,6 +886,7 @@ function openAddReminder(presetAccountId = '') {
       Title: title, DueDate: dueDate, Priority: val('f-priority'),
       Type: val('f-type'), AccountID: accountId, AccountName: accountName,
       StaffID: staffId, StaffName: staffName, Notes: val('f-notes'),
+      Recurrence: val('f-recurrence'),
     });
     modal.close();
     toast('Reminder added');
@@ -891,6 +909,7 @@ function openEditReminder(id) {
       Title: title, DueDate: dueDate, Priority: val('f-priority'),
       Type: val('f-type'), AccountID: accountId, AccountName: accountName,
       StaffID: staffId, StaffName: staffName, Notes: val('f-notes'),
+      Recurrence: val('f-recurrence'),
     });
     modal.close();
     toast('Reminder updated');
@@ -899,8 +918,13 @@ function openEditReminder(id) {
 }
 
 async function completeReminder(id) {
-  await api.put(`/api/reminders/${id}`, { Completed: 'true' });
-  toast('Marked as done');
+  const result = await api.put(`/api/reminders/${id}`, { Completed: 'true' });
+  if (result._nextReminder) {
+    const label = RECURRENCE_OPTIONS.find(o => o.value === result._nextReminder.Recurrence)?.label || result._nextReminder.Recurrence;
+    toast(`Done — next ${label.toLowerCase()} occurrence on ${formatDate(result._nextReminder.DueDate)}`);
+  } else {
+    toast('Marked as done');
+  }
   loadReminders();
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -488,7 +488,8 @@ tbody td {
 .badge-today     { background: var(--warning-bg); color: var(--warning-text); }
 .badge-upcoming  { background: var(--success-bg); color: var(--success-text); }
 .badge-future    { background: var(--neutral-bg); color: var(--neutral-text); }
-.badge-completed { background: var(--neutral-bg); color: var(--neutral-text); }
+.badge-completed  { background: var(--neutral-bg); color: var(--neutral-text); }
+.badge-recurrence { background: var(--neutral-bg); color: var(--neutral-text); font-size: 0.7rem; padding: 1px 4px; vertical-align: middle; cursor: default; }
 
 .badge-low-stock { background: var(--danger-bg); color: var(--danger-text); }
 .badge-ok-stock  { background: var(--success-bg); color: var(--success-text); }

--- a/routes/reminders.js
+++ b/routes/reminders.js
@@ -6,6 +6,21 @@ const { getAllRows, addRow, updateRow, deleteRow } = require('../sheets');
 
 const router = express.Router();
 
+const RECURRENCE_VALUES = new Set(['none', 'daily', 'weekly', 'biweekly', 'monthly', 'quarterly', 'yearly']);
+
+function nextDueDate(dueDateStr, recurrence) {
+  const d = new Date(dueDateStr + 'T00:00:00');
+  switch (recurrence) {
+    case 'daily':     d.setDate(d.getDate() + 1); break;
+    case 'weekly':    d.setDate(d.getDate() + 7); break;
+    case 'biweekly':  d.setDate(d.getDate() + 14); break;
+    case 'monthly':   d.setMonth(d.getMonth() + 1); break;
+    case 'quarterly': d.setMonth(d.getMonth() + 3); break;
+    case 'yearly':    d.setFullYear(d.getFullYear() + 1); break;
+  }
+  return d.toISOString().split('T')[0];
+}
+
 router.get('/', async (req, res) => {
   try {
     const { status } = req.query; // 'active', 'completed', 'all'
@@ -27,9 +42,11 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
   try {
-    const { Type, AccountID, AccountName, Title, DueDate, Priority, Notes, StaffID, StaffName } = req.body;
+    const { Type, AccountID, AccountName, Title, DueDate, Priority, Notes, StaffID, StaffName, Recurrence, RecurrenceParentID } = req.body;
     if (!Title) return res.status(400).json({ error: 'Title is required' });
     if (!DueDate) return res.status(400).json({ error: 'DueDate is required' });
+
+    const recurrence = RECURRENCE_VALUES.has(Recurrence) ? Recurrence : 'none';
 
     const reminder = {
       ID: uuidv4(),
@@ -43,6 +60,8 @@ router.post('/', async (req, res) => {
       Completed: 'false',
       StaffID: StaffID || '',
       StaffName: StaffName || '',
+      Recurrence: recurrence,
+      RecurrenceParentID: RecurrenceParentID || '',
       CreatedAt: new Date().toISOString().split('T')[0],
     };
 
@@ -59,6 +78,29 @@ router.put('/:id', async (req, res) => {
     delete updates.ID;
     delete updates.CreatedAt;
     const updated = await updateRow('REMINDERS', req.params.id, updates);
+
+    // When completing a recurring reminder, spawn the next occurrence
+    if (updates.Completed === 'true' && updated.Recurrence && RECURRENCE_VALUES.has(updated.Recurrence) && updated.Recurrence !== 'none') {
+      const next = {
+        ID: uuidv4(),
+        Type: updated.Type || 'Other',
+        AccountID: updated.AccountID || '',
+        AccountName: updated.AccountName || '',
+        Title: updated.Title,
+        DueDate: nextDueDate(updated.DueDate, updated.Recurrence),
+        Priority: updated.Priority || 'Medium',
+        Notes: updated.Notes || '',
+        Completed: 'false',
+        StaffID: updated.StaffID || '',
+        StaffName: updated.StaffName || '',
+        Recurrence: updated.Recurrence,
+        RecurrenceParentID: updated.RecurrenceParentID || updated.ID,
+        CreatedAt: new Date().toISOString().split('T')[0],
+      };
+      await addRow('REMINDERS', next);
+      return res.json({ ...updated, _nextReminder: next });
+    }
+
     res.json(updated);
   } catch (err) {
     res.status(err.message.includes('not found') ? 404 : 500).json({ error: err.message });

--- a/sheets.js
+++ b/sheets.js
@@ -20,7 +20,7 @@ const HEADERS = {
   INVENTORY: ['ID', 'Name', 'Style', 'ABV', 'Format', 'Units', 'PricePerUnit', 'LowStockThreshold', 'Notes', 'LastUpdated'],
   ACCOUNTS:  ['ID', 'Name', 'Type', 'ContactName', 'Email', 'Phone', 'PreferredMethod', 'Address', 'City', 'State', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'CreatedAt'],
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
-  REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'StaffID', 'StaffName', 'CreatedAt'],
+  REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
   STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt'],
   SALES:     ['ID', 'AccountID', 'AccountName', 'StaffID', 'StaffName', 'SaleDate', 'DeliveryDate', 'InvoiceNumber', 'SaleAmount', 'TaxAmount', 'Notes', 'Status', 'CreatedAt'],
 };


### PR DESCRIPTION
… yearly)

- sheets.js: Add Recurrence and RecurrenceParentID columns to REMINDERS schema
- routes/reminders.js: Accept Recurrence on create; when a recurring reminder is marked complete, automatically spawn the next occurrence with the correct due date and return it as _nextReminder in the response
- public/app.js: Add Recurrence dropdown to the reminder form; show a ↻ badge on recurring reminders in the table; display a smart toast on completion that shows the next occurrence date
- public/style.css: Style for .badge-recurrence

https://claude.ai/code/session_01HZYXzPuSYTjeMqirqtjKjp