### PR TITLE
Fix staff dropdown not populating in outreach form

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1052,9 +1052,10 @@ function outreachForm(entry = {}, presetAccountId = '') {
 async function loadOutreach() {
   _paginationReset('outreach');
   showLoading();
-  const [outreach, accounts] = await Promise.all([api.get('/api/outreach'), api.get('/api/accounts')]);
+  const [outreach, accounts, staff] = await Promise.all([api.get('/api/outreach'), api.get('/api/accounts'), api.get('/api/staff')]);
   state.outreach = outreach;
   state.accounts = accounts;
+  state.staff = staff;
   renderOutreach();
 }
 


### PR DESCRIPTION
## Summary
- Fixes the "Assign To" staff dropdown being empty when logging outreach
- Root cause: `loadOutreach()` fetched outreach and accounts but not staff, so `state.staff` was empty when the form rendered
- Fix: added `api.get('/api/staff')` to the `loadOutreach()` fetch

## Test plan
- [ ] Navigate to Outreach, click "+ Log Contact"
- [ ] Verify the "Assign To" dropdown is populated with staff members
- [ ] Verify creating a todo with a staff assignment works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)