### PR TITLE
Show only in-stock products in delivery confirmation

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2185,6 +2185,16 @@ function openDeliveryConfirmModal(orderId, order, onComplete) {
     return;
   }
 
+  const inStock = items.filter(i => parseInt(i.Units || '0') > 0);
+  const outOfStock = items.filter(i => parseInt(i.Units || '0') <= 0);
+  const delivRow = (item, hidden) => `<tr data-stock="${hidden ? 'out' : 'in'}"${hidden ? ' style="display:none"' : ''}>
+            <td class="fw-600">${esc(item.Name)}</td>
+            <td class="text-sm">${esc(item.Format) || '—'}</td>
+            <td class="text-sm">${esc(item.Units)}</td>
+            <td><input class="form-control" type="number" min="0" value="0"
+                 id="deliv-qty-${item.ID}" style="width:80px" /></td>
+          </tr>`;
+
   modal.open('Confirm Delivery', `
     <p class="text-muted text-sm" style="margin-bottom:16px">
       Confirming delivery for <strong>${esc(acctName)}</strong>${invLabel}.
@@ -2194,16 +2204,18 @@ function openDeliveryConfirmModal(orderId, order, onComplete) {
       <table>
         <thead><tr><th>Product</th><th>Format</th><th>In Stock</th><th>Qty Delivered</th></tr></thead>
         <tbody>
-          ${items.map(item => `<tr>
-            <td class="fw-600">${esc(item.Name)}</td>
-            <td class="text-sm">${esc(item.Format) || '—'}</td>
-            <td class="text-sm">${esc(item.Units)}</td>
-            <td><input class="form-control" type="number" min="0" value="0"
-                 id="deliv-qty-${item.ID}" style="width:80px" /></td>
-          </tr>`).join('')}
+          ${inStock.map(i => delivRow(i, false)).join('')}
+          ${outOfStock.map(i => delivRow(i, true)).join('')}
         </tbody>
       </table>
     </div>
+    ${outOfStock.length ? `<div class="form-group">
+      <label style="cursor:pointer">
+        <input type="checkbox" id="deliv-show-oos" style="margin-right:6px"
+          onchange="document.querySelectorAll('#modal-overlay tr[data-stock=out]').forEach(r=>r.style.display=this.checked?'':'none')" />
+        Show out-of-stock products (${outOfStock.length})
+      </label>
+    </div>` : ''}
     <div class="form-group">
       <label>Delivery Notes</label>
       <textarea class="form-control" id="deliv-notes" rows="2" placeholder="Optional notes..."></textarea>


### PR DESCRIPTION
## Summary
- Delivery confirmation modal now shows only products with stock (Units > 0) by default
- Adds a "Show out-of-stock products (N)" toggle checkbox to reveal hidden items when inventory may be inaccurate
- Out-of-stock rows are rendered in the DOM but hidden via `display:none`, toggled inline via the checkbox

## Test plan
- [ ] Confirm delivery on an order — verify only in-stock products are shown
- [ ] Check the "Show out-of-stock products" toggle — verify out-of-stock items appear
- [ ] Uncheck the toggle — verify they hide again
- [ ] Enter quantities for both in-stock and revealed out-of-stock items, confirm — verify stock movements are recorded correctly
- [ ] Verify the toggle does not appear when all products are in stock

🤖 Generated with [Claude Code](https://claude.com/claude-code)