### PR TITLE
Use sequential numeric IDs for accounts

### DIFF
--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -1,10 +1,15 @@
 'use strict';
 
 const express = require('express');
-const { v4: uuidv4 } = require('uuid');
 const { getAllRows, addRow, updateRow, deleteRow } = require('../sheets');
 
 const router = express.Router();
+
+async function getNextAccountId() {
+  const accounts = await getAllRows('ACCOUNTS');
+  const maxId = Math.max(0, ...accounts.map(a => parseInt(a.ID, 10) || 0));
+  return String(maxId + 1);
+}
 
 router.get('/', async (req, res) => {
   try {
@@ -21,7 +26,7 @@ router.post('/', async (req, res) => {
     if (!Name) return res.status(400).json({ error: 'Account name is required' });
 
     const account = {
-      ID: uuidv4(),
+      ID: await getNextAccountId(),
       Name: Name.trim(),
       Type: Type || 'Bar',
       ContactName: ContactName || '',


### PR DESCRIPTION
## Summary
- Replace UUID-based account IDs with short, sequential numeric IDs (1, 2, 3...)
- New `getNextAccountId()` helper scans existing accounts and returns the next available number
- Existing accounts with UUID IDs continue to work (all lookups are string equality)

## Test plan
- [ ] Create a new account and verify it gets a sequential numeric ID
- [ ] Create a second account and verify it increments
- [ ] Verify existing accounts still load, edit, and delete correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)