### PR TITLE
Fix search field losing focus on Todos list

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1342,7 +1342,7 @@ function renderTodos() {
       </table>
     </div>
     ${pg.total > 0 ? paginationControls('todos', pg, 'renderTodos') : ''}`);
-  if (_focused === 'rem-search') refocusSearch("todo-search");
+  if (_focused === 'todo-search') refocusSearch('todo-search');
 }
 
 function openAddTodo(presetAccountId = '') {


### PR DESCRIPTION
## Summary
- Fixes the Todos search field losing cursor focus after each keystroke
- Root cause: the refocus check was comparing against the old element ID `rem-search` but the input uses `todo-search`, so the match never succeeded
- All other list tables (Inventory, Accounts, Outreach, Staff, Orders) were already correct

## Test plan
- [ ] Type in the Todos search field — verify the cursor stays in the field between keystrokes
- [ ] Verify search still filters results correctly
- [ ] Verify the other list table search fields still retain focus as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)