### PR TITLE
Prevent delivery quantity from exceeding stock level

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2191,7 +2191,7 @@ function openDeliveryConfirmModal(orderId, order, onComplete) {
             <td class="fw-600">${esc(item.Name)}</td>
             <td class="text-sm">${esc(item.Format) || '—'}</td>
             <td class="text-sm">${esc(item.Units)}</td>
-            <td><input class="form-control" type="number" min="0" value="0"
+            <td><input class="form-control" type="number" min="0" max="${parseInt(item.Units || '0')}" value="0"
                  id="deliv-qty-${item.ID}" style="width:80px" /></td>
           </tr>`;
 
@@ -2223,9 +2223,13 @@ function openDeliveryConfirmModal(orderId, order, onComplete) {
     const delivItems = items
       .map(item => ({
         inventoryId: item.ID,
+        name: item.Name,
+        stock: parseInt(item.Units || '0'),
         quantity: parseInt(document.getElementById(`deliv-qty-${item.ID}`)?.value || '0'),
       }))
       .filter(i => i.quantity > 0);
+    const overStock = delivItems.find(i => i.quantity > i.stock);
+    if (overStock) { toast(`${overStock.name} only has ${overStock.stock} in stock`, 'error'); return; }
     const notes = (document.getElementById('deliv-notes')?.value || '').trim();
     await api.post('/api/stock-movements/bulk', {
       orderId,


### PR DESCRIPTION
## Summary
- Adds `max` attribute to delivery quantity inputs, capping the spinner at the current stock level
- Adds submit-time validation that blocks confirmation if any product quantity exceeds available stock, with an error toast naming the product and its stock level

## Test plan
- [ ] Open delivery confirmation — verify the number input spinner stops at the current stock level
- [ ] Manually type a number higher than stock and submit — verify an error toast appears (e.g. "Product X only has 5 in stock")
- [ ] Enter valid quantities at or below stock — verify delivery confirms successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)