### PR TITLE
Add staff assignment to outreach follow-up todos

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -939,6 +939,13 @@ function outreachForm(entry = {}, presetAccountId = '') {
         <input type="checkbox" id="f-create-todo" style="margin-right:6px;" />
         Create a todo for this follow-up
       </label>
+    </div>
+    <div class="form-group">
+      <label>Assign To</label>
+      <select class="form-control" id="f-todo-staff">
+        <option value="">-- Unassigned --</option>
+        ${staffOptions()}
+      </select>
     </div>`;
 }
 
@@ -1041,11 +1048,14 @@ function openAddOutreach(presetAccountId = '', presetAccountName = '') {
     });
 
     if (createTodo && followUpDate) {
+      const todoStaffId = val('f-todo-staff');
+      const todoStaffName = todoStaffId ? (state.staff.find(s => s.ID === todoStaffId) || {}).Name || '' : '';
       await api.post('/api/reminders', {
         Type: 'Follow-up', AccountID: accountId, AccountName: accountName,
         Title: `Follow up with ${accountName}`,
         DueDate: followUpDate, Priority: 'Medium',
         Notes: `Re: outreach on ${val('f-date')}`,
+        StaffID: todoStaffId, StaffName: todoStaffName,
       });
     }
 


### PR DESCRIPTION
## Summary
- Add an "Assign To" staff dropdown in the outreach form's follow-up section
- When "Create a todo for this follow-up" is checked, the selected staff member is assigned to the resulting todo
- Uses the existing `staffOptions()` helper for the dropdown, consistent with the todo form
- Defaults to "Unassigned" to preserve current behavior when no staff is selected

## Test plan
- [ ] Log a contact with "Create a todo" checked and a staff member selected — verify the todo is created with that staff assignment
- [ ] Log a contact with "Create a todo" checked but staff left as "Unassigned" — todo created without assignment
- [ ] Log a contact without "Create a todo" — no todo created (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)