### PR TITLE
Add Zapier webhook endpoint for automatic sale log creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,12 @@ GOOGLE_KEY_FILE=credentials.json
 
 # Server port (optional, defaults to 3000)
 PORT=3000
+
+# ── Webhooks ──────────────────────────────────────────────────────
+# Secret token that authorises incoming Zapier webhook calls.
+# Set this to a long random string (e.g. openssl rand -hex 32).
+# If left unset, the /webhooks/zapier/sale endpoint returns 503.
+#
+# In Zapier:  Action → Webhooks by Zapier → POST
+#             Add header:  Authorization: Bearer <this value>
+WEBHOOK_SECRET=your_webhook_secret_here

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -1,0 +1,152 @@
+'use strict';
+
+/**
+ * Zapier Webhook — Sale Log Creation
+ *
+ * Endpoint:  POST /webhooks/zapier/sale
+ * Auth:      Authorization: Bearer <WEBHOOK_SECRET>
+ *
+ * Zapier setup:
+ *   Action:  Webhooks by Zapier → POST
+ *   URL:     https://<your-domain>/webhooks/zapier/sale
+ *   Headers: Authorization: Bearer <your WEBHOOK_SECRET value>
+ *   Payload format: JSON (data below)
+ *
+ * Accepted fields (all optional except at least one of account_name / AccountName / AccountID):
+ *
+ *   invoice_number  | InvoiceNumber  | invoiceNumber   → InvoiceNumber
+ *   sale_date       | SaleDate       | invoice_date    → SaleDate       (defaults to today)
+ *   delivery_date   | DeliveryDate                    → DeliveryDate
+ *   amount          | sale_amount    | SaleAmount      → SaleAmount     (pre-tax total)
+ *   tax             | tax_amount     | TaxAmount       → TaxAmount
+ *   status          | Status                          → Status          (Pending/Delivered/Paid/Cancelled)
+ *   notes           | Notes          | memo            → Notes
+ *   account_id      | AccountID                       → AccountID       (our internal ID)
+ *   account_name    | AccountName    | customer_name
+ *                   | client_name                     → account name lookup
+ *
+ * Responses:
+ *   201  { sale }                — created successfully
+ *   400  { error, details }      — missing/invalid fields
+ *   401  { error }               — bad or missing token
+ *   404  { error }               — account name not found
+ *   503  { error }               — WEBHOOK_SECRET not configured on server
+ */
+
+const express = require('express');
+const { v4: uuidv4 } = require('uuid');
+const { getAllRows, addRow } = require('../sheets');
+
+const router = express.Router();
+
+// ── Auth middleware ──────────────────────────────────────────────
+
+function requireWebhookSecret(req, res, next) {
+  const secret = process.env.WEBHOOK_SECRET;
+  if (!secret) {
+    return res.status(503).json({ error: 'Webhook not configured: WEBHOOK_SECRET is not set on this server.' });
+  }
+
+  const authHeader = req.headers['authorization'] || '';
+  const provided = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : '';
+
+  if (!provided || provided !== secret) {
+    return res.status(401).json({ error: 'Unauthorized: invalid or missing Bearer token.' });
+  }
+
+  next();
+}
+
+// ── Field normalisation ──────────────────────────────────────────
+
+// Pick the first key in `body` that matches any of the given candidates.
+function pick(body, ...keys) {
+  for (const k of keys) {
+    if (body[k] !== undefined && body[k] !== null && body[k] !== '') return String(body[k]).trim();
+  }
+  return '';
+}
+
+function normalise(body) {
+  return {
+    accountId:     pick(body, 'AccountID',     'account_id'),
+    accountName:   pick(body, 'AccountName',   'account_name', 'customer_name', 'client_name'),
+    invoiceNumber: pick(body, 'InvoiceNumber', 'invoice_number', 'invoiceNumber'),
+    saleDate:      pick(body, 'SaleDate',      'sale_date',     'invoice_date', 'date'),
+    deliveryDate:  pick(body, 'DeliveryDate',  'delivery_date'),
+    saleAmount:    pick(body, 'SaleAmount',    'sale_amount',   'amount',    'subtotal'),
+    taxAmount:     pick(body, 'TaxAmount',     'tax_amount',    'tax'),
+    status:        pick(body, 'Status',        'status'),
+    notes:         pick(body, 'Notes',         'notes',         'memo'),
+  };
+}
+
+const VALID_STATUSES = new Set(['Pending', 'Delivered', 'Paid', 'Cancelled']);
+
+// ── POST /webhooks/zapier/sale ───────────────────────────────────
+
+router.post('/zapier/sale', requireWebhookSecret, async (req, res) => {
+  try {
+    const f = normalise(req.body);
+
+    // Require at least an account identifier
+    if (!f.accountId && !f.accountName) {
+      return res.status(400).json({
+        error: 'Missing required field: provide AccountID or AccountName (or account_name / customer_name).',
+      });
+    }
+
+    // Resolve account
+    let resolvedAccountId   = f.accountId;
+    let resolvedAccountName = f.accountName;
+
+    if (!resolvedAccountId && resolvedAccountName) {
+      const accounts = await getAllRows('ACCOUNTS');
+      const match = accounts.find(
+        a => a.Name && a.Name.toLowerCase() === resolvedAccountName.toLowerCase()
+      );
+      if (!match) {
+        return res.status(404).json({
+          error: `Account not found: no account named "${resolvedAccountName}". ` +
+                 'Check the spelling or use AccountID instead.',
+        });
+      }
+      resolvedAccountId   = match.ID;
+      resolvedAccountName = match.Name;
+    }
+
+    // Date defaults
+    const today    = new Date().toISOString().split('T')[0];
+    const saleDate = f.saleDate || today;
+
+    // Status validation
+    let status = f.status || 'Pending';
+    // Capitalise first letter to match our enum
+    status = status.charAt(0).toUpperCase() + status.slice(1);
+    if (!VALID_STATUSES.has(status)) status = 'Pending';
+
+    const sale = {
+      ID:            uuidv4(),
+      AccountID:     resolvedAccountId,
+      AccountName:   resolvedAccountName,
+      StaffID:       '',
+      StaffName:     '',
+      SaleDate:      saleDate,
+      DeliveryDate:  f.deliveryDate || '',
+      InvoiceNumber: f.invoiceNumber || '',
+      SaleAmount:    f.saleAmount   || '0',
+      TaxAmount:     f.taxAmount    || '0',
+      Notes:         f.notes        || '',
+      Status:        status,
+      CreatedAt:     today,
+    };
+
+    await addRow('SALES', sale);
+
+    res.status(201).json({ sale });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const remindersRoutes = require('./routes/reminders');
 const staffRoutes     = require('./routes/staff');
 const salesRoutes     = require('./routes/sales');
 const dashboardRoutes = require('./routes/dashboard');
+const webhooksRoutes  = require('./routes/webhooks');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -26,6 +27,7 @@ app.use('/api/reminders', remindersRoutes);
 app.use('/api/staff',     staffRoutes);
 app.use('/api/sales',     salesRoutes);
 app.use('/api/dashboard', dashboardRoutes);
+app.use('/webhooks',      webhooksRoutes);
 
 app.get('/api/status', (req, res) => {
   res.json({


### PR DESCRIPTION
POST /webhooks/zapier/sale accepts a JSON payload from Zapier (or any HTTP client) and creates a sale log entry in the Sales sheet.

- routes/webhooks.js: new route with Bearer token auth (WEBHOOK_SECRET), flexible field mapping to accept snake_case, camelCase, or canonical names from any invoicing system, and account lookup by name when AccountID is not available
- server.js: mount webhooks router at /webhooks
- .env.example: document WEBHOOK_SECRET with generation instructions

Zapier setup:
  Action:  Webhooks by Zapier → POST
  URL:     https://<your-domain>/webhooks/zapier/sale
  Header:  Authorization: Bearer <WEBHOOK_SECRET>
  Payload: JSON with invoice fields (see routes/webhooks.js for full field map)

https://claude.ai/code/session_01HZYXzPuSYTjeMqirqtjKjp