### PR TITLE
Add Other as a todo type option

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -155,8 +155,9 @@ function typeBadge(type) {
     'Event': 'badge-type-event',
     'Draft Cleaning': 'badge-type-cleaning',
     'Pre-Sale': 'badge-type-presale',
+    'Other': 'badge-type-other',
   };
-  return `<span class="badge ${map[type] || 'badge-type-followup'}">${esc(type)}</span>`;
+  return `<span class="badge ${map[type] || 'badge-type-other'}">${esc(type)}</span>`;
 }
 
 function toast(msg, type = 'success') {
@@ -1186,7 +1187,7 @@ async function deleteOutreach(id) {
 
 // ── Todos View ────────────────────────────────────────────────
 
-const TODO_TYPES = ['Follow-up', 'Delivery', 'Collect Payment', 'Sampling', 'Event', 'Draft Cleaning', 'Pre-Sale'];
+const TODO_TYPES = ['Follow-up', 'Delivery', 'Collect Payment', 'Sampling', 'Event', 'Draft Cleaning', 'Pre-Sale', 'Other'];
 const PRIORITIES = ['High', 'Medium', 'Low'];
 const RECURRENCE_OPTIONS = [
   { value: 'none',      label: 'None' },

--- a/public/style.css
+++ b/public/style.css
@@ -591,6 +591,7 @@ tbody td {
 .badge-type-event     { background: #e0f2f1; color: #00695c; }
 .badge-type-cleaning  { background: #fce4ec; color: #c62828; }
 .badge-type-presale   { background: #e8eaf6; color: #283593; }
+.badge-type-other     { background: #eceff1; color: #455a64; }
 
 /* Staff active badges */
 .badge-staff-active   { background: var(--success-bg); color: var(--success-text); }


### PR DESCRIPTION
## Summary
- Adds "Other" to the todo type dropdown options
- Adds a neutral grey badge style for the "Other" type
- Unknown/unmapped types now also fall back to the "Other" badge style instead of "Follow-up"

## Test plan
- [ ] Verify "Other" appears in the type dropdown when creating/editing a todo
- [ ] Verify the "Other" badge displays with a grey style on all todo lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)