### PR TITLE
Add color-coded type badges to todos

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -72,6 +72,20 @@ function priorityBadge(p) {
   return `<span class="badge ${map[p] || 'badge-medium'}">${esc(p)}</span>`;
 }
 
+function typeBadge(type) {
+  if (!type) return '';
+  const map = {
+    'Follow-up': 'badge-type-followup',
+    'Delivery': 'badge-type-delivery',
+    'Collect Payment': 'badge-type-payment',
+    'Sampling': 'badge-type-sampling',
+    'Event': 'badge-type-event',
+    'Draft Cleaning': 'badge-type-cleaning',
+    'Pre-Sale': 'badge-type-presale',
+  };
+  return `<span class="badge ${map[type] || 'badge-type-followup'}">${esc(type)}</span>`;
+}
+
 function toast(msg, type = 'success') {
   const el = document.createElement('div');
   el.className = `toast ${type !== 'success' ? type : ''}`;
@@ -615,7 +629,7 @@ async function loadAccountProfile(accountId) {
     ? `<tr><td colspan="6" class="empty-state">No todos for this account.</td></tr>`
     : acctTodos.map(t => `<tr class="${t.Completed === 'true' ? 'row-completed' : ''}">
         <td class="fw-600"><span class="td-link" onclick="profileEditTodo('${esc(t.ID)}')">${esc(t.Title)}</span>${t.Recurrence && t.Recurrence !== 'none' ? ' <span class="badge badge-recurrence" title="Recurring">↻</span>' : ''}</td>
-        <td>${esc(t.Type) || '—'}</td>
+        <td>${typeBadge(t.Type) || '—'}</td>
         <td>${urgencyBadge(t.DueDate, t.Completed)}</td>
         <td>${priorityBadge(t.Priority)}</td>
         <td class="text-sm text-muted">${esc(t.Notes) || '—'}</td>
@@ -1212,7 +1226,7 @@ function renderTodos() {
               <td>${urgencyBadge(r.DueDate, r.Completed)}</td>
               <td class="fw-600"><span class="td-link" onclick="openEditTodo('${esc(r.ID)}')">${esc(r.Title)}</span>${r.Recurrence && r.Recurrence !== 'none' ? ` <span class="badge badge-recurrence" title="${esc(RECURRENCE_OPTIONS.find(o => o.value === r.Recurrence)?.label || r.Recurrence)}">↻</span>` : ''}</td>
               <td class="text-sm">${r.AccountID ? `<span class="td-link" onclick="loadAccountProfile('${esc(r.AccountID)}')">${esc(r.AccountName)}</span>` : '—'}</td>
-              <td class="text-sm">${esc(r.Type)}</td>
+              <td class="text-sm">${typeBadge(r.Type)}</td>
               <td class="text-sm">${esc(r.StaffName) || '<span class="text-muted">—</span>'}</td>
               <td>${priorityBadge(r.Priority)}</td>
               <td class="td-actions">
@@ -1404,6 +1418,7 @@ async function loadDashboard() {
         <li class="clickable" onclick="navigate('todos')">
           <div>
             ${urgencyBadge(r.DueDate, r.Completed)}
+            ${typeBadge(r.Type)}
             <span class="dash-label">${esc(r.Title)}</span>
             ${r.AccountName ? `<span class="text-muted text-sm"> &mdash; ${esc(r.AccountName)}</span>` : ''}
           </div>
@@ -1418,6 +1433,7 @@ async function loadDashboard() {
           <li class="clickable" onclick="navigate('todos')">
             <div>
               ${urgencyBadge(r.DueDate, r.Completed)}
+              ${typeBadge(r.Type)}
               <span class="dash-label">${esc(r.Title)}</span>
               ${r.AccountName ? `<span class="text-muted text-sm"> &mdash; ${esc(r.AccountName)}</span>` : ''}
             </div>
@@ -1431,6 +1447,7 @@ async function loadDashboard() {
         ${dash.overdueReminders.map(r => `
           <li class="clickable" onclick="navigate('todos')">
             ${urgencyBadge(r.DueDate, r.Completed)}
+            ${typeBadge(r.Type)}
             <span class="dash-label">${esc(r.Title)}</span>
             ${r.AccountName ? `<span class="text-muted text-sm"> &mdash; ${esc(r.AccountName)}</span>` : ''}
             <button class="btn btn-ghost btn-sm text-success" onclick="event.stopPropagation();completeTodo('${esc(r.ID)}')">Done</button>

--- a/public/style.css
+++ b/public/style.css
@@ -583,6 +583,15 @@ tbody td {
 .badge-paid      { background: var(--success-bg); color: var(--success-text); }
 .badge-cancelled { background: var(--neutral-bg); color: var(--neutral-text); }
 
+/* Todo type badges */
+.badge-type-followup  { background: #e3f2fd; color: #1565c0; }
+.badge-type-delivery  { background: #e8f5e9; color: #2e7d32; }
+.badge-type-payment   { background: #fff8e1; color: #f57f17; }
+.badge-type-sampling  { background: #f3e5f5; color: #6a1b9a; }
+.badge-type-event     { background: #e0f2f1; color: #00695c; }
+.badge-type-cleaning  { background: #fce4ec; color: #c62828; }
+.badge-type-presale   { background: #e8eaf6; color: #283593; }
+
 /* Staff active badges */
 .badge-staff-active   { background: var(--success-bg); color: var(--success-text); }
 .badge-staff-inactive { background: var(--neutral-bg); color: var(--neutral-text); }


### PR DESCRIPTION
## Summary
- Add a `typeBadge()` function that maps each todo type to a distinct color badge
- **Colors:** Follow-up (blue), Delivery (green), Collect Payment (amber), Sampling (purple), Event (teal), Draft Cleaning (pink), Pre-Sale (indigo)
- Replace plain text type display with colored badges in the Todos table and account profile todos table
- Add type badges to all three dashboard todo cards (My Todos, Upcoming, Overdue)

## Test plan
- [ ] Open Todos page — Type column shows colored badges instead of plain text
- [ ] Open an account profile — Todos section shows colored type badges
- [ ] Dashboard My Todos, Upcoming, and Overdue cards show type badges alongside urgency badges
- [ ] All 7 types have visually distinct, readable colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)