### PR TITLE
Fix Done button broken by single quotes in account names

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -880,7 +880,7 @@ function renderReminders() {
               <td>${priorityBadge(r.Priority)}</td>
               <td class="td-actions">
                 ${r.Completed !== 'true'
-                  ? `<button class="btn btn-ghost btn-sm text-success" onclick="completeReminder('${esc(r.ID)}','${esc(r.AccountID||'')}','${esc(r.AccountName||'')}')">Done</button>`
+                  ? `<button class="btn btn-ghost btn-sm text-success" onclick="completeReminder('${esc(r.ID)}')">Done</button>`
                   : `<button class="btn btn-ghost btn-sm" onclick="reopenReminder('${esc(r.ID)}')">Reopen</button>`
                 }
                 <button class="btn btn-ghost btn-sm" onclick="openEditReminder('${esc(r.ID)}')">Edit</button>
@@ -939,12 +939,13 @@ function openEditReminder(id) {
   });
 }
 
-async function completeReminder(id, accountId = '', accountName = '') {
-  // Prefer data from cache (reminders view); fall back to passed-in args (dashboard)
-  const cached = _remindersCache.find(r => r.ID === id);
-  const acctId   = (cached && cached.AccountID)   || accountId;
-  const acctName = (cached && cached.AccountName) || accountName;
-  const title    = (cached && cached.Title) || '';
+async function completeReminder(id) {
+  // Look up reminder data from whichever cache is populated
+  const reminder = _remindersCache.find(r => r.ID === id)
+                || (state.dashReminders || []).find(r => r.ID === id);
+  const acctId   = reminder?.AccountID   || '';
+  const acctName = reminder?.AccountName || '';
+  const title    = reminder?.Title       || '';
 
   const formHtml = `
     <p style="margin:0 0 14px;color:var(--text-secondary);font-size:13px">
@@ -1035,6 +1036,7 @@ async function loadDashboard() {
     api.get('/api/accounts'),
   ]);
   state.accounts = accounts;
+  state.dashReminders = [...(dash.overdueReminders || []), ...(dash.upcomingReminders || [])];
 
   const lowStockHtml = dash.lowStockItems.length === 0
     ? '<li class="empty-state" style="padding:12px 0">All products are well stocked.</li>'
@@ -1066,7 +1068,7 @@ async function loadDashboard() {
             ${urgencyBadge(r.DueDate, r.Completed)}
             <span class="dash-label">${esc(r.Title)}</span>
             ${r.AccountName ? `<span class="text-muted text-sm"> &mdash; ${esc(r.AccountName)}</span>` : ''}
-            <button class="btn btn-ghost btn-sm text-success" onclick="event.stopPropagation();completeReminder('${esc(r.ID)}','${esc(r.AccountID||'')}','${esc(r.AccountName||'')}')">Done</button>
+            <button class="btn btn-ghost btn-sm text-success" onclick="event.stopPropagation();completeReminder('${esc(r.ID)}')">Done</button>
           </li>`).join('')}
       </ul>
     </div>`;


### PR DESCRIPTION
The root cause: account names/IDs were passed through onclick attributes as JS string literals using esc(), but esc() doesn't escape single quotes. An account name like "Murphy's Bar" would generate:
  onclick="completeReminder('id','acct','Murphy's Bar')"
which is a JS syntax error, silently breaking the click handler for any reminder tied to an account with an apostrophe in its name.

Fix: pass only the reminder ID and look up the full data from state:
- _remindersCache (populated when viewing the Reminders view)
- state.dashReminders (now populated in loadDashboard from overdue + upcoming reminder lists) for lookups from the dashboard

https://claude.ai/code/session_01HZYXzPuSYTjeMqirqtjKjp