### PR TITLE
Improve spacing around order totals footer row

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -607,6 +607,9 @@ tbody td {
   font-weight: 700;
   background: #f7faf7;
   border-top: 2px solid var(--border);
+  padding-top: 14px;
+  padding-bottom: 14px;
+  font-size: 14px;
 }
 
 /* ── Modal ────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Increased vertical padding on the order totals footer row (14px top/bottom vs the default table cell padding)
- Bumped font size to 14px so totals stand out from data rows
- Keeps the existing bold weight and green-tinted background

## Test plan
- [ ] View the Orders list with multiple records — verify the totals row has more breathing room
- [ ] Verify the totals row on the account profile orders table also looks improved

🤖 Generated with [Claude Code](https://claude.com/claude-code)