### PR TITLE
Add todo type selector to outreach follow-up creation

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1032,12 +1032,20 @@ function outreachForm(entry = {}, presetAccountId = '') {
         Create a todo for this follow-up
       </label>
     </div>
-    <div class="form-group">
-      <label>Assign To</label>
-      <select class="form-control" id="f-todo-staff">
-        <option value="">-- Unassigned --</option>
-        ${staffOptions()}
-      </select>
+    <div class="form-row">
+      <div class="form-group">
+        <label>Todo Type</label>
+        <select class="form-control" id="f-todo-type">
+          ${TODO_TYPES.map(t => `<option value="${t}" ${t === 'Follow-up' ? 'selected' : ''}>${t}</option>`).join('')}
+        </select>
+      </div>
+      <div class="form-group">
+        <label>Assign To</label>
+        <select class="form-control" id="f-todo-staff">
+          <option value="">-- Unassigned --</option>
+          ${staffOptions()}
+        </select>
+      </div>
     </div>`;
 }
 
@@ -1144,10 +1152,11 @@ function openAddOutreach(presetAccountId = '', presetAccountName = '') {
     });
 
     if (createTodo && followUpDate) {
+      const todoType = val('f-todo-type') || 'Follow-up';
       const todoStaffId = val('f-todo-staff');
       const todoStaffName = todoStaffId ? (state.staff.find(s => s.ID === todoStaffId) || {}).Name || '' : '';
       await api.post('/api/reminders', {
-        Type: 'Follow-up', AccountID: accountId, AccountName: accountName,
+        Type: todoType, AccountID: accountId, AccountName: accountName,
         Title: `Follow up with ${accountName}`,
         DueDate: followUpDate, Priority: 'Medium',
         Notes: `Re: outreach on ${val('f-date')}`,


### PR DESCRIPTION
## Summary
- Adds a "Todo Type" dropdown to the outreach follow-up section, displayed alongside the "Assign To" dropdown
- Defaults to "Follow-up" but allows selecting any todo type (Delivery, Collect Payment, Sampling, Event, Draft Cleaning, Pre-Sale, Other)
- Previously the type was hardcoded to "Follow-up"

## Test plan
- [ ] Log a new outreach, check "Create a todo for this follow-up" — verify the Todo Type dropdown appears
- [ ] Verify it defaults to "Follow-up"
- [ ] Select a different type (e.g., "Sampling"), submit — verify the created todo has the correct type
- [ ] Verify the type badge displays correctly on the todos list

🤖 Generated with [Claude Code](https://claude.com/claude-code)