### PR TITLE
Add Settings page with dynamic company name and locations

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // ── State ────────────────────────────────────────────────────────
-const LOCATIONS = ['Hutchinson', 'Mission'];
+let LOCATIONS = ['Hutchinson', 'Mission']; // Defaults; overwritten by settings on init
 
 const state = {
   view: 'dashboard',
@@ -9,6 +9,7 @@ const state = {
   accounts: [],      // cached for select dropdowns
   inventory: [],
   staff: [],         // cached for staff dropdowns
+  settings: {},
 };
 
 // ── Pagination ──────────────────────────────────────────────────
@@ -2266,6 +2267,140 @@ async function openDeliveryConfirmModal(orderId, order, onComplete) {
   }, 'Confirm Delivery');
 }
 
+// ── Settings View ─────────────────────────────────────────────────
+
+async function loadSettings() {
+  showLoading();
+  const settings = await api.get('/api/settings');
+  state.settings = settings;
+  renderSettings();
+}
+
+function renderSettings() {
+  const s = state.settings;
+  const companyName = s.companyName || '';
+  const locations = Array.isArray(s.locations) ? s.locations : [...LOCATIONS];
+
+  setContent(`
+    <div class="view-header">
+      <div>
+        <h2>Settings</h2>
+        <p class="subtitle">Manage application configuration</p>
+      </div>
+    </div>
+
+    <div class="settings-grid">
+      <div class="card">
+        <div class="card-header"><h3>Company</h3></div>
+        <div style="padding:0 18px 18px">
+          <div class="form-group">
+            <label>Company Name</label>
+            <input class="form-control" id="settings-company-name" value="${esc(companyName)}" placeholder="e.g. My Brewery" />
+          </div>
+          <button class="btn btn-primary" onclick="saveCompanyName()">Save</button>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <h3>Locations</h3>
+          <button class="btn btn-ghost btn-sm" onclick="openAddLocation()">+ Add Location</button>
+        </div>
+        <div style="padding:0 18px 18px">
+          <p class="text-sm text-muted" style="margin-bottom:12px">
+            Manage warehouse and distribution locations. These appear in the sidebar switcher and in inventory/order forms.
+          </p>
+          ${locations.length === 0
+            ? '<p class="empty-state">No locations configured.</p>'
+            : `<ul class="settings-location-list">
+                ${locations.map((loc, i) => `
+                  <li class="settings-location-item">
+                    <span class="settings-location-name">${esc(loc)}</span>
+                    <div class="settings-location-actions">
+                      <button class="btn btn-ghost btn-sm" onclick="openRenameLocation(${i}, '${esc(loc)}')">Rename</button>
+                      <button class="btn btn-ghost btn-sm text-danger" onclick="removeLocation(${i}, '${esc(loc)}')">Remove</button>
+                    </div>
+                  </li>`).join('')}
+              </ul>`
+          }
+        </div>
+      </div>
+    </div>`);
+}
+
+function saveCompanyName() {
+  const name = val('settings-company-name');
+  api.put('/api/settings', { companyName: name }).then(updated => {
+    state.settings = updated;
+    applySettings(updated);
+    toast('Company name saved');
+  }).catch(err => toast(err.message, 'error'));
+}
+
+function openAddLocation() {
+  modal.open('Add Location', `
+    <div class="form-group">
+      <label>Location Name <span class="required">*</span></label>
+      <input class="form-control" id="f-location-name" placeholder="e.g. Kansas City" />
+    </div>
+  `, async () => {
+    const name = val('f-location-name');
+    if (!name) { toast('Location name is required', 'error'); return; }
+    const current = Array.isArray(state.settings.locations) ? [...state.settings.locations] : [...LOCATIONS];
+    if (current.includes(name)) { toast('Location already exists', 'error'); return; }
+    current.push(name);
+    const updated = await api.put('/api/settings', { locations: current });
+    state.settings = updated;
+    applySettings(updated);
+    modal.close();
+    toast('Location added');
+    renderSettings();
+  });
+}
+
+function openRenameLocation(index, oldName) {
+  modal.open('Rename Location', `
+    <div class="form-group">
+      <label>New Name <span class="required">*</span></label>
+      <input class="form-control" id="f-location-name" value="${esc(oldName)}" />
+    </div>
+  `, async () => {
+    const newName = val('f-location-name');
+    if (!newName) { toast('Location name is required', 'error'); return; }
+    const current = Array.isArray(state.settings.locations) ? [...state.settings.locations] : [...LOCATIONS];
+    if (current.includes(newName) && newName !== oldName) { toast('Location already exists', 'error'); return; }
+    current[index] = newName;
+    const updated = await api.put('/api/settings', { locations: current });
+    state.settings = updated;
+    applySettings(updated);
+    if (state.location === oldName) {
+      state.location = newName;
+      localStorage.setItem('brewLocation', newName);
+    }
+    modal.close();
+    toast('Location renamed');
+    renderSettings();
+  });
+}
+
+function removeLocation(index, name) {
+  const current = Array.isArray(state.settings.locations) ? [...state.settings.locations] : [...LOCATIONS];
+  if (current.length <= 1) { toast('At least one location is required', 'error'); return; }
+  modal.confirm('Remove Location', `Remove "${name}"? Existing inventory and orders at this location will not be affected.`, async () => {
+    current.splice(index, 1);
+    const updated = await api.put('/api/settings', { locations: current });
+    state.settings = updated;
+    applySettings(updated);
+    if (state.location === name && current.length > 0) {
+      state.location = current[0];
+      localStorage.setItem('brewLocation', current[0]);
+    }
+    modal.close();
+    toast('Location removed');
+    renderSettings();
+  });
+}
+
 // ── Navigation ────────────────────────────────────────────────────
 
 const VIEW_LOADERS = {
@@ -2276,6 +2411,7 @@ const VIEW_LOADERS = {
   todos: loadTodos,
   orders:    loadOrders,
   staff:     loadStaff,
+  settings:  loadSettings,
 };
 
 function navigate(view, filters = {}) {
@@ -2294,20 +2430,36 @@ function navigate(view, filters = {}) {
 
 // ── Location ──────────────────────────────────────────────────────
 
-function updateLocationSwitcher() {
-  LOCATIONS.forEach(loc => {
-    const btn = document.getElementById(`loc-btn-${loc}`);
-    if (btn) btn.classList.toggle('active', state.location === loc);
-  });
+function renderLocationSwitcher() {
+  const container = document.getElementById('location-switcher');
+  if (!container) return;
+  container.innerHTML = LOCATIONS.map(loc =>
+    `<button class="loc-btn${state.location === loc ? ' active' : ''}" onclick="switchLocation('${esc(loc)}')">${esc(loc)}</button>`
+  ).join('');
 }
 
 function switchLocation(loc) {
   state.location = loc;
   localStorage.setItem('brewLocation', loc);
   state.inventory = []; // clear cached inventory so next load refetches for new location
-  updateLocationSwitcher();
+  renderLocationSwitcher();
   const loader = VIEW_LOADERS[state.view];
   if (loader) loader().catch(err => toast(err.message, 'error'));
+}
+
+function applySettings(settings) {
+  if (Array.isArray(settings.locations) && settings.locations.length > 0) {
+    LOCATIONS = settings.locations;
+  }
+  if (!LOCATIONS.includes(state.location)) {
+    state.location = LOCATIONS[0];
+    localStorage.setItem('brewLocation', state.location);
+  }
+  if (settings.companyName) {
+    const el = document.getElementById('brand-title');
+    if (el) el.textContent = settings.companyName;
+  }
+  renderLocationSwitcher();
 }
 
 // ── Init ──────────────────────────────────────────────────────────
@@ -2341,7 +2493,15 @@ async function init() {
     return;
   }
 
-  updateLocationSwitcher();
+  // Load settings (locations, company name) before rendering UI
+  try {
+    const settings = await api.get('/api/settings');
+    state.settings = settings;
+    applySettings(settings);
+  } catch (e) {
+    console.warn('Failed to load settings, using defaults:', e.message);
+    renderLocationSwitcher();
+  }
 
   // Mobile sidebar toggle
   const menuBtn = document.getElementById('mobile-menu-btn');

--- a/public/index.html
+++ b/public/index.html
@@ -28,14 +28,13 @@
         <div class="sidebar-brand">
           <span class="brand-icon">&#127866;</span>
           <div>
-            <div class="brand-title">Brewery Distro</div>
+            <div class="brand-title" id="brand-title">Brewery Distro</div>
             <div class="brand-sub">Distribution Manager</div>
           </div>
         </div>
 
-        <div class="location-switcher">
-          <button class="loc-btn" id="loc-btn-Hutchinson" onclick="switchLocation('Hutchinson')">Hutchinson</button>
-          <button class="loc-btn" id="loc-btn-Mission" onclick="switchLocation('Mission')">Mission</button>
+        <div class="location-switcher" id="location-switcher">
+          <!-- Populated dynamically by app.js -->
         </div>
 
         <nav class="sidebar-nav">
@@ -59,6 +58,9 @@
           </a>
           <a class="nav-item" data-view="staff" href="#staff">
             <span class="nav-icon">&#9632;</span> Staff
+          </a>
+          <a class="nav-item" data-view="settings" href="#settings">
+            <span class="nav-icon">&#9632;</span> Settings
           </a>
         </nav>
 

--- a/public/style.css
+++ b/public/style.css
@@ -1001,6 +1001,43 @@ tr.row-completed button {
   font-size: 12px;
 }
 
+/* ── Settings ────────────────────────────────────────── */
+
+.settings-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 18px;
+  max-width: 640px;
+}
+
+.settings-location-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.settings-location-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.settings-location-item:last-child {
+  border-bottom: none;
+}
+
+.settings-location-name {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.settings-location-actions {
+  display: flex;
+  gap: 4px;
+}
+
 /* ── Mobile Menu Button & Backdrop (hidden on desktop) ── */
 
 .mobile-menu-btn {

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const express = require('express');
+const { v4: uuidv4 } = require('uuid');
+const { getAllRows, addRow, updateRow } = require('../sheets');
+
+const router = express.Router();
+
+// GET /api/settings — returns settings as a key-value map
+router.get('/', async (req, res) => {
+  try {
+    const rows = await getAllRows('SETTINGS');
+    const settings = {};
+    for (const row of rows) {
+      settings[row.Key] = row.Value;
+    }
+    // Parse JSON values
+    if (settings.locations) {
+      try { settings.locations = JSON.parse(settings.locations); }
+      catch (e) { settings.locations = []; }
+    }
+    res.json(settings);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// PUT /api/settings — accepts a key-value map, upserts each key
+router.put('/', async (req, res) => {
+  try {
+    const incoming = req.body;
+    const rows = await getAllRows('SETTINGS');
+    const existingByKey = {};
+    for (const row of rows) {
+      existingByKey[row.Key] = row;
+    }
+
+    for (const [key, rawValue] of Object.entries(incoming)) {
+      const value = (typeof rawValue === 'object') ? JSON.stringify(rawValue) : String(rawValue);
+      const now = new Date().toISOString().split('T')[0];
+
+      if (existingByKey[key]) {
+        await updateRow('SETTINGS', existingByKey[key].ID, { Value: value, UpdatedAt: now });
+      } else {
+        await addRow('SETTINGS', { ID: uuidv4(), Key: key, Value: value, UpdatedAt: now });
+      }
+    }
+
+    // Return updated settings
+    const updated = await getAllRows('SETTINGS');
+    const result = {};
+    for (const row of updated) {
+      result[row.Key] = row.Value;
+    }
+    if (result.locations) {
+      try { result.locations = JSON.parse(result.locations); }
+      catch (e) { result.locations = []; }
+    }
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -20,6 +20,7 @@ const ordersRoutes         = require('./routes/orders');
 const dashboardRoutes      = require('./routes/dashboard');
 const webhooksRoutes       = require('./routes/webhooks');
 const stockMovementsRoutes = require('./routes/stock-movements');
+const settingsRoutes       = require('./routes/settings');
 
 const app  = express();
 const PORT = process.env.PORT || 3000;
@@ -65,6 +66,7 @@ app.use('/api/staff',     requireAuth, staffRoutes);
 app.use('/api/orders',          requireAuth, ordersRoutes);
 app.use('/api/stock-movements', requireAuth, stockMovementsRoutes);
 app.use('/api/dashboard',       requireAuth, dashboardRoutes);
+app.use('/api/settings',        requireAuth, settingsRoutes);
 
 // Status endpoint (public – used by the frontend before auth).
 app.get('/api/status', (req, res) => {

--- a/sheets.js
+++ b/sheets.js
@@ -13,6 +13,7 @@ const SHEETS = {
   STAFF:           'Staff',
   ORDERS:          'Orders',
   STOCK_MOVEMENTS: 'StockMovements',
+  SETTINGS:        'Settings',
 };
 
 // HEADERS defines every column each sheet should have.
@@ -25,6 +26,7 @@ const HEADERS = {
   STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt'],
   ORDERS:          ['ID', 'AccountID', 'AccountName', 'Location', 'StaffID', 'StaffName', 'OrderDate', 'DeliveryDate', 'InvoiceNumber', 'OrderAmount', 'TaxAmount', 'Notes', 'Status', 'Delivered', 'CreatedAt'],
   STOCK_MOVEMENTS: ['ID', 'InventoryID', 'InventoryName', 'OrderID', 'Type', 'Quantity', 'Notes', 'Date', 'CreatedAt'],
+  SETTINGS:        ['ID', 'Key', 'Value', 'UpdatedAt'],
 };
 
 // Cached sheet header rows — avoids an extra API call on every write


### PR DESCRIPTION
## Summary
- Adds a new **Settings page** accessible from the sidebar navigation
- **Company Name**: configurable text input that updates the sidebar brand title in real-time
- **Locations**: full CRUD management (add, rename, remove) replacing the hardcoded `['Hutchinson', 'Mission']` array
  - Location buttons in the sidebar switcher render dynamically from settings
  - Location dropdowns in Inventory and Order forms automatically reflect changes
  - Prevents removing the last location
  - Handles active location rename/removal gracefully
- **Key-value store architecture** in a new `Settings` Google Sheet — designed to support future settings without schema changes
- **Backwards compatible**: app uses default locations until settings are first edited; no data migration needed

### Files changed
- `sheets.js` — new SETTINGS sheet/headers config
- `routes/settings.js` — new GET/PUT endpoints for key-value settings
- `server.js` — register settings route
- `public/index.html` — dynamic location switcher container, brand-title ID, settings nav item
- `public/app.js` — settings view, `applySettings()`, `renderLocationSwitcher()`, init-time settings load
- `public/style.css` — settings page layout styles

## Test plan
- [ ] Settings nav item appears in sidebar and loads the settings page
- [ ] Save a company name — verify the sidebar brand title updates immediately
- [ ] Add a new location — verify it appears in the sidebar switcher and in Inventory/Order form dropdowns
- [ ] Rename a location — verify the switcher and forms update; if it was the active location, verify it stays selected
- [ ] Remove a location — verify confirmation prompt; verify it disappears from switcher and forms
- [ ] Try removing the last location — verify it's blocked with an error
- [ ] Refresh the page — verify settings persist (loaded from Google Sheet)
- [ ] First load with no settings saved — verify defaults still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)