### PR TITLE
Hide todo fields until create todo checkbox is checked

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1028,11 +1028,11 @@ function outreachForm(entry = {}, presetAccountId = '') {
     </div>
     <div class="form-group">
       <label>
-        <input type="checkbox" id="f-create-todo" style="margin-right:6px;" />
+        <input type="checkbox" id="f-create-todo" style="margin-right:6px;" onchange="document.getElementById('todo-fields').style.display=this.checked?'':'none'" />
         Create a todo for this follow-up
       </label>
     </div>
-    <div class="form-row">
+    <div class="form-row" id="todo-fields" style="display:none">
       <div class="form-group">
         <label>Todo Type</label>
         <select class="form-control" id="f-todo-type">


### PR DESCRIPTION
## Summary
- Todo Type and Assign To dropdowns in the outreach form are now hidden by default
- They are revealed when the "Create a todo for this follow-up" checkbox is checked
- Unchecking the checkbox hides them again

## Test plan
- [ ] Open Log Contact — verify Todo Type and Assign To are not visible
- [ ] Check "Create a todo for this follow-up" — verify both fields appear
- [ ] Uncheck the checkbox — verify both fields hide again
- [ ] Check the box, select a type and staff, submit — verify the todo is created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)