### PR TITLE
Show staff name in dashboard Upcoming todos

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1407,7 +1407,7 @@ async function loadDashboard() {
             <span class="dash-label">${esc(r.Title)}</span>
             ${r.AccountName ? `<span class="text-muted text-sm"> &mdash; ${esc(r.AccountName)}</span>` : ''}
           </div>
-          <span class="dash-meta">${formatDate(r.DueDate)}</span>
+          <span class="dash-meta">${r.StaffName ? `${esc(r.StaffName)} · ` : ''}${formatDate(r.DueDate)}</span>
         </li>`).join('');
 
   const myTodosHtml = !currentStaffId


### PR DESCRIPTION
## Summary
- Display the assigned staff member's name next to each todo in the "Upcoming (7 days)" dashboard card
- Format: "Alex Johnson · Feb 25, 2026" — staff name shown before the due date, separated by a dot
- Unassigned todos just show the date as before

## Test plan
- [ ] Verify each upcoming todo shows the assigned staff name before the date
- [ ] Verify unassigned todos display only the date without a leading dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)