### PR TITLE
Link dashboard outreach entries to account details

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1558,7 +1558,7 @@ async function loadDashboard() {
   const recentHtml = dash.recentOutreach.length === 0
     ? '<li class="empty-state" style="padding:12px 0">No outreach logged yet.</li>'
     : dash.recentOutreach.map(o => `
-        <li class="clickable" onclick="navigate('outreach')">
+        <li class="clickable" onclick="loadAccountProfile('${esc(o.AccountID)}')">
           ${methodBadge(o.Method)}
           <span class="dash-label">${esc(o.AccountName)}</span>
           <span class="dash-meta">${formatDate(o.Date)}</span>


### PR DESCRIPTION
## Summary
- Dashboard recent outreach entries now link to the associated account's detail page instead of the outreach list view
- Clicking an outreach entry calls `loadAccountProfile()` with the entry's AccountID

## Test plan
- [ ] Verify clicking a recent outreach entry on the dashboard opens the correct account detail page
- [ ] Verify the account profile loads with outreach history, todos, and orders for that account

🤖 Generated with [Claude Code](https://claude.com/claude-code)