### PR TITLE
Extend session length to 24 hours with rolling expiry

### DIFF
--- a/server.js
+++ b/server.js
@@ -31,11 +31,12 @@ app.use(session({
   secret:            process.env.SESSION_SECRET || 'change-me-in-production',
   resave:            false,
   saveUninitialized: false,
+  rolling:           true, // Reset expiry on every request so active users stay logged in
   cookie: {
     httpOnly: true,
     // Set secure:true when behind HTTPS in production.
     secure:   process.env.NODE_ENV === 'production',
-    maxAge:   8 * 60 * 60 * 1000, // 8 hours
+    maxAge:   24 * 60 * 60 * 1000, // 24 hours
   },
 }));
 


### PR DESCRIPTION
## Summary
- Extended session cookie `maxAge` from 8 hours to 24 hours
- Enabled `rolling: true` so the session expiry resets on every request — active users stay logged in indefinitely as long as they use the app within any 24-hour window

**Note:** The app uses the default in-memory session store, which means all sessions are lost on server restart. If frequent logouts persist after this change, consider switching to a persistent session store (e.g., `connect-session-file` or similar).

## Test plan
- [ ] Log in and verify the session persists for longer than 8 hours
- [ ] Verify active usage keeps extending the session
- [ ] Verify logging out still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)