### PR TITLE
Add multi-location support for Hutchinson and Mission

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,8 +1,11 @@
 'use strict';
 
 // ── State ────────────────────────────────────────────────────────
+const LOCATIONS = ['Hutchinson', 'Mission'];
+
 const state = {
   view: 'dashboard',
+  location: localStorage.getItem('brewLocation') || LOCATIONS[0],
   accounts: [],      // cached for select dropdowns
   inventory: [],
   staff: [],         // cached for staff dropdowns
@@ -299,6 +302,14 @@ function inventoryForm(item = {}) {
         <input class="form-control" id="f-name" value="${esc(item.Name)}" placeholder="e.g. Cascade IPA" />
       </div>
       <div class="form-group">
+        <label>Location <span class="required">*</span></label>
+        <select class="form-control" id="f-location">
+          ${LOCATIONS.map(l => `<option value="${l}" ${(item.Location || state.location) === l ? 'selected' : ''}>${l}</option>`).join('')}
+        </select>
+      </div>
+    </div>
+    <div class="form-row">
+      <div class="form-group">
         <label>Style</label>
         <select class="form-control" id="f-style">
           <option value="">-- Select --</option>
@@ -342,7 +353,8 @@ function inventoryForm(item = {}) {
 async function loadInventory() {
   _paginationReset('inventory');
   showLoading();
-  const items = await api.get('/api/inventory');
+  const locParam = state.location ? `?location=${encodeURIComponent(state.location)}` : '';
+  const items = await api.get(`/api/inventory${locParam}`);
   state.inventory = items;
   renderInventory();
 }
@@ -398,7 +410,7 @@ function renderInventory() {
     <div class="view-header">
       <div>
         <h2>Inventory</h2>
-        <p class="subtitle">${items.length} product${items.length !== 1 ? 's' : ''} tracked</p>
+        <p class="subtitle">${items.length} product${items.length !== 1 ? 's' : ''} at ${esc(state.location)}</p>
       </div>
       <div class="view-header-actions">
         <button class="btn btn-primary" onclick="openAddInventory()">+ Add Product</button>
@@ -447,7 +459,7 @@ function openAddInventory() {
     const name = val('f-name');
     if (!name) { toast('Name is required', 'error'); return; }
     await api.post('/api/inventory', {
-      Name: name, Style: val('f-style'), ABV: val('f-abv'),
+      Name: name, Location: val('f-location'), Style: val('f-style'), ABV: val('f-abv'),
       Format: val('f-format'), Units: val('f-units'),
       PricePerUnit: val('f-price'), LowStockThreshold: val('f-threshold'),
       Notes: val('f-notes'),
@@ -1587,8 +1599,9 @@ async function deleteTodo(id) {
 
 async function loadDashboard() {
   showLoading();
+  const locParam = state.location ? `?location=${encodeURIComponent(state.location)}` : '';
   const [dash, accounts, staff] = await Promise.all([
-    api.get('/api/dashboard'),
+    api.get(`/api/dashboard${locParam}`),
     api.get('/api/accounts'),
     api.get('/api/staff'),
   ]);
@@ -1911,6 +1924,14 @@ function orderForm(order = {}, presetAccountId = '') {
         ${presetAccountId ? `<input type="hidden" id="f-account-hidden" value="${esc(presetAccountId)}" />` : ''}
       </div>
       <div class="form-group">
+        <label>Location <span class="required">*</span></label>
+        <select class="form-control" id="f-location">
+          ${LOCATIONS.map(l => `<option value="${l}" ${(order.Location || state.location) === l ? 'selected' : ''}>${l}</option>`).join('')}
+        </select>
+      </div>
+    </div>
+    <div class="form-row">
+      <div class="form-group">
         <label>Sales Rep</label>
         <select class="form-control" id="f-staff">
           <option value="">-- Unassigned --</option>
@@ -1971,8 +1992,9 @@ function fmtMoney(val) {
 async function loadOrders() {
   _paginationReset('orders');
   showLoading();
+  const locParam = state.location ? `?location=${encodeURIComponent(state.location)}` : '';
   const [orders, accounts, staff] = await Promise.all([
-    api.get('/api/orders'),
+    api.get(`/api/orders${locParam}`),
     api.get('/api/accounts'),
     api.get('/api/staff'),
   ]);
@@ -2023,7 +2045,7 @@ function renderOrders() {
     <div class="view-header">
       <div>
         <h2>Orders</h2>
-        <p class="subtitle">${orders.length} order${orders.length !== 1 ? 's' : ''} recorded</p>
+        <p class="subtitle">${orders.length} order${orders.length !== 1 ? 's' : ''} at ${esc(state.location)}</p>
       </div>
       <div class="view-header-actions">
         <button class="btn btn-primary" onclick="openAddOrder()">+ Log Order</button>
@@ -2100,6 +2122,7 @@ async function openAddOrder(presetAccountId = '') {
     const staffName = staffId ? (state.staff.find(s => s.ID === staffId) || {}).Name || '' : '';
     await api.post('/api/orders', {
       AccountID: accountId, AccountName: accountName,
+      Location: val('f-location') || state.location,
       StaffID: staffId, StaffName: staffName,
       OrderDate: orderDate, DeliveryDate: val('f-delivery-date'),
       InvoiceNumber: val('f-invoice'), Status: val('f-status'),
@@ -2120,6 +2143,7 @@ function openEditOrder(id) {
     const staffId = val('f-staff');
     const staffName = staffId ? (state.staff.find(s => s.ID === staffId) || {}).Name || '' : '';
     await api.put(`/api/orders/${id}`, {
+      Location: val('f-location') || state.location,
       StaffID: staffId, StaffName: staffName,
       OrderDate: val('f-order-date'), DeliveryDate: val('f-delivery-date'),
       InvoiceNumber: val('f-invoice'), Status: val('f-status'),
@@ -2150,8 +2174,7 @@ async function markOrderPaid(id) {
 async function toggleDelivered(id) {
   const order = _ordersCache.find(s => s.ID === id);
   if (!order) return;
-  if (state.inventory.length === 0) state.inventory = await api.get('/api/inventory');
-  openDeliveryConfirmModal(id, order, loadOrders);
+  await openDeliveryConfirmModal(id, order, loadOrders);
 }
 
 async function profileMarkOrderPaid(id) {
@@ -2161,21 +2184,21 @@ async function profileMarkOrderPaid(id) {
 }
 
 async function profileToggleDelivered(id) {
-  if (state.inventory.length === 0) state.inventory = await api.get('/api/inventory');
   const orders = await api.get(`/api/orders?accountId=${encodeURIComponent(state.accountProfileId)}`);
   const order = orders.find(s => s.ID === id);
   if (!order) return;
-  openDeliveryConfirmModal(id, order, () => loadAccountProfile(state.accountProfileId));
+  await openDeliveryConfirmModal(id, order, () => loadAccountProfile(state.accountProfileId));
 }
 
-function openDeliveryConfirmModal(orderId, order, onComplete) {
-  const items = state.inventory;
+async function openDeliveryConfirmModal(orderId, order, onComplete) {
+  const locQuery = order.Location ? `?location=${encodeURIComponent(order.Location)}` : '';
+  const items = await api.get(`/api/inventory${locQuery}`);
   const acctName = order.AccountName || '';
   const invLabel = order.InvoiceNumber ? ` — Invoice #${esc(order.InvoiceNumber)}` : '';
 
   if (!items.length) {
     modal.confirm('Confirm Delivery',
-      `No inventory products are configured. Mark this order as delivered without recording stock movements?`,
+      `No inventory products are configured for ${order.Location || 'this location'}. Mark this order as delivered without recording stock movements?`,
       async () => {
         await api.put(`/api/orders/${orderId}`, { Delivered: 'true' });
         modal.close();
@@ -2253,6 +2276,24 @@ function navigate(view, filters = {}) {
   });
 }
 
+// ── Location ──────────────────────────────────────────────────────
+
+function updateLocationSwitcher() {
+  LOCATIONS.forEach(loc => {
+    const btn = document.getElementById(`loc-btn-${loc}`);
+    if (btn) btn.classList.toggle('active', state.location === loc);
+  });
+}
+
+function switchLocation(loc) {
+  state.location = loc;
+  localStorage.setItem('brewLocation', loc);
+  state.inventory = []; // clear cached inventory so next load refetches for new location
+  updateLocationSwitcher();
+  const loader = VIEW_LOADERS[state.view];
+  if (loader) loader().catch(err => toast(err.message, 'error'));
+}
+
 // ── Init ──────────────────────────────────────────────────────────
 
 async function init() {
@@ -2283,6 +2324,8 @@ async function init() {
     window.location.href = '/login';
     return;
   }
+
+  updateLocationSwitcher();
 
   // Mobile sidebar toggle
   const menuBtn = document.getElementById('mobile-menu-btn');

--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,11 @@
           </div>
         </div>
 
+        <div class="location-switcher">
+          <button class="loc-btn" id="loc-btn-Hutchinson" onclick="switchLocation('Hutchinson')">Hutchinson</button>
+          <button class="loc-btn" id="loc-btn-Mission" onclick="switchLocation('Mission')">Mission</button>
+        </div>
+
         <nav class="sidebar-nav">
           <a class="nav-item active" data-view="dashboard" href="#dashboard">
             <span class="nav-icon">&#9632;</span> Dashboard

--- a/public/style.css
+++ b/public/style.css
@@ -141,6 +141,44 @@ body {
   opacity: 1;
 }
 
+/* ── Location Switcher ───────────────────────────────── */
+
+.location-switcher {
+  display: flex;
+  gap: 4px;
+  padding: 10px 12px 8px;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+
+.loc-btn {
+  flex: 1;
+  padding: 5px 6px;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 5px;
+  color: var(--sidebar-text);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: center;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.loc-btn:hover {
+  background: rgba(255,255,255,0.12);
+  color: #fff;
+}
+
+.loc-btn.active {
+  background: var(--sidebar-active);
+  border-color: var(--sidebar-active);
+  color: #fff;
+  font-weight: 600;
+}
+
 .sidebar-user {
   padding: 12px 18px;
   border-top: 1px solid rgba(255,255,255,0.08);

--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -7,13 +7,18 @@ const router = express.Router();
 
 router.get('/', async (req, res) => {
   try {
-    const [inventory, accounts, outreach, reminders, orders] = await Promise.all([
+    const { location } = req.query;
+    let [inventory, accounts, outreach, reminders, orders] = await Promise.all([
       getAllRows('INVENTORY'),
       getAllRows('ACCOUNTS'),
       getAllRows('OUTREACH'),
       getAllRows('REMINDERS'),
       getAllRows('ORDERS'),
     ]);
+    if (location) {
+      inventory = inventory.filter(i => i.Location === location);
+      orders    = orders.filter(o => o.Location === location);
+    }
 
     const today = new Date().toISOString().split('T')[0];
     const in7Days = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];

--- a/routes/inventory.js
+++ b/routes/inventory.js
@@ -8,7 +8,9 @@ const router = express.Router();
 
 router.get('/', async (req, res) => {
   try {
-    const items = await getAllRows('INVENTORY');
+    const { location } = req.query;
+    let items = await getAllRows('INVENTORY');
+    if (location) items = items.filter(i => i.Location === location);
     res.json(items);
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -17,12 +19,13 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
   try {
-    const { Name, Style, ABV, Format, Units, PricePerUnit, LowStockThreshold, Notes } = req.body;
+    const { Name, Location, Style, ABV, Format, Units, PricePerUnit, LowStockThreshold, Notes } = req.body;
     if (!Name) return res.status(400).json({ error: 'Name is required' });
 
     const item = {
       ID: uuidv4(),
       Name: Name.trim(),
+      Location: Location || '',
       Style: Style || '',
       ABV: ABV || '',
       Format: Format || '',

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -8,10 +8,11 @@ const router = express.Router();
 
 router.get('/', async (req, res) => {
   try {
-    const { accountId, staffId } = req.query;
+    const { accountId, staffId, location } = req.query;
     let orders = await getAllRows('ORDERS');
     if (accountId) orders = orders.filter(s => s.AccountID === accountId);
     if (staffId)   orders = orders.filter(s => s.StaffID === staffId);
+    if (location)  orders = orders.filter(s => s.Location === location);
     // Sort newest first
     orders.sort((a, b) => (b.OrderDate || '').localeCompare(a.OrderDate || ''));
     res.json(orders);
@@ -23,7 +24,7 @@ router.get('/', async (req, res) => {
 router.post('/', async (req, res) => {
   try {
     const {
-      AccountID, AccountName, StaffID, StaffName,
+      AccountID, AccountName, Location, StaffID, StaffName,
       OrderDate, DeliveryDate, InvoiceNumber,
       OrderAmount, TaxAmount, Notes, Status, Delivered,
     } = req.body;
@@ -35,6 +36,7 @@ router.post('/', async (req, res) => {
       ID: uuidv4(),
       AccountID,
       AccountName: AccountName || '',
+      Location:    Location || '',
       StaffID:     StaffID || '',
       StaffName:   StaffName || '',
       OrderDate,

--- a/sheets.js
+++ b/sheets.js
@@ -18,12 +18,12 @@ const SHEETS = {
 // HEADERS defines every column each sheet should have.
 // On startup, any missing columns are automatically appended (migration-safe).
 const HEADERS = {
-  INVENTORY: ['ID', 'Name', 'Style', 'ABV', 'Format', 'Units', 'PricePerUnit', 'LowStockThreshold', 'Notes', 'LastUpdated'],
+  INVENTORY: ['ID', 'Name', 'Location', 'Style', 'ABV', 'Format', 'Units', 'PricePerUnit', 'LowStockThreshold', 'Notes', 'LastUpdated'],
   ACCOUNTS:  ['ID', 'Name', 'Type', 'ContactName', 'Email', 'Phone', 'PreferredMethod', 'Address', 'City', 'State', 'ABCLicense', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'CreatedAt'],
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
   REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
   STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt'],
-  ORDERS:          ['ID', 'AccountID', 'AccountName', 'StaffID', 'StaffName', 'OrderDate', 'DeliveryDate', 'InvoiceNumber', 'OrderAmount', 'TaxAmount', 'Notes', 'Status', 'Delivered', 'CreatedAt'],
+  ORDERS:          ['ID', 'AccountID', 'AccountName', 'Location', 'StaffID', 'StaffName', 'OrderDate', 'DeliveryDate', 'InvoiceNumber', 'OrderAmount', 'TaxAmount', 'Notes', 'Status', 'Delivered', 'CreatedAt'],
   STOCK_MOVEMENTS: ['ID', 'InventoryID', 'InventoryName', 'OrderID', 'Type', 'Quantity', 'Notes', 'Date', 'CreatedAt'],
 };
 


### PR DESCRIPTION
- New Location field on Inventory and Orders sheets (migration-safe, added automatically on next startup)
- Location switcher in sidebar persists to localStorage so each browser session remembers the last selected location
- Inventory, Orders, and Dashboard API routes all accept a ?location= query param and filter results accordingly
- All load functions (loadInventory, loadOrders, loadDashboard) pass the active location, so each view shows only that location's data
- Inventory and Order forms include a Location dropdown pre-filled from the active location but editable, so staff can cross-post
- Delivery confirmation modal fetches inventory by the order's own location regardless of which location is currently selected in the sidebar, ensuring correct stock is decremented
- View subtitles ("N products at Hutchinson") reinforce context

https://claude.ai/code/session_01HZYXzPuSYTjeMqirqtjKjp