### PR TITLE
Fix todo status filter not retaining selected value

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1253,14 +1253,15 @@ function todoForm(todo = {}) {
 }
 
 let _todosCache = [];
+let _todoStatusFilter = 'active';
 
 async function loadTodos() {
   _paginationReset('todos');
-  const statusFilter = (document.getElementById('todo-status') || {}).value || 'active';
+  _todoStatusFilter = (document.getElementById('todo-status') || {}).value || _todoStatusFilter;
   showLoading();
 
   const [todos, accounts, staff] = await Promise.all([
-    api.get(`/api/reminders?status=${statusFilter}`),
+    api.get(`/api/reminders?status=${_todoStatusFilter}`),
     api.get('/api/accounts'),
     api.get('/api/staff'),
   ]);
@@ -1274,7 +1275,7 @@ async function loadTodos() {
 function renderTodos() {
   const todos = _todosCache;
   const _focused = document.activeElement?.id;
-  const statusFilter = (document.getElementById('todo-status') || {}).value || 'active';
+  const statusFilter = _todoStatusFilter;
   const search = (document.getElementById('todo-search') || {}).value || '';
   const staffFilter = state.navFilters?.staffId || '';
   const staffFilterName = state.navFilters?.staffName || '';


### PR DESCRIPTION
## Summary
- Fixes bug where the todo status dropdown (Active/Completed/All) always reset to "Active" after changing
- Root cause: `showLoading()` destroyed the DOM before `renderTodos()` could read the selected value back, so it defaulted to "active"
- Fix: persist the selected status in a `_todoStatusFilter` variable that survives DOM re-renders

## Test plan
- [ ] Select "Completed" from the status dropdown — verify it stays on "Completed" and shows completed todos
- [ ] Select "All" — verify it stays on "All" and shows all todos
- [ ] Switch back to "Active" — verify it works correctly
- [ ] Verify search and pagination still work alongside the status filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)