### PR TITLE
Fix: Complete Todo from account profile reloads profile, not dashboard

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1291,7 +1291,8 @@ async function completeTodo(id) {
       toast(logOutreach ? 'Marked done & outreach logged' : 'Marked as done');
     }
 
-    if (state.view === 'todos') loadTodos();
+    if (state.view === 'account-profile') loadAccountProfile(state.accountProfileId);
+    else if (state.view === 'todos') loadTodos();
     else loadDashboard();
   }, 'Mark Done');
 


### PR DESCRIPTION
completeTodo() was falling through to loadDashboard() because it only checked for the 'todos' view. Added 'account-profile' check so marking a todo done from the account detail page stays on that page.

https://claude.ai/code/session_01HZYXzPuSYTjeMqirqtjKjp