### PR TITLE
Rename Sales to Orders throughout the application

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ PORT=3000
 # ── Webhooks ──────────────────────────────────────────────────────
 # Secret token that authorises incoming Zapier webhook calls.
 # Set this to a long random string (e.g. openssl rand -hex 32).
-# If left unset, the /webhooks/zapier/sale endpoint returns 503.
+# If left unset, the /webhooks/zapier/order endpoint returns 503.
 #
 # In Zapier:  Action → Webhooks by Zapier → POST
 #             Add header:  Authorization: Bearer <this value>

--- a/public/app.js
+++ b/public/app.js
@@ -554,10 +554,10 @@ async function loadAccountProfile(accountId) {
   });
   showLoading();
 
-  const [outreach, todos, sales] = await Promise.all([
+  const [outreach, todos, orders] = await Promise.all([
     api.get('/api/outreach'),
     api.get('/api/reminders?status=all'),
-    api.get('/api/sales'),
+    api.get('/api/orders'),
   ]);
   if (state.accounts.length === 0) state.accounts = await api.get('/api/accounts');
 
@@ -570,11 +570,11 @@ async function loadAccountProfile(accountId) {
   const acctTodos = todos
     .filter(t => t.AccountID === accountId)
     .sort((a, b) => (a.DueDate || '').localeCompare(b.DueDate || ''));
-  const acctSales = sales
+  const acctOrders = orders
     .filter(s => s.AccountID === accountId)
-    .sort((a, b) => (b.SaleDate || '').localeCompare(a.SaleDate || ''));
+    .sort((a, b) => (b.OrderDate || '').localeCompare(a.OrderDate || ''));
 
-  const totalRevenue = acctSales.reduce((sum, s) => sum + (parseFloat(s.SaleAmount || 0) + parseFloat(s.TaxAmount || 0)), 0);
+  const totalRevenue = acctOrders.reduce((sum, s) => sum + (parseFloat(s.OrderAmount || 0) + parseFloat(s.TaxAmount || 0)), 0);
   const activeTodos  = acctTodos.filter(t => t.Completed !== 'true').length;
 
   const infoRows = [
@@ -618,30 +618,30 @@ async function loadAccountProfile(accountId) {
         </td>
       </tr>`).join('');
 
-  const salesRows = acctSales.length === 0
-    ? `<tr><td colspan="9" class="empty-state">No sales recorded yet.</td></tr>`
-    : acctSales.map(s => {
-        const total = parseFloat(s.SaleAmount || 0) + parseFloat(s.TaxAmount || 0);
+  const orderRows = acctOrders.length === 0
+    ? `<tr><td colspan="9" class="empty-state">No orders recorded yet.</td></tr>`
+    : acctOrders.map(s => {
+        const total = parseFloat(s.OrderAmount || 0) + parseFloat(s.TaxAmount || 0);
         return `<tr>
-          <td class="text-sm">${formatDate(s.SaleDate)}</td>
+          <td class="text-sm">${formatDate(s.OrderDate)}</td>
           <td class="text-sm">${esc(s.InvoiceNumber) || '—'}</td>
           <td class="text-sm">${esc(s.StaffName) || '—'}</td>
-          <td>${fmtMoney(s.SaleAmount)}</td>
+          <td>${fmtMoney(s.OrderAmount)}</td>
           <td>${s.TaxAmount && parseFloat(s.TaxAmount) > 0 ? fmtMoney(s.TaxAmount) : '—'}</td>
           <td class="fw-600">${fmtMoney(total)}</td>
-          <td>${salesStatusBadge(s.Status)}</td>
+          <td>${orderStatusBadge(s.Status)}</td>
           <td class="text-center"><input type="checkbox" ${s.Delivered === 'true' ? 'checked' : ''} onchange="profileToggleDelivered('${esc(s.ID)}', ${s.Delivered === 'true'})" /></td>
           <td class="td-actions">
-            ${s.Status === 'Pending' ? `<button class="btn btn-ghost btn-sm text-success" onclick="profileMarkSalePaid('${esc(s.ID)}')">Mark Paid</button>` : ''}
-            <button class="btn btn-ghost btn-sm" onclick="profileEditSale('${esc(s.ID)}')">Edit</button>
-            <button class="btn btn-ghost btn-sm text-danger" onclick="profileDeleteSale('${esc(s.ID)}')">Del</button>
+            ${s.Status === 'Pending' ? `<button class="btn btn-ghost btn-sm text-success" onclick="profileMarkOrderPaid('${esc(s.ID)}')">Mark Paid</button>` : ''}
+            <button class="btn btn-ghost btn-sm" onclick="profileEditOrder('${esc(s.ID)}')">Edit</button>
+            <button class="btn btn-ghost btn-sm text-danger" onclick="profileDeleteOrder('${esc(s.ID)}')">Del</button>
           </td>
         </tr>`;
       }).join('');
 
-  const salesFooter = acctSales.length > 1
+  const orderFooter = acctOrders.length > 1
     ? `<tfoot><tr class="table-totals">
-        <td colspan="5" class="text-muted text-sm">${acctSales.length} sales</td>
+        <td colspan="5" class="text-muted text-sm">${acctOrders.length} orders</td>
         <td class="fw-600">${fmtMoney(totalRevenue)}</td>
         <td colspan="3"></td>
       </tr></tfoot>`
@@ -659,7 +659,7 @@ async function loadAccountProfile(accountId) {
       <div class="view-header-actions">
         <button class="btn btn-ghost btn-sm" onclick="openLogOutreach('${esc(accountId)}')">+ Log Contact</button>
         <button class="btn btn-ghost btn-sm" onclick="openAddTodo('${esc(accountId)}')">+ Add Todo</button>
-        <button class="btn btn-ghost btn-sm" onclick="openAddSale('${esc(accountId)}')">+ Log Sale</button>
+        <button class="btn btn-ghost btn-sm" onclick="openAddOrder('${esc(accountId)}')">+ Log Order</button>
         <button class="btn btn-primary btn-sm" onclick="openEditAccount('${esc(accountId)}')">Edit Account</button>
       </div>
     </div>
@@ -667,7 +667,7 @@ async function loadAccountProfile(accountId) {
     <div class="profile-stats">
       <div class="profile-stat"><div class="stat-value">${acctOutreach.length}</div><div class="stat-label">Contacts Logged</div></div>
       <div class="profile-stat"><div class="stat-value">${activeTodos}</div><div class="stat-label">Open Todos</div></div>
-      <div class="profile-stat"><div class="stat-value">${acctSales.length}</div><div class="stat-label">Sales</div></div>
+      <div class="profile-stat"><div class="stat-value">${acctOrders.length}</div><div class="stat-label">Orders</div></div>
       <div class="profile-stat"><div class="stat-value">${fmtMoney(totalRevenue)}</div><div class="stat-label">Total Revenue</div></div>
     </div>
 
@@ -703,14 +703,14 @@ async function loadAccountProfile(accountId) {
 
     <div class="profile-section">
       <div class="profile-section-header">
-        <h3>Sales History <span class="text-muted text-sm">(${acctSales.length})</span></h3>
-        <button class="btn btn-ghost btn-sm" onclick="openAddSale('${esc(accountId)}')">+ Log Sale</button>
+        <h3>Order History <span class="text-muted text-sm">(${acctOrders.length})</span></h3>
+        <button class="btn btn-ghost btn-sm" onclick="openAddOrder('${esc(accountId)}')">+ Log Order</button>
       </div>
       <div class="table-wrap">
         <table>
-          <thead><tr><th>Sale Date</th><th>Invoice #</th><th>Sales Rep</th><th>Amount</th><th>Tax</th><th>Total</th><th>Status</th><th>Delivered</th><th>Actions</th></tr></thead>
-          <tbody>${salesRows}</tbody>
-          ${salesFooter}
+          <thead><tr><th>Order Date</th><th>Invoice #</th><th>Sales Rep</th><th>Amount</th><th>Tax</th><th>Total</th><th>Status</th><th>Delivered</th><th>Actions</th></tr></thead>
+          <tbody>${orderRows}</tbody>
+          ${orderFooter}
         </table>
       </div>
     </div>
@@ -787,32 +787,32 @@ function profileDeleteTodo(id) {
   });
 }
 
-function profileEditSale(id) {
-  api.get('/api/sales').then(items => {
-    const sale = items.find(s => s.ID === id);
-    if (!sale) return;
-    modal.open('Edit Sale', salesForm(sale), async () => {
+function profileEditOrder(id) {
+  api.get('/api/orders').then(items => {
+    const order = items.find(s => s.ID === id);
+    if (!order) return;
+    modal.open('Edit Order', orderForm(order), async () => {
       const staffId = val('f-staff');
       const staffName = staffId ? (state.staff.find(s => s.ID === staffId) || {}).Name || '' : '';
-      await api.put(`/api/sales/${id}`, {
+      await api.put(`/api/orders/${id}`, {
         StaffID: staffId, StaffName: staffName,
-        SaleDate: val('f-sale-date'), DeliveryDate: val('f-delivery-date'),
+        OrderDate: val('f-order-date'), DeliveryDate: val('f-delivery-date'),
         InvoiceNumber: val('f-invoice'), Status: val('f-status'),
-        SaleAmount: val('f-amount'), TaxAmount: val('f-tax'),
+        OrderAmount: val('f-amount'), TaxAmount: val('f-tax'),
         Notes: val('f-notes'),
       });
       modal.close();
-      toast('Sale updated');
+      toast('Order updated');
       loadAccountProfile(state.accountProfileId);
     });
   });
 }
 
-function profileDeleteSale(id) {
-  modal.confirm('Delete Sale', 'Delete this sale record? This cannot be undone.', async () => {
-    await api.del(`/api/sales/${id}`);
+function profileDeleteOrder(id) {
+  modal.confirm('Delete Order', 'Delete this order? This cannot be undone.', async () => {
+    await api.del(`/api/orders/${id}`);
     modal.close();
-    toast('Sale deleted');
+    toast('Order deleted');
     loadAccountProfile(state.accountProfileId);
   });
 }
@@ -861,7 +861,7 @@ function openEditAccount(id) {
 async function deleteAccount(id, name) {
   modal.confirm(
     'Delete Account',
-    `Delete "${name}"? All associated outreach logs, todos, and sales will also be deleted.`,
+    `Delete "${name}"? All associated outreach logs, todos, and orders will also be deleted.`,
     async () => {
       await api.del(`/api/accounts/${id}`);
       modal.close();
@@ -1434,9 +1434,9 @@ async function loadDashboard() {
         <div class="stat-value">${dash.prospectAccounts}</div>
         <div class="stat-label">Prospects</div>
       </div>
-      <div class="stat-card accent" onclick="navigate('sales')">
-        <div class="stat-value">$${parseFloat(dash.monthlySalesTotal || 0).toLocaleString('en-US', {minimumFractionDigits: 0, maximumFractionDigits: 0})}</div>
-        <div class="stat-label">Sales This Month (${dash.monthlySalesCount || 0})</div>
+      <div class="stat-card accent" onclick="navigate('orders')">
+        <div class="stat-value">$${parseFloat(dash.monthlyOrdersTotal || 0).toLocaleString('en-US', {minimumFractionDigits: 0, maximumFractionDigits: 0})}</div>
+        <div class="stat-label">Orders This Month (${dash.monthlyOrdersCount || 0})</div>
       </div>
       <div class="stat-card ${dash.overdueCount > 0 ? 'danger' : 'warning'}" onclick="navigate('todos')">
         <div class="stat-value">${dash.overdueCount > 0 ? dash.overdueCount : dash.totalActiveReminders}</div>
@@ -1626,12 +1626,12 @@ async function deleteStaff(id, name) {
   );
 }
 
-// ── Sales View ────────────────────────────────────────────────────
+// ── Orders View ───────────────────────────────────────────────────
 
-const SALE_STATUSES = ['Pending', 'Paid', 'Cancelled'];
+const ORDER_STATUSES = ['Pending', 'Paid', 'Cancelled'];
 
-function salesForm(sale = {}, presetAccountId = '') {
-  const selAcctId = sale.AccountID || presetAccountId;
+function orderForm(order = {}, presetAccountId = '') {
+  const selAcctId = order.AccountID || presetAccountId;
   return `
     <div class="form-row">
       <div class="form-group">
@@ -1646,57 +1646,57 @@ function salesForm(sale = {}, presetAccountId = '') {
         <label>Sales Rep</label>
         <select class="form-control" id="f-staff">
           <option value="">-- Unassigned --</option>
-          ${staffOptions(sale.StaffID)}
+          ${staffOptions(order.StaffID)}
         </select>
       </div>
     </div>
     <div class="form-row">
       <div class="form-group">
-        <label>Sale Date <span class="required">*</span></label>
-        <input class="form-control" id="f-sale-date" type="date" value="${esc(sale.SaleDate || today())}" />
+        <label>Order Date <span class="required">*</span></label>
+        <input class="form-control" id="f-order-date" type="date" value="${esc(order.OrderDate || today())}" />
       </div>
       <div class="form-group">
         <label>Delivery Date</label>
-        <input class="form-control" id="f-delivery-date" type="date" value="${esc(sale.DeliveryDate)}" />
+        <input class="form-control" id="f-delivery-date" type="date" value="${esc(order.DeliveryDate)}" />
       </div>
     </div>
     <div class="form-row">
       <div class="form-group">
         <label>Invoice Number</label>
-        <input class="form-control" id="f-invoice" value="${esc(sale.InvoiceNumber)}" placeholder="e.g. INV-2024-001" />
+        <input class="form-control" id="f-invoice" value="${esc(order.InvoiceNumber)}" placeholder="e.g. INV-2024-001" />
       </div>
       <div class="form-group">
         <label>Status</label>
         <select class="form-control" id="f-status">
-          ${SALE_STATUSES.map(s => `<option value="${s}" ${sale.Status === s ? 'selected' : ''}>${s}</option>`).join('')}
+          ${ORDER_STATUSES.map(s => `<option value="${s}" ${order.Status === s ? 'selected' : ''}>${s}</option>`).join('')}
         </select>
       </div>
     </div>
     <div class="form-row">
       <div class="form-group">
-        <label>Sale Amount ($) <span class="required">*</span></label>
-        <input class="form-control" id="f-amount" type="number" step="0.01" min="0" value="${esc(sale.SaleAmount || '')}" placeholder="0.00" />
+        <label>Order Amount ($) <span class="required">*</span></label>
+        <input class="form-control" id="f-amount" type="number" step="0.01" min="0" value="${esc(order.OrderAmount || '')}" placeholder="0.00" />
       </div>
       <div class="form-group">
         <label>Tax Amount ($)</label>
-        <input class="form-control" id="f-tax" type="number" step="0.01" min="0" value="${esc(sale.TaxAmount || '')}" placeholder="0.00" />
+        <input class="form-control" id="f-tax" type="number" step="0.01" min="0" value="${esc(order.TaxAmount || '')}" placeholder="0.00" />
       </div>
     </div>
     <div class="form-group">
       <label class="checkbox-label">
-        <input type="checkbox" id="f-delivered" ${sale.Delivered === 'true' ? 'checked' : ''} />
+        <input type="checkbox" id="f-delivered" ${order.Delivered === 'true' ? 'checked' : ''} />
         Order Delivered
       </label>
     </div>
     <div class="form-group">
       <label>Notes / Reference</label>
-      <textarea class="form-control" id="f-notes" rows="2" placeholder="Order details, product breakdown, etc.">${esc(sale.Notes)}</textarea>
+      <textarea class="form-control" id="f-notes" rows="2" placeholder="Order details, product breakdown, etc.">${esc(order.Notes)}</textarea>
     </div>`;
 }
 
-let _salesCache = [];
+let _ordersCache = [];
 
-function salesStatusBadge(status) {
+function orderStatusBadge(status) {
   const map = { Pending: 'badge-pending', Paid: 'badge-paid', Cancelled: 'badge-cancelled' };
   return `<span class="badge ${map[status] || 'badge-pending'}">${esc(status || 'Pending')}</span>`;
 }
@@ -1706,28 +1706,28 @@ function fmtMoney(val) {
   return isNaN(n) ? '—' : '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
-async function loadSales() {
+async function loadOrders() {
   showLoading();
-  const [sales, accounts, staff] = await Promise.all([
-    api.get('/api/sales'),
+  const [orders, accounts, staff] = await Promise.all([
+    api.get('/api/orders'),
     api.get('/api/accounts'),
     api.get('/api/staff'),
   ]);
   state.accounts = accounts;
   state.staff = staff;
-  _salesCache = sales;
-  renderSales();
+  _ordersCache = orders;
+  renderOrders();
 }
 
-function renderSales() {
-  const sales = _salesCache;
+function renderOrders() {
+  const orders = _ordersCache;
   const _focused = document.activeElement?.id;
-  const accountFilter = (document.getElementById('sales-account') || {}).value || '';
-  const staffFilter   = (document.getElementById('sales-staff') || {}).value || '';
-  const statusFilter  = (document.getElementById('sales-status') || {}).value || '';
-  const search        = (document.getElementById('sales-search') || {}).value || '';
+  const accountFilter = (document.getElementById('orders-account') || {}).value || '';
+  const staffFilter   = (document.getElementById('orders-staff') || {}).value || '';
+  const statusFilter  = (document.getElementById('orders-status') || {}).value || '';
+  const search        = (document.getElementById('orders-search') || {}).value || '';
 
-  let filtered = sales;
+  let filtered = orders;
   if (accountFilter) filtered = filtered.filter(s => s.AccountID === accountFilter);
   if (staffFilter)   filtered = filtered.filter(s => s.StaffID === staffFilter);
   if (statusFilter)  filtered = filtered.filter(s => s.Status === statusFilter);
@@ -1740,17 +1740,17 @@ function renderSales() {
     );
   }
 
-  const totalSale = filtered.reduce((sum, s) => sum + parseFloat(s.SaleAmount || 0), 0);
-  const totalTax  = filtered.reduce((sum, s) => sum + parseFloat(s.TaxAmount  || 0), 0);
+  const totalOrder = filtered.reduce((sum, s) => sum + parseFloat(s.OrderAmount || 0), 0);
+  const totalTax   = filtered.reduce((sum, s) => sum + parseFloat(s.TaxAmount   || 0), 0);
 
   const acctOpts = `<option value="">All Accounts</option>` +
-    [...new Map(sales.map(s => [s.AccountID, s.AccountName])).entries()]
+    [...new Map(orders.map(s => [s.AccountID, s.AccountName])).entries()]
       .sort((a, b) => a[1].localeCompare(b[1]))
       .map(([id, name]) => `<option value="${esc(id)}" ${accountFilter === id ? 'selected' : ''}>${esc(name)}</option>`)
       .join('');
 
   const staffOpts = `<option value="">All Reps</option>` +
-    [...new Map(sales.filter(s => s.StaffID).map(s => [s.StaffID, s.StaffName])).entries()]
+    [...new Map(orders.filter(s => s.StaffID).map(s => [s.StaffID, s.StaffName])).entries()]
       .sort((a, b) => a[1].localeCompare(b[1]))
       .map(([id, name]) => `<option value="${esc(id)}" ${staffFilter === id ? 'selected' : ''}>${esc(name)}</option>`)
       .join('');
@@ -1758,49 +1758,49 @@ function renderSales() {
   setContent(`
     <div class="view-header">
       <div>
-        <h2>Sales Log</h2>
-        <p class="subtitle">${sales.length} sale${sales.length !== 1 ? 's' : ''} recorded</p>
+        <h2>Orders</h2>
+        <p class="subtitle">${orders.length} order${orders.length !== 1 ? 's' : ''} recorded</p>
       </div>
       <div class="view-header-actions">
-        <button class="btn btn-primary" onclick="openAddSale()">+ Log Sale</button>
+        <button class="btn btn-primary" onclick="openAddOrder()">+ Log Order</button>
       </div>
     </div>
     <div class="filter-bar">
-      <input type="search" id="sales-search" placeholder="Search account, invoice…" value="${esc(search)}" oninput="renderSales()" />
-      <select id="sales-account" onchange="renderSales()">${acctOpts}</select>
-      <select id="sales-staff" onchange="renderSales()">${staffOpts}</select>
-      <select id="sales-status" onchange="renderSales()">
+      <input type="search" id="orders-search" placeholder="Search account, invoice…" value="${esc(search)}" oninput="renderOrders()" />
+      <select id="orders-account" onchange="renderOrders()">${acctOpts}</select>
+      <select id="orders-staff" onchange="renderOrders()">${staffOpts}</select>
+      <select id="orders-status" onchange="renderOrders()">
         <option value="">All Statuses</option>
-        ${SALE_STATUSES.map(s => `<option value="${s}" ${statusFilter === s ? 'selected' : ''}>${s}</option>`).join('')}
+        ${ORDER_STATUSES.map(s => `<option value="${s}" ${statusFilter === s ? 'selected' : ''}>${s}</option>`).join('')}
       </select>
     </div>
     <div class="table-wrap">
       <table>
         <thead>
           <tr>
-            <th>Sale Date</th><th>Account</th><th>Invoice #</th><th>Sales Rep</th>
-            <th>Sale Amt</th><th>Tax</th><th>Total</th><th>Delivery</th><th>Status</th><th>Delivered</th><th>Actions</th>
+            <th>Order Date</th><th>Account</th><th>Invoice #</th><th>Sales Rep</th>
+            <th>Order Amt</th><th>Tax</th><th>Total</th><th>Delivery</th><th>Status</th><th>Delivered</th><th>Actions</th>
           </tr>
         </thead>
         <tbody>
-          ${filtered.length === 0 ? `<tr><td colspan="11" class="empty-state">No sales found.</td></tr>` :
+          ${filtered.length === 0 ? `<tr><td colspan="11" class="empty-state">No orders found.</td></tr>` :
             filtered.map(s => {
-              const total = parseFloat(s.SaleAmount || 0) + parseFloat(s.TaxAmount || 0);
+              const total = parseFloat(s.OrderAmount || 0) + parseFloat(s.TaxAmount || 0);
               return `<tr>
-                <td>${formatDate(s.SaleDate)}</td>
+                <td>${formatDate(s.OrderDate)}</td>
                 <td class="fw-600"><span class="td-link" onclick="loadAccountProfile('${esc(s.AccountID)}')">${esc(s.AccountName)}</span></td>
                 <td class="text-sm">${esc(s.InvoiceNumber) || '—'}</td>
                 <td class="text-sm">${esc(s.StaffName) || '—'}</td>
-                <td>${fmtMoney(s.SaleAmount)}</td>
+                <td>${fmtMoney(s.OrderAmount)}</td>
                 <td>${s.TaxAmount && parseFloat(s.TaxAmount) > 0 ? fmtMoney(s.TaxAmount) : '—'}</td>
                 <td class="fw-600">${fmtMoney(total)}</td>
                 <td class="text-sm">${s.DeliveryDate ? formatDate(s.DeliveryDate) : '—'}</td>
-                <td>${salesStatusBadge(s.Status)}</td>
+                <td>${orderStatusBadge(s.Status)}</td>
                 <td class="text-center"><input type="checkbox" ${s.Delivered === 'true' ? 'checked' : ''} onchange="toggleDelivered('${esc(s.ID)}')" /></td>
                 <td class="td-actions">
-                  ${s.Status === 'Pending' ? `<button class="btn btn-ghost btn-sm text-success" onclick="markSalePaid('${esc(s.ID)}')">Mark Paid</button>` : ''}
-                  <button class="btn btn-ghost btn-sm" onclick="openEditSale('${esc(s.ID)}')">Edit</button>
-                  <button class="btn btn-ghost btn-sm text-danger" onclick="deleteSale('${esc(s.ID)}')">Del</button>
+                  ${s.Status === 'Pending' ? `<button class="btn btn-ghost btn-sm text-success" onclick="markOrderPaid('${esc(s.ID)}')">Mark Paid</button>` : ''}
+                  <button class="btn btn-ghost btn-sm" onclick="openEditOrder('${esc(s.ID)}')">Edit</button>
+                  <button class="btn btn-ghost btn-sm text-danger" onclick="deleteOrder('${esc(s.ID)}')">Del</button>
                 </td>
               </tr>`;
             }).join('')}
@@ -1809,97 +1809,97 @@ function renderSales() {
         <tfoot>
           <tr class="table-totals">
             <td colspan="4" class="text-muted text-sm">${filtered.length} records</td>
-            <td>${fmtMoney(totalSale)}</td>
+            <td>${fmtMoney(totalOrder)}</td>
             <td>${fmtMoney(totalTax)}</td>
-            <td class="fw-600">${fmtMoney(totalSale + totalTax)}</td>
+            <td class="fw-600">${fmtMoney(totalOrder + totalTax)}</td>
             <td colspan="4"></td>
           </tr>
         </tfoot>` : ''}
       </table>
     </div>`);
-  if (_focused === 'sales-search') refocusSearch('sales-search');
+  if (_focused === 'orders-search') refocusSearch('orders-search');
 }
 
-async function openAddSale(presetAccountId = '') {
+async function openAddOrder(presetAccountId = '') {
   if (state.staff.length === 0) state.staff = await api.get('/api/staff');
   if (state.accounts.length === 0) state.accounts = await api.get('/api/accounts');
-  modal.open('Log Sale', salesForm({}, presetAccountId), async () => {
+  modal.open('Log Order', orderForm({}, presetAccountId), async () => {
     const accountId = presetAccountId || val('f-account');
     if (!accountId) { toast('Please select an account', 'error'); return; }
-    const saleDate = val('f-sale-date');
-    if (!saleDate) { toast('Sale date is required', 'error'); return; }
+    const orderDate = val('f-order-date');
+    if (!orderDate) { toast('Order date is required', 'error'); return; }
     const accountName = (state.accounts.find(a => a.ID === accountId) || {}).Name || '';
     const staffId = val('f-staff');
     const staffName = staffId ? (state.staff.find(s => s.ID === staffId) || {}).Name || '' : '';
-    await api.post('/api/sales', {
+    await api.post('/api/orders', {
       AccountID: accountId, AccountName: accountName,
       StaffID: staffId, StaffName: staffName,
-      SaleDate: saleDate, DeliveryDate: val('f-delivery-date'),
+      OrderDate: orderDate, DeliveryDate: val('f-delivery-date'),
       InvoiceNumber: val('f-invoice'), Status: val('f-status'),
-      SaleAmount: val('f-amount'), TaxAmount: val('f-tax'),
+      OrderAmount: val('f-amount'), TaxAmount: val('f-tax'),
       Notes: val('f-notes'),
       Delivered: document.getElementById('f-delivered').checked ? 'true' : 'false',
     });
     modal.close();
-    toast('Sale logged');
+    toast('Order logged');
     if (state.view === 'account-profile') loadAccountProfile(state.accountProfileId);
-    else loadSales();
+    else loadOrders();
   });
 }
 
-function openEditSale(id) {
-  const sale = _salesCache.find(s => s.ID === id);
-  if (!sale) return;
-  modal.open('Edit Sale', salesForm(sale), async () => {
+function openEditOrder(id) {
+  const order = _ordersCache.find(s => s.ID === id);
+  if (!order) return;
+  modal.open('Edit Order', orderForm(order), async () => {
     const staffId = val('f-staff');
     const staffName = staffId ? (state.staff.find(s => s.ID === staffId) || {}).Name || '' : '';
-    await api.put(`/api/sales/${id}`, {
+    await api.put(`/api/orders/${id}`, {
       StaffID: staffId, StaffName: staffName,
-      SaleDate: val('f-sale-date'), DeliveryDate: val('f-delivery-date'),
+      OrderDate: val('f-order-date'), DeliveryDate: val('f-delivery-date'),
       InvoiceNumber: val('f-invoice'), Status: val('f-status'),
-      SaleAmount: val('f-amount'), TaxAmount: val('f-tax'),
+      OrderAmount: val('f-amount'), TaxAmount: val('f-tax'),
       Notes: val('f-notes'),
       Delivered: document.getElementById('f-delivered').checked ? 'true' : 'false',
     });
     modal.close();
-    toast('Sale updated');
-    loadSales();
+    toast('Order updated');
+    loadOrders();
   });
 }
 
-async function deleteSale(id) {
-  modal.confirm('Delete Sale', 'Delete this sale record? This cannot be undone.', async () => {
-    await api.del(`/api/sales/${id}`);
+async function deleteOrder(id) {
+  modal.confirm('Delete Order', 'Delete this order? This cannot be undone.', async () => {
+    await api.del(`/api/orders/${id}`);
     modal.close();
-    toast('Sale deleted');
-    loadSales();
+    toast('Order deleted');
+    loadOrders();
   });
 }
 
-async function markSalePaid(id) {
-  await api.put(`/api/sales/${id}`, { Status: 'Paid' });
-  toast('Sale marked as paid');
-  loadSales();
+async function markOrderPaid(id) {
+  await api.put(`/api/orders/${id}`, { Status: 'Paid' });
+  toast('Order marked as paid');
+  loadOrders();
 }
 
 async function toggleDelivered(id) {
-  const sale = _salesCache.find(s => s.ID === id);
-  if (!sale) return;
-  const newDelivered = sale.Delivered === 'true' ? 'false' : 'true';
-  await api.put(`/api/sales/${id}`, { Delivered: newDelivered });
+  const order = _ordersCache.find(s => s.ID === id);
+  if (!order) return;
+  const newDelivered = order.Delivered === 'true' ? 'false' : 'true';
+  await api.put(`/api/orders/${id}`, { Delivered: newDelivered });
   toast(newDelivered === 'true' ? 'Marked as delivered' : 'Marked as undelivered');
-  loadSales();
+  loadOrders();
 }
 
-async function profileMarkSalePaid(id) {
-  await api.put(`/api/sales/${id}`, { Status: 'Paid' });
-  toast('Sale marked as paid');
+async function profileMarkOrderPaid(id) {
+  await api.put(`/api/orders/${id}`, { Status: 'Paid' });
+  toast('Order marked as paid');
   loadAccountProfile(state.accountProfileId);
 }
 
 async function profileToggleDelivered(id, isDelivered) {
   const newDelivered = isDelivered ? 'false' : 'true';
-  await api.put(`/api/sales/${id}`, { Delivered: newDelivered });
+  await api.put(`/api/orders/${id}`, { Delivered: newDelivered });
   toast(newDelivered === 'true' ? 'Marked as delivered' : 'Marked as undelivered');
   loadAccountProfile(state.accountProfileId);
 }
@@ -1912,7 +1912,7 @@ const VIEW_LOADERS = {
   accounts:  loadAccounts,
   outreach:  loadOutreach,
   todos: loadTodos,
-  sales:     loadSales,
+  orders:    loadOrders,
   staff:     loadStaff,
 };
 

--- a/public/index.html
+++ b/public/index.html
@@ -46,8 +46,8 @@
           <a class="nav-item" data-view="todos" href="#todos">
             <span class="nav-icon">&#9632;</span> Todos
           </a>
-          <a class="nav-item" data-view="sales" href="#sales">
-            <span class="nav-icon">&#9632;</span> Sales
+          <a class="nav-item" data-view="orders" href="#orders">
+            <span class="nav-icon">&#9632;</span> Orders
           </a>
           <a class="nav-item" data-view="staff" href="#staff">
             <span class="nav-icon">&#9632;</span> Staff

--- a/public/style.css
+++ b/public/style.css
@@ -578,7 +578,7 @@ tbody td {
 .badge-low-stock { background: var(--danger-bg); color: var(--danger-text); }
 .badge-ok-stock  { background: var(--success-bg); color: var(--success-text); }
 
-/* Sales status badges */
+/* Order status badges */
 .badge-pending   { background: #e3f2fd; color: #1565c0; }
 .badge-paid      { background: var(--success-bg); color: var(--success-text); }
 .badge-cancelled { background: var(--neutral-bg); color: var(--neutral-text); }
@@ -587,7 +587,7 @@ tbody td {
 .badge-staff-active   { background: var(--success-bg); color: var(--success-text); }
 .badge-staff-inactive { background: var(--neutral-bg); color: var(--neutral-text); }
 
-/* Sales totals footer row */
+/* Order totals footer row */
 .table-totals td {
   font-weight: 700;
   background: #f7faf7;

--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -78,11 +78,11 @@ router.delete('/:id', async (req, res) => {
       }
     }
 
-    // Cascade delete: remove associated sales
-    const sales = await getAllRows('SALES');
-    for (const sale of sales) {
-      if (sale.AccountID === id) {
-        await deleteRow('SALES', sale.ID);
+    // Cascade delete: remove associated orders
+    const orders = await getAllRows('ORDERS');
+    for (const order of orders) {
+      if (order.AccountID === id) {
+        await deleteRow('ORDERS', order.ID);
       }
     }
 

--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -7,12 +7,12 @@ const router = express.Router();
 
 router.get('/', async (req, res) => {
   try {
-    const [inventory, accounts, outreach, reminders, sales] = await Promise.all([
+    const [inventory, accounts, outreach, reminders, orders] = await Promise.all([
       getAllRows('INVENTORY'),
       getAllRows('ACCOUNTS'),
       getAllRows('OUTREACH'),
       getAllRows('REMINDERS'),
-      getAllRows('SALES'),
+      getAllRows('ORDERS'),
     ]);
 
     const today = new Date().toISOString().split('T')[0];
@@ -39,9 +39,9 @@ router.get('/', async (req, res) => {
       .slice(0, 8);
 
     const currentMonth = today.substring(0, 7); // 'YYYY-MM'
-    const monthlySales = sales.filter(s => (s.SaleDate || '').startsWith(currentMonth));
-    const monthlySalesTotal = monthlySales.reduce((sum, s) => sum + parseFloat(s.SaleAmount || 0), 0);
-    const pendingDeliveries = sales.filter(s => s.Delivered !== 'true' && s.Status !== 'Cancelled').length;
+    const monthlyOrders = orders.filter(s => (s.OrderDate || '').startsWith(currentMonth));
+    const monthlyOrdersTotal = monthlyOrders.reduce((sum, s) => sum + parseFloat(s.OrderAmount || 0), 0);
+    const pendingDeliveries = orders.filter(s => s.Delivered !== 'true' && s.Status !== 'Cancelled').length;
 
     res.json({
       totalProducts: inventory.length,
@@ -54,8 +54,8 @@ router.get('/', async (req, res) => {
       overdueReminders: overdueReminders.sort((a, b) => a.DueDate.localeCompare(b.DueDate)),
       lowStockItems,
       recentOutreach,
-      monthlySalesTotal: monthlySalesTotal.toFixed(2),
-      monthlySalesCount: monthlySales.length,
+      monthlyOrdersTotal: monthlyOrdersTotal.toFixed(2),
+      monthlyOrdersCount: monthlyOrders.length,
       pendingDeliveries,
     });
   } catch (err) {

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -9,12 +9,12 @@ const router = express.Router();
 router.get('/', async (req, res) => {
   try {
     const { accountId, staffId } = req.query;
-    let sales = await getAllRows('SALES');
-    if (accountId) sales = sales.filter(s => s.AccountID === accountId);
-    if (staffId)   sales = sales.filter(s => s.StaffID === staffId);
+    let orders = await getAllRows('ORDERS');
+    if (accountId) orders = orders.filter(s => s.AccountID === accountId);
+    if (staffId)   orders = orders.filter(s => s.StaffID === staffId);
     // Sort newest first
-    sales.sort((a, b) => (b.SaleDate || '').localeCompare(a.SaleDate || ''));
-    res.json(sales);
+    orders.sort((a, b) => (b.OrderDate || '').localeCompare(a.OrderDate || ''));
+    res.json(orders);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -24,23 +24,23 @@ router.post('/', async (req, res) => {
   try {
     const {
       AccountID, AccountName, StaffID, StaffName,
-      SaleDate, DeliveryDate, InvoiceNumber,
-      SaleAmount, TaxAmount, Notes, Status, Delivered,
+      OrderDate, DeliveryDate, InvoiceNumber,
+      OrderAmount, TaxAmount, Notes, Status, Delivered,
     } = req.body;
 
     if (!AccountID) return res.status(400).json({ error: 'AccountID is required' });
-    if (!SaleDate)  return res.status(400).json({ error: 'SaleDate is required' });
+    if (!OrderDate)  return res.status(400).json({ error: 'OrderDate is required' });
 
-    const sale = {
+    const order = {
       ID: uuidv4(),
       AccountID,
       AccountName: AccountName || '',
       StaffID:     StaffID || '',
       StaffName:   StaffName || '',
-      SaleDate,
+      OrderDate,
       DeliveryDate: DeliveryDate || '',
       InvoiceNumber: InvoiceNumber || '',
-      SaleAmount: SaleAmount || '0',
+      OrderAmount: OrderAmount || '0',
       TaxAmount:  TaxAmount  || '0',
       Notes:     Notes     || '',
       Status:    Status    || 'Pending',
@@ -48,8 +48,8 @@ router.post('/', async (req, res) => {
       CreatedAt: new Date().toISOString().split('T')[0],
     };
 
-    await addRow('SALES', sale);
-    res.status(201).json(sale);
+    await addRow('ORDERS', order);
+    res.status(201).json(order);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -60,7 +60,7 @@ router.put('/:id', async (req, res) => {
     const updates = { ...req.body };
     delete updates.ID;
     delete updates.CreatedAt;
-    const updated = await updateRow('SALES', req.params.id, updates);
+    const updated = await updateRow('ORDERS', req.params.id, updates);
     res.json(updated);
   } catch (err) {
     res.status(err.message.includes('not found') ? 404 : 500).json({ error: err.message });
@@ -69,7 +69,7 @@ router.put('/:id', async (req, res) => {
 
 router.delete('/:id', async (req, res) => {
   try {
-    await deleteRow('SALES', req.params.id);
+    await deleteRow('ORDERS', req.params.id);
     res.json({ success: true });
   } catch (err) {
     res.status(err.message.includes('not found') ? 404 : 500).json({ error: err.message });

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -1,23 +1,25 @@
 'use strict';
 
 /**
- * Zapier Webhook — Sale Log Creation
+ * Zapier Webhook — Order Creation
  *
- * Endpoint:  POST /webhooks/zapier/sale
+ * Endpoint:  POST /webhooks/zapier/order
  * Auth:      Authorization: Bearer <WEBHOOK_SECRET>
  *
  * Zapier setup:
  *   Action:  Webhooks by Zapier → POST
- *   URL:     https://<your-domain>/webhooks/zapier/sale
+ *   URL:     https://<your-domain>/webhooks/zapier/order
  *   Headers: Authorization: Bearer <your WEBHOOK_SECRET value>
  *   Payload format: JSON (data below)
  *
  * Accepted fields (all optional except at least one of account_name / AccountName / AccountID):
  *
  *   invoice_number  | InvoiceNumber  | invoiceNumber   → InvoiceNumber
- *   sale_date       | SaleDate       | invoice_date    → SaleDate       (defaults to today)
+ *   order_date      | OrderDate      | sale_date
+ *                   | SaleDate       | invoice_date    → OrderDate       (defaults to today)
  *   delivery_date   | DeliveryDate                    → DeliveryDate
- *   amount          | sale_amount    | SaleAmount      → SaleAmount     (pre-tax total)
+ *   amount          | order_amount   | OrderAmount
+ *                   | sale_amount    | SaleAmount      → OrderAmount     (pre-tax total)
  *   tax             | tax_amount     | TaxAmount       → TaxAmount
  *   status          | Status                          → Status          (Pending/Paid/Cancelled)
  *   notes           | Notes          | memo            → Notes
@@ -26,7 +28,7 @@
  *                   | client_name                     → account name lookup
  *
  * Responses:
- *   201  { sale }                — created successfully
+ *   201  { order }               — created successfully
  *   400  { error, details }      — missing/invalid fields
  *   401  { error }               — bad or missing token
  *   404  { error }               — account name not found
@@ -72,9 +74,9 @@ function normalise(body) {
     accountId:     pick(body, 'AccountID',     'account_id'),
     accountName:   pick(body, 'AccountName',   'account_name', 'customer_name', 'client_name'),
     invoiceNumber: pick(body, 'InvoiceNumber', 'invoice_number', 'invoiceNumber'),
-    saleDate:      pick(body, 'SaleDate',      'sale_date',     'invoice_date', 'date'),
+    orderDate:     pick(body, 'OrderDate',     'order_date',    'SaleDate', 'sale_date', 'invoice_date', 'date'),
     deliveryDate:  pick(body, 'DeliveryDate',  'delivery_date'),
-    saleAmount:    pick(body, 'SaleAmount',    'sale_amount',   'amount',    'subtotal'),
+    orderAmount:   pick(body, 'OrderAmount',   'order_amount',  'SaleAmount', 'sale_amount', 'amount', 'subtotal'),
     taxAmount:     pick(body, 'TaxAmount',     'tax_amount',    'tax'),
     status:        pick(body, 'Status',        'status'),
     notes:         pick(body, 'Notes',         'notes',         'memo'),
@@ -83,9 +85,9 @@ function normalise(body) {
 
 const VALID_STATUSES = new Set(['Pending', 'Paid', 'Cancelled']);
 
-// ── POST /webhooks/zapier/sale ───────────────────────────────────
+// ── POST /webhooks/zapier/order ───────────────────────────────────
 
-router.post('/zapier/sale', requireWebhookSecret, async (req, res) => {
+router.post('/zapier/order', requireWebhookSecret, async (req, res) => {
   try {
     const f = normalise(req.body);
 
@@ -116,8 +118,8 @@ router.post('/zapier/sale', requireWebhookSecret, async (req, res) => {
     }
 
     // Date defaults
-    const today    = new Date().toISOString().split('T')[0];
-    const saleDate = f.saleDate || today;
+    const today     = new Date().toISOString().split('T')[0];
+    const orderDate = f.orderDate || today;
 
     // Status validation
     let status = f.status || 'Pending';
@@ -125,25 +127,25 @@ router.post('/zapier/sale', requireWebhookSecret, async (req, res) => {
     status = status.charAt(0).toUpperCase() + status.slice(1);
     if (!VALID_STATUSES.has(status)) status = 'Pending';
 
-    const sale = {
+    const order = {
       ID:            uuidv4(),
       AccountID:     resolvedAccountId,
       AccountName:   resolvedAccountName,
       StaffID:       '',
       StaffName:     '',
-      SaleDate:      saleDate,
+      OrderDate:     orderDate,
       DeliveryDate:  f.deliveryDate || '',
       InvoiceNumber: f.invoiceNumber || '',
-      SaleAmount:    f.saleAmount   || '0',
+      OrderAmount:   f.orderAmount  || '0',
       TaxAmount:     f.taxAmount    || '0',
       Notes:         f.notes        || '',
       Status:        status,
       CreatedAt:     today,
     };
 
-    await addRow('SALES', sale);
+    await addRow('ORDERS', order);
 
-    res.status(201).json({ sale });
+    res.status(201).json({ order });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ const accountsRoutes  = require('./routes/accounts');
 const outreachRoutes  = require('./routes/outreach');
 const remindersRoutes = require('./routes/reminders');
 const staffRoutes     = require('./routes/staff');
-const salesRoutes     = require('./routes/sales');
+const ordersRoutes    = require('./routes/orders');
 const dashboardRoutes = require('./routes/dashboard');
 const webhooksRoutes  = require('./routes/webhooks');
 
@@ -60,7 +60,7 @@ app.use('/api/accounts',  requireAuth, accountsRoutes);
 app.use('/api/outreach',  requireAuth, outreachRoutes);
 app.use('/api/reminders', requireAuth, remindersRoutes);
 app.use('/api/staff',     requireAuth, staffRoutes);
-app.use('/api/sales',     requireAuth, salesRoutes);
+app.use('/api/orders',    requireAuth, ordersRoutes);
 app.use('/api/dashboard', requireAuth, dashboardRoutes);
 
 // Status endpoint (public – used by the frontend before auth).

--- a/sheets.js
+++ b/sheets.js
@@ -11,7 +11,7 @@ const SHEETS = {
   OUTREACH:  'Outreach',
   REMINDERS: 'Reminders',
   STAFF:     'Staff',
-  SALES:     'Sales',
+  ORDERS:    'Orders',
 };
 
 // HEADERS defines every column each sheet should have.
@@ -22,7 +22,7 @@ const HEADERS = {
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
   REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
   STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt'],
-  SALES:     ['ID', 'AccountID', 'AccountName', 'StaffID', 'StaffName', 'SaleDate', 'DeliveryDate', 'InvoiceNumber', 'SaleAmount', 'TaxAmount', 'Notes', 'Status', 'Delivered', 'CreatedAt'],
+  ORDERS:    ['ID', 'AccountID', 'AccountName', 'StaffID', 'StaffName', 'OrderDate', 'DeliveryDate', 'InvoiceNumber', 'OrderAmount', 'TaxAmount', 'Notes', 'Status', 'Delivered', 'CreatedAt'],
 };
 
 // Cached sheet header rows — avoids an extra API call on every write


### PR DESCRIPTION
Renames the "Sales" domain concept to "Orders" across all layers: routes, data model, API endpoints, UI labels, and frontend logic. Webhook field mappings preserve old aliases for backward compatibility.