### PR TITLE
Add responsive mobile layout

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1972,11 +1972,30 @@ async function init() {
     return;
   }
 
+  // Mobile sidebar toggle
+  const menuBtn = document.getElementById('mobile-menu-btn');
+  const sidebar = document.getElementById('sidebar');
+  const backdrop = document.getElementById('sidebar-backdrop');
+
+  function closeSidebar() {
+    sidebar.classList.remove('open');
+    backdrop.classList.remove('open');
+  }
+
+  menuBtn.addEventListener('click', () => {
+    const isOpen = sidebar.classList.contains('open');
+    sidebar.classList.toggle('open', !isOpen);
+    backdrop.classList.toggle('open', !isOpen);
+  });
+
+  backdrop.addEventListener('click', closeSidebar);
+
   // Wire up nav clicks
   document.querySelectorAll('.nav-item').forEach(el => {
     el.addEventListener('click', e => {
       e.preventDefault();
       navigate(el.dataset.view);
+      closeSidebar();
     });
   });
 

--- a/public/index.html
+++ b/public/index.html
@@ -20,8 +20,11 @@
 
     <div class="layout">
 
+      <!-- Mobile menu toggle -->
+      <button class="mobile-menu-btn" id="mobile-menu-btn" aria-label="Open navigation menu">&#9776;</button>
+
       <!-- Sidebar -->
-      <aside class="sidebar">
+      <aside class="sidebar" id="sidebar">
         <div class="sidebar-brand">
           <span class="brand-icon">&#127866;</span>
           <div>
@@ -70,6 +73,7 @@
           </form>
         </div>
       </aside>
+      <div class="sidebar-backdrop" id="sidebar-backdrop"></div>
 
       <!-- Main Content -->
       <main class="main-content">

--- a/public/style.css
+++ b/public/style.css
@@ -889,6 +889,32 @@ tr.row-completed button {
   opacity: 1;
 }
 
+/* ── Mobile Menu Button & Backdrop (hidden on desktop) ── */
+
+.mobile-menu-btn {
+  display: none;
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 200;
+  background: var(--sidebar-bg);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  width: 40px;
+  height: 40px;
+  font-size: 22px;
+  cursor: pointer;
+  line-height: 1;
+  box-shadow: var(--shadow);
+  align-items: center;
+  justify-content: center;
+}
+
+.sidebar-backdrop {
+  display: none;
+}
+
 /* ── Responsive ───────────────────────────────────────── */
 
 @media (max-width: 900px) {
@@ -899,7 +925,173 @@ tr.row-completed button {
 }
 
 @media (max-width: 640px) {
-  .sidebar { display: none; }
-  .main-content { margin-left: 0; }
-  .setup-banner-inner { margin-left: 0; }
+  /* ── Show hamburger button ── */
+  .mobile-menu-btn {
+    display: flex;
+  }
+
+  /* ── Sidebar: off-screen by default, slide in when .open ── */
+  .sidebar {
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+  }
+
+  .sidebar.open {
+    transform: translateX(0);
+  }
+
+  /* ── Backdrop overlay when sidebar is open ── */
+  .sidebar-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 99;
+  }
+
+  .sidebar-backdrop.open {
+    display: block;
+  }
+
+  /* ── Main content: remove sidebar offset ── */
+  .main-content {
+    margin-left: 0;
+  }
+
+  .setup-banner-inner {
+    margin-left: 0;
+  }
+
+  /* ── Content area: tighter padding for phones ── */
+  .content-area {
+    padding: 14px 12px;
+    padding-top: 56px;
+  }
+
+  /* ── View header: stack title and actions vertically ── */
+  .view-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .view-header-actions {
+    justify-content: flex-start;
+  }
+
+  /* ── Profile stats: 2 columns instead of 4 ── */
+  .profile-stats {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+  }
+
+  /* ── Profile info: single column ── */
+  .profile-info {
+    grid-template-columns: 1fr;
+  }
+
+  /* ── Filter bar: inputs adapt to available width ── */
+  .filter-bar input[type="search"] {
+    min-width: 0;
+    flex: 1 1 100%;
+  }
+
+  .filter-bar select {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  /* ── Table: tighter cell padding ── */
+  thead th {
+    padding: 8px 10px;
+    font-size: 11px;
+  }
+
+  tbody td {
+    padding: 7px 10px;
+    font-size: 12.5px;
+  }
+
+  /* ── Stat cards: smaller text on mobile ── */
+  .stat-value {
+    font-size: 24px;
+  }
+
+  .stat-card {
+    padding: 14px 16px;
+  }
+
+  /* ── Stats grid: smaller minimums ── */
+  .stats-grid {
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 10px;
+  }
+
+  /* ── Modal: nearly full-screen ── */
+  .modal-overlay {
+    padding: 10px 8px;
+    align-items: stretch;
+  }
+
+  .modal {
+    max-width: 100%;
+    border-radius: var(--radius);
+    margin: 0;
+  }
+
+  .modal-body {
+    max-height: 70vh;
+    padding: 16px;
+  }
+
+  .modal-header {
+    padding: 14px 16px 12px;
+  }
+
+  .modal-footer {
+    padding: 12px 16px;
+  }
+
+  /* ── Toast: fit to phone width ── */
+  #toast-container {
+    left: 12px;
+    right: 12px;
+    bottom: 12px;
+  }
+
+  .toast {
+    min-width: 0;
+    max-width: 100%;
+    width: 100%;
+  }
+
+  /* ── Dashboard grid: single column ── */
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  /* ── Buttons: slightly smaller for mobile density ── */
+  .btn {
+    padding: 6px 12px;
+    font-size: 12.5px;
+  }
+
+  .btn-sm {
+    padding: 4px 8px;
+    font-size: 11.5px;
+  }
+}
+
+@media (max-width: 400px) {
+  .profile-stat .stat-value {
+    font-size: 18px;
+  }
+
+  .view-header h2 {
+    font-size: 18px;
+  }
+
+  .content-area {
+    padding: 12px 8px;
+    padding-top: 56px;
+  }
 }


### PR DESCRIPTION
## Summary
- Add hamburger menu button for mobile navigation (visible ≤640px) with slide-in sidebar and backdrop overlay
- Comprehensive responsive CSS at three breakpoints (900px, 640px, 400px) covering tables, modals, forms, stat grids, filter bars, toasts, and buttons
- Profile stats grid adapts from 4 columns → 2 on mobile; profile info goes single-column
- Modals go nearly full-screen on phones; filter inputs flex to available width

## Test plan
- [ ] Resize browser to ≤640px — hamburger button appears, sidebar is hidden
- [ ] Tap hamburger — sidebar slides in with dark backdrop
- [ ] Tap a nav item — sidebar closes, view loads
- [ ] Tap backdrop — sidebar closes
- [ ] Verify tables scroll horizontally on mobile
- [ ] Verify modals are nearly full-screen on phones
- [ ] Check profile page stats show 2 columns on mobile
- [ ] Check at 375px (iPhone SE) — everything fits without overflow
- [ ] Resize back to desktop — hamburger gone, sidebar fixed, normal layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)