### PR TITLE
Replace Delivered sale status with a dedicated delivered toggle

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -610,7 +610,7 @@ async function loadAccountProfile(accountId) {
       </tr>`).join('');
 
   const salesRows = acctSales.length === 0
-    ? `<tr><td colspan="7" class="empty-state">No sales recorded yet.</td></tr>`
+    ? `<tr><td colspan="9" class="empty-state">No sales recorded yet.</td></tr>`
     : acctSales.map(s => {
         const total = parseFloat(s.SaleAmount || 0) + parseFloat(s.TaxAmount || 0);
         return `<tr>
@@ -621,6 +621,7 @@ async function loadAccountProfile(accountId) {
           <td>${s.TaxAmount && parseFloat(s.TaxAmount) > 0 ? fmtMoney(s.TaxAmount) : '—'}</td>
           <td class="fw-600">${fmtMoney(total)}</td>
           <td>${salesStatusBadge(s.Status)}</td>
+          <td class="text-center"><input type="checkbox" ${s.Delivered === 'true' ? 'checked' : ''} onchange="profileToggleDelivered('${esc(s.ID)}', ${s.Delivered === 'true'})" /></td>
           <td class="td-actions">
             ${s.Status === 'Pending' ? `<button class="btn btn-ghost btn-sm text-success" onclick="profileMarkSalePaid('${esc(s.ID)}')">Mark Paid</button>` : ''}
             <button class="btn btn-ghost btn-sm" onclick="profileEditSale('${esc(s.ID)}')">Edit</button>
@@ -633,7 +634,7 @@ async function loadAccountProfile(accountId) {
     ? `<tfoot><tr class="table-totals">
         <td colspan="5" class="text-muted text-sm">${acctSales.length} sales</td>
         <td class="fw-600">${fmtMoney(totalRevenue)}</td>
-        <td colspan="2"></td>
+        <td colspan="3"></td>
       </tr></tfoot>`
     : '';
 
@@ -698,7 +699,7 @@ async function loadAccountProfile(accountId) {
       </div>
       <div class="table-wrap">
         <table>
-          <thead><tr><th>Sale Date</th><th>Invoice #</th><th>Sales Rep</th><th>Amount</th><th>Tax</th><th>Total</th><th>Status</th><th>Actions</th></tr></thead>
+          <thead><tr><th>Sale Date</th><th>Invoice #</th><th>Sales Rep</th><th>Amount</th><th>Tax</th><th>Total</th><th>Status</th><th>Delivered</th><th>Actions</th></tr></thead>
           <tbody>${salesRows}</tbody>
           ${salesFooter}
         </table>
@@ -1618,7 +1619,7 @@ async function deleteStaff(id, name) {
 
 // ── Sales View ────────────────────────────────────────────────────
 
-const SALE_STATUSES = ['Pending', 'Delivered', 'Paid', 'Cancelled'];
+const SALE_STATUSES = ['Pending', 'Paid', 'Cancelled'];
 
 function salesForm(sale = {}, presetAccountId = '') {
   const selAcctId = sale.AccountID || presetAccountId;
@@ -1673,6 +1674,12 @@ function salesForm(sale = {}, presetAccountId = '') {
       </div>
     </div>
     <div class="form-group">
+      <label class="checkbox-label">
+        <input type="checkbox" id="f-delivered" ${sale.Delivered === 'true' ? 'checked' : ''} />
+        Order Delivered
+      </label>
+    </div>
+    <div class="form-group">
       <label>Notes / Reference</label>
       <textarea class="form-control" id="f-notes" rows="2" placeholder="Order details, product breakdown, etc.">${esc(sale.Notes)}</textarea>
     </div>`;
@@ -1681,7 +1688,7 @@ function salesForm(sale = {}, presetAccountId = '') {
 let _salesCache = [];
 
 function salesStatusBadge(status) {
-  const map = { Pending: 'badge-pending', Delivered: 'badge-delivered', Paid: 'badge-paid', Cancelled: 'badge-cancelled' };
+  const map = { Pending: 'badge-pending', Paid: 'badge-paid', Cancelled: 'badge-cancelled' };
   return `<span class="badge ${map[status] || 'badge-pending'}">${esc(status || 'Pending')}</span>`;
 }
 
@@ -1763,11 +1770,11 @@ function renderSales() {
         <thead>
           <tr>
             <th>Sale Date</th><th>Account</th><th>Invoice #</th><th>Sales Rep</th>
-            <th>Sale Amt</th><th>Tax</th><th>Total</th><th>Delivery</th><th>Status</th><th>Actions</th>
+            <th>Sale Amt</th><th>Tax</th><th>Total</th><th>Delivery</th><th>Status</th><th>Delivered</th><th>Actions</th>
           </tr>
         </thead>
         <tbody>
-          ${filtered.length === 0 ? `<tr><td colspan="10" class="empty-state">No sales found.</td></tr>` :
+          ${filtered.length === 0 ? `<tr><td colspan="11" class="empty-state">No sales found.</td></tr>` :
             filtered.map(s => {
               const total = parseFloat(s.SaleAmount || 0) + parseFloat(s.TaxAmount || 0);
               return `<tr>
@@ -1780,6 +1787,7 @@ function renderSales() {
                 <td class="fw-600">${fmtMoney(total)}</td>
                 <td class="text-sm">${s.DeliveryDate ? formatDate(s.DeliveryDate) : '—'}</td>
                 <td>${salesStatusBadge(s.Status)}</td>
+                <td class="text-center"><input type="checkbox" ${s.Delivered === 'true' ? 'checked' : ''} onchange="toggleDelivered('${esc(s.ID)}')" /></td>
                 <td class="td-actions">
                   ${s.Status === 'Pending' ? `<button class="btn btn-ghost btn-sm text-success" onclick="markSalePaid('${esc(s.ID)}')">Mark Paid</button>` : ''}
                   <button class="btn btn-ghost btn-sm" onclick="openEditSale('${esc(s.ID)}')">Edit</button>
@@ -1795,7 +1803,7 @@ function renderSales() {
             <td>${fmtMoney(totalSale)}</td>
             <td>${fmtMoney(totalTax)}</td>
             <td class="fw-600">${fmtMoney(totalSale + totalTax)}</td>
-            <td colspan="3"></td>
+            <td colspan="4"></td>
           </tr>
         </tfoot>` : ''}
       </table>
@@ -1821,6 +1829,7 @@ async function openAddSale(presetAccountId = '') {
       InvoiceNumber: val('f-invoice'), Status: val('f-status'),
       SaleAmount: val('f-amount'), TaxAmount: val('f-tax'),
       Notes: val('f-notes'),
+      Delivered: document.getElementById('f-delivered').checked ? 'true' : 'false',
     });
     modal.close();
     toast('Sale logged');
@@ -1841,6 +1850,7 @@ function openEditSale(id) {
       InvoiceNumber: val('f-invoice'), Status: val('f-status'),
       SaleAmount: val('f-amount'), TaxAmount: val('f-tax'),
       Notes: val('f-notes'),
+      Delivered: document.getElementById('f-delivered').checked ? 'true' : 'false',
     });
     modal.close();
     toast('Sale updated');
@@ -1863,9 +1873,25 @@ async function markSalePaid(id) {
   loadSales();
 }
 
+async function toggleDelivered(id) {
+  const sale = _salesCache.find(s => s.ID === id);
+  if (!sale) return;
+  const newDelivered = sale.Delivered === 'true' ? 'false' : 'true';
+  await api.put(`/api/sales/${id}`, { Delivered: newDelivered });
+  toast(newDelivered === 'true' ? 'Marked as delivered' : 'Marked as undelivered');
+  loadSales();
+}
+
 async function profileMarkSalePaid(id) {
   await api.put(`/api/sales/${id}`, { Status: 'Paid' });
   toast('Sale marked as paid');
+  loadAccountProfile(state.accountProfileId);
+}
+
+async function profileToggleDelivered(id, isDelivered) {
+  const newDelivered = isDelivered ? 'false' : 'true';
+  await api.put(`/api/sales/${id}`, { Delivered: newDelivered });
+  toast(newDelivered === 'true' ? 'Marked as delivered' : 'Marked as undelivered');
   loadAccountProfile(state.accountProfileId);
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -580,7 +580,6 @@ tbody td {
 
 /* Sales status badges */
 .badge-pending   { background: #e3f2fd; color: #1565c0; }
-.badge-delivered { background: var(--warning-bg); color: var(--warning-text); }
 .badge-paid      { background: var(--success-bg); color: var(--success-text); }
 .badge-cancelled { background: var(--neutral-bg); color: var(--neutral-text); }
 

--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -41,7 +41,7 @@ router.get('/', async (req, res) => {
     const currentMonth = today.substring(0, 7); // 'YYYY-MM'
     const monthlySales = sales.filter(s => (s.SaleDate || '').startsWith(currentMonth));
     const monthlySalesTotal = monthlySales.reduce((sum, s) => sum + parseFloat(s.SaleAmount || 0), 0);
-    const pendingDeliveries = sales.filter(s => s.Status === 'Pending' || s.Status === 'Delivered').length;
+    const pendingDeliveries = sales.filter(s => s.Delivered !== 'true' && s.Status !== 'Cancelled').length;
 
     res.json({
       totalProducts: inventory.length,

--- a/routes/sales.js
+++ b/routes/sales.js
@@ -25,7 +25,7 @@ router.post('/', async (req, res) => {
     const {
       AccountID, AccountName, StaffID, StaffName,
       SaleDate, DeliveryDate, InvoiceNumber,
-      SaleAmount, TaxAmount, Notes, Status,
+      SaleAmount, TaxAmount, Notes, Status, Delivered,
     } = req.body;
 
     if (!AccountID) return res.status(400).json({ error: 'AccountID is required' });
@@ -42,8 +42,9 @@ router.post('/', async (req, res) => {
       InvoiceNumber: InvoiceNumber || '',
       SaleAmount: SaleAmount || '0',
       TaxAmount:  TaxAmount  || '0',
-      Notes:  Notes  || '',
-      Status: Status || 'Pending',
+      Notes:     Notes     || '',
+      Status:    Status    || 'Pending',
+      Delivered: Delivered || 'false',
       CreatedAt: new Date().toISOString().split('T')[0],
     };
 

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -19,7 +19,7 @@
  *   delivery_date   | DeliveryDate                    → DeliveryDate
  *   amount          | sale_amount    | SaleAmount      → SaleAmount     (pre-tax total)
  *   tax             | tax_amount     | TaxAmount       → TaxAmount
- *   status          | Status                          → Status          (Pending/Delivered/Paid/Cancelled)
+ *   status          | Status                          → Status          (Pending/Paid/Cancelled)
  *   notes           | Notes          | memo            → Notes
  *   account_id      | AccountID                       → AccountID       (our internal ID)
  *   account_name    | AccountName    | customer_name
@@ -81,7 +81,7 @@ function normalise(body) {
   };
 }
 
-const VALID_STATUSES = new Set(['Pending', 'Delivered', 'Paid', 'Cancelled']);
+const VALID_STATUSES = new Set(['Pending', 'Paid', 'Cancelled']);
 
 // ── POST /webhooks/zapier/sale ───────────────────────────────────
 

--- a/sheets.js
+++ b/sheets.js
@@ -22,7 +22,7 @@ const HEADERS = {
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
   REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
   STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt'],
-  SALES:     ['ID', 'AccountID', 'AccountName', 'StaffID', 'StaffName', 'SaleDate', 'DeliveryDate', 'InvoiceNumber', 'SaleAmount', 'TaxAmount', 'Notes', 'Status', 'CreatedAt'],
+  SALES:     ['ID', 'AccountID', 'AccountName', 'StaffID', 'StaffName', 'SaleDate', 'DeliveryDate', 'InvoiceNumber', 'SaleAmount', 'TaxAmount', 'Notes', 'Status', 'Delivered', 'CreatedAt'],
 };
 
 // Cached sheet header rows — avoids an extra API call on every write


### PR DESCRIPTION
- Remove "Delivered" from SALE_STATUSES; valid statuses are now Pending, Paid, Cancelled
- Add a boolean Delivered column to the SALES sheet schema (auto-migrated)
- Add delivered checkbox to the sale form (create & edit)
- Add Delivered column with checkbox toggle to the sales list table and account profile sales table
- Add toggleDelivered() and profileToggleDelivered() functions for inline toggling
- Update dashboard pendingDeliveries count to use the new Delivered field
- Remove badge-delivered CSS class

https://claude.ai/code/session_01M1t76qQwADdqEKVZUbkHhM