### PR TITLE
Add horizontal padding to order totals footer row

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -607,8 +607,7 @@ tbody td {
   font-weight: 700;
   background: #f7faf7;
   border-top: 2px solid var(--border);
-  padding-top: 14px;
-  padding-bottom: 14px;
+  padding: 14px 12px;
   font-size: 14px;
 }
 


### PR DESCRIPTION
## Summary
- Adds horizontal padding (12px) to the order totals footer row cells so the text isn't flush against the edges

## Test plan
- [ ] Verify the totals row has proper left/right padding on the Orders list

🤖 Generated with [Claude Code](https://claude.com/claude-code)