### PR TITLE
Link dashboard todo entries to account details page

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1515,7 +1515,7 @@ async function loadDashboard() {
   const upcomingHtml = dash.upcomingReminders.length === 0
     ? '<li class="empty-state" style="padding:12px 0">No upcoming todos in the next 7 days.</li>'
     : dash.upcomingReminders.map(r => `
-        <li class="clickable" onclick="navigate('todos')">
+        <li class="clickable" onclick="${r.AccountID ? `loadAccountProfile('${esc(r.AccountID)}')` : `navigate('todos')`}">
           <div>
             ${urgencyBadge(r.DueDate, r.Completed)}
             ${typeBadge(r.Type)}
@@ -1530,7 +1530,7 @@ async function loadDashboard() {
     : myTodos.length === 0
       ? '<li class="empty-state" style="padding:12px 0">You have no upcoming or overdue todos.</li>'
       : myTodos.map(r => `
-          <li class="clickable" onclick="navigate('todos')">
+          <li class="clickable" onclick="${r.AccountID ? `loadAccountProfile('${esc(r.AccountID)}')` : `navigate('todos')`}">
             <div>
               ${urgencyBadge(r.DueDate, r.Completed)}
               ${typeBadge(r.Type)}
@@ -1545,7 +1545,7 @@ async function loadDashboard() {
       <div class="card-header"><h3 class="text-danger">Overdue (${dash.overdueReminders.length})</h3></div>
       <ul class="dash-list">
         ${dash.overdueReminders.map(r => `
-          <li class="clickable" onclick="navigate('todos')">
+          <li class="clickable" onclick="${r.AccountID ? `loadAccountProfile('${esc(r.AccountID)}')` : `navigate('todos')`}">
             ${urgencyBadge(r.DueDate, r.Completed)}
             ${typeBadge(r.Type)}
             <span class="dash-label">${esc(r.Title)}</span>


### PR DESCRIPTION
## Summary
- Dashboard todo entries now link to the associated account's detail page instead of the todos list view
- Applies to all three dashboard todo sections: Upcoming, My Todos, and Overdue
- Todos without an associated account gracefully fall back to the todos list view

## Test plan
- [ ] Verify clicking a todo with an account opens the correct account detail page
- [ ] Verify clicking a todo without an account navigates to the todos list
- [ ] Verify this works in all three sections: Upcoming, My Todos, and Overdue
- [ ] Verify the "Done" button on overdue todos still works without triggering navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)