### PR TITLE
Truncate long outreach notes with expand/collapse toggle

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -91,6 +91,15 @@ function esc(str) {
     .replace(/"/g, '&quot;');
 }
 
+let _noteIdCounter = 0;
+function truncateNote(text, limit = 100) {
+  if (!text) return '—';
+  const safe = esc(text);
+  if (text.length <= limit) return `<span class="note-text">${safe}</span>`;
+  const id = '_n' + (++_noteIdCounter);
+  return `<span class="note-text"><span id="${id}_short">${esc(text.substring(0, limit))}… <a href="#" class="note-toggle" onclick="event.preventDefault();document.getElementById('${id}_short').style.display='none';document.getElementById('${id}_full').style.display='inline'">more</a></span><span id="${id}_full" style="display:none">${safe} <a href="#" class="note-toggle" onclick="event.preventDefault();document.getElementById('${id}_full').style.display='none';document.getElementById('${id}_short').style.display='inline'">less</a></span></span>`;
+}
+
 function formatDate(d) {
   if (!d) return '—';
   const [y, m, day] = d.split('-');
@@ -700,7 +709,7 @@ async function loadAccountProfile(accountId) {
     : acctOutreach.map(o => `<tr>
         <td class="text-sm">${formatDate(o.Date)}</td>
         <td>${methodBadge(o.Method)}</td>
-        <td class="text-sm" style="max-width:320px;white-space:pre-wrap">${esc(o.Notes) || '—'}</td>
+        <td class="text-sm note-cell">${truncateNote(o.Notes)}</td>
         <td class="text-sm">${o.FollowUpDate ? formatDate(o.FollowUpDate) : '—'}</td>
         <td class="td-actions">
           <button class="btn btn-ghost btn-sm" onclick="profileEditOutreach('${esc(o.ID)}')">Edit</button>
@@ -1100,7 +1109,7 @@ function renderOutreach() {
               <td class="fw-600"><span class="td-link" onclick="loadAccountProfile('${esc(o.AccountID)}')">${esc(o.AccountName)}</span></td>
               <td>${formatDate(o.Date)}</td>
               <td>${methodBadge(o.Method)}</td>
-              <td class="text-sm">${esc(o.Notes).substring(0, 80)}${o.Notes && o.Notes.length > 80 ? '…' : ''}</td>
+              <td class="text-sm note-cell">${truncateNote(o.Notes)}</td>
               <td class="text-sm">${o.FollowUpDate ? formatDate(o.FollowUpDate) : '—'}</td>
               <td class="td-actions">
                 <button class="btn btn-ghost btn-sm" onclick="openEditOutreach('${esc(o.ID)}')">Edit</button>

--- a/public/style.css
+++ b/public/style.css
@@ -535,6 +535,11 @@ tbody td {
   vertical-align: middle;
 }
 
+.note-cell { max-width: 320px; }
+.note-text { white-space: pre-wrap; word-break: break-word; line-height: 1.4; }
+.note-toggle { color: var(--primary); font-size: 11px; font-weight: 500; text-decoration: none; white-space: nowrap; }
+.note-toggle:hover { text-decoration: underline; }
+
 .td-actions {
   display: flex;
   gap: 4px;


### PR DESCRIPTION
## Summary
- Long outreach notes are now truncated at 100 characters with a "more" link
- Clicking "more" expands the full text inline with a "less" link to collapse
- Applied to both the main outreach list table and the account profile outreach section
- Notes column is constrained to 320px max-width with proper word wrapping

## Test plan
- [ ] Verify short notes display normally without a toggle
- [ ] Verify long notes are truncated with "more" link visible
- [ ] Click "more" — verify full text expands inline
- [ ] Click "less" — verify text collapses back
- [ ] Verify this works on both the Outreach list view and the account profile outreach table

🤖 Generated with [Claude Code](https://claude.com/claude-code)