### PR TITLE
Add keg tracking system

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -778,10 +778,11 @@ async function loadAccountProfile(accountId) {
   });
   showLoading();
 
-  const [outreach, todos, orders] = await Promise.all([
+  const [outreach, todos, orders, kegRecords] = await Promise.all([
     api.get('/api/outreach'),
     api.get('/api/reminders?status=all'),
     api.get('/api/orders'),
+    api.get(`/api/keg-tracking?accountId=${accountId}`),
   ]);
   if (state.accounts.length === 0) state.accounts = await api.get('/api/accounts');
 
@@ -800,6 +801,14 @@ async function loadAccountProfile(accountId) {
 
   const totalRevenue = acctOrders.reduce((sum, s) => sum + (parseFloat(s.OrderAmount || 0) + parseFloat(s.TaxAmount || 0)), 0);
   const activeTodos  = acctTodos.filter(t => t.Completed !== 'true').length;
+
+  // Keg tracking calculations
+  const acctKegs = (kegRecords || []).sort((a, b) => (b.DeliveredDate || '').localeCompare(a.DeliveredDate || ''));
+  const outstandingKegs = acctKegs.reduce((sum, k) => {
+    const qty = parseInt(k.Quantity) || 0;
+    const returned = parseInt(k.ReturnedQuantity) || 0;
+    return sum + Math.max(0, qty - returned);
+  }, 0);
 
   const infoRows = [
     `<div class="profile-info-item"><span class="profile-info-label">Account ID</span><span class="text-muted text-sm" style="font-family:monospace">${esc(acct.ID)}</span></div>`,
@@ -875,6 +884,28 @@ async function loadAccountProfile(accountId) {
       </tr></tfoot>`
     : '';
 
+  const kegRows = acctKegs.length === 0
+    ? `<tr><td colspan="7" class="empty-state">No keg deliveries recorded.</td></tr>`
+    : acctKegs.map(k => {
+        const qty = parseInt(k.Quantity) || 0;
+        const returned = parseInt(k.ReturnedQuantity) || 0;
+        const outstanding = Math.max(0, qty - returned);
+        const fullyReturned = outstanding === 0;
+        return `<tr class="${fullyReturned ? 'row-completed' : ''}">
+          <td class="text-sm">${formatDate(k.DeliveredDate)}</td>
+          <td class="fw-600">${esc(k.ProductName)}</td>
+          <td class="text-sm">${esc(k.Format)}</td>
+          <td class="text-center">${qty}</td>
+          <td class="text-center">${returned}</td>
+          <td class="text-center fw-600${outstanding > 0 ? ' text-danger' : ''}">${outstanding}</td>
+          <td class="td-actions">
+            ${outstanding > 0
+              ? `<button class="btn btn-ghost btn-sm" onclick="openReturnKegs('${esc(k.ID)}', '${esc(k.ProductName)}', '${esc(k.Format)}', ${qty}, ${returned})">Return Kegs</button>`
+              : '<span class="badge" style="background:#e8f5e9;color:#2e7d32">Returned</span>'}
+          </td>
+        </tr>`;
+      }).join('');
+
   setContent(`
     <div class="view-header">
       <div style="display:flex;align-items:center;gap:12px">
@@ -897,6 +928,7 @@ async function loadAccountProfile(accountId) {
       <div class="profile-stat"><div class="stat-value">${activeTodos}</div><div class="stat-label">Open Todos</div></div>
       <div class="profile-stat"><div class="stat-value">${acctOrders.length}</div><div class="stat-label">Orders</div></div>
       <div class="profile-stat"><div class="stat-value">${fmtMoney(totalRevenue)}</div><div class="stat-label">Total Revenue</div></div>
+      <div class="profile-stat"><div class="stat-value${outstandingKegs > 0 ? ' text-danger' : ''}">${outstandingKegs}</div><div class="stat-label">Kegs Out</div></div>
     </div>
 
     <div class="profile-info card" style="margin-bottom:24px">
@@ -942,7 +974,67 @@ async function loadAccountProfile(accountId) {
         </table>
       </div>
     </div>
+
+    <div class="profile-section">
+      <div class="profile-section-header">
+        <h3>Keg Tracking <span class="text-muted text-sm">(${outstandingKegs} outstanding)</span></h3>
+      </div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Delivered</th><th>Product</th><th>Format</th><th class="text-center">Qty</th><th class="text-center">Returned</th><th class="text-center">Outstanding</th><th>Actions</th></tr></thead>
+          <tbody>${kegRows}</tbody>
+        </table>
+      </div>
+    </div>
   `);
+}
+
+function openReturnKegs(kegId, productName, format, totalQty, alreadyReturned) {
+  const outstanding = totalQty - alreadyReturned;
+  const formHtml = `
+    <div class="form-group">
+      <label class="form-label">Product</label>
+      <div class="text-sm">${esc(productName)} — ${esc(format)}</div>
+    </div>
+    <div class="form-row">
+      <div class="form-group">
+        <label class="form-label">Total Delivered</label>
+        <div class="text-sm">${totalQty}</div>
+      </div>
+      <div class="form-group">
+        <label class="form-label">Already Returned</label>
+        <div class="text-sm">${alreadyReturned}</div>
+      </div>
+      <div class="form-group">
+        <label class="form-label">Outstanding</label>
+        <div class="text-sm fw-600 text-danger">${outstanding}</div>
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="form-label" for="f-return-qty">Kegs Returned Now</label>
+      <input class="form-input" type="number" id="f-return-qty" min="1" max="${outstanding}" value="${outstanding}" />
+    </div>
+    <div class="form-group">
+      <label class="form-label" for="f-return-notes">Notes</label>
+      <input class="form-input" type="text" id="f-return-notes" placeholder="Optional notes" />
+    </div>
+  `;
+  modal.open('Return Kegs', formHtml, async () => {
+    const returnQty = parseInt(val('f-return-qty'));
+    if (!returnQty || returnQty < 1 || returnQty > outstanding) {
+      toast('Enter a valid return quantity (1–' + outstanding + ')', 'error');
+      return;
+    }
+    const newReturnedTotal = alreadyReturned + returnQty;
+    await api.put(`/api/keg-tracking/${kegId}`, {
+      ReturnedQuantity: String(newReturnedTotal),
+      ReturnedDate: new Date().toISOString().split('T')[0],
+      Notes: val('f-return-notes') || '',
+    });
+    modal.close();
+    toast(`${returnQty} keg${returnQty > 1 ? 's' : ''} marked as returned`);
+    loadAccountProfile(state.accountProfileId);
+  });
 }
 
 // Profile-page action wrappers — reload profile instead of their default views

--- a/public/style.css
+++ b/public/style.css
@@ -863,7 +863,7 @@ textarea.form-control { resize: vertical; min-height: 72px; }
 
 .profile-stats {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   gap: 16px;
   margin-bottom: 20px;
 }
@@ -1127,7 +1127,7 @@ tr.row-completed button {
     justify-content: flex-start;
   }
 
-  /* ── Profile stats: 2 columns instead of 4 ── */
+  /* ── Profile stats: 2 columns instead of 5 ── */
   .profile-stats {
     grid-template-columns: repeat(2, 1fr);
     gap: 10px;

--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -92,6 +92,14 @@ router.delete('/:id', async (req, res) => {
       }
     }
 
+    // Cascade delete: remove associated keg tracking records
+    const kegs = await getAllRows('KEG_TRACKING');
+    for (const keg of kegs) {
+      if (keg.AccountID === id) {
+        await deleteRow('KEG_TRACKING', keg.ID);
+      }
+    }
+
     await deleteRow('ACCOUNTS', id);
     res.json({ success: true });
   } catch (err) {

--- a/routes/keg-tracking.js
+++ b/routes/keg-tracking.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const express = require('express');
+const { v4: uuidv4 } = require('uuid');
+const { getAllRows, addRow, updateRow } = require('../sheets');
+
+const router = express.Router();
+
+// GET /api/keg-tracking — returns keg records, optionally filtered by accountId
+router.get('/', async (req, res) => {
+  try {
+    const rows = await getAllRows('KEG_TRACKING');
+    if (req.query.accountId) {
+      return res.json(rows.filter(r => r.AccountID === req.query.accountId));
+    }
+    res.json(rows);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /api/keg-tracking/summary — per-account outstanding keg counts
+router.get('/summary', async (req, res) => {
+  try {
+    const rows = await getAllRows('KEG_TRACKING');
+    const summary = {};
+    for (const r of rows) {
+      const qty = parseInt(r.Quantity) || 0;
+      const returned = parseInt(r.ReturnedQuantity) || 0;
+      const outstanding = qty - returned;
+      if (outstanding <= 0) continue;
+      if (!summary[r.AccountID]) {
+        summary[r.AccountID] = { accountId: r.AccountID, accountName: r.AccountName, outstanding: 0 };
+      }
+      summary[r.AccountID].outstanding += outstanding;
+    }
+    res.json(Object.values(summary));
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /api/keg-tracking — create a keg tracking record
+router.post('/', async (req, res) => {
+  try {
+    const { accountId, accountName, orderId, inventoryId, productName, format, quantity, deliveredDate, notes } = req.body;
+    if (!accountId || !quantity) return res.status(400).json({ error: 'accountId and quantity are required' });
+
+    const record = {
+      ID: uuidv4(),
+      AccountID: accountId,
+      AccountName: accountName || '',
+      OrderID: orderId || '',
+      InventoryID: inventoryId || '',
+      ProductName: productName || '',
+      Format: format || '',
+      Quantity: String(quantity),
+      DeliveredDate: deliveredDate || new Date().toISOString().split('T')[0],
+      ReturnedDate: '',
+      ReturnedQuantity: '0',
+      Notes: notes || '',
+      CreatedAt: new Date().toISOString(),
+    };
+    await addRow('KEG_TRACKING', record);
+    res.json(record);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// PUT /api/keg-tracking/:id — update a keg tracking record (mark returned)
+router.put('/:id', async (req, res) => {
+  try {
+    const id = req.params.id;
+    const updates = {};
+    const allowed = ['ReturnedDate', 'ReturnedQuantity', 'Notes'];
+    for (const key of allowed) {
+      if (req.body[key] !== undefined) updates[key] = req.body[key];
+    }
+    const updated = await updateRow('KEG_TRACKING', id, updates);
+    res.json(updated);
+  } catch (err) {
+    res.status(err.message.includes('not found') ? 404 : 500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/routes/stock-movements.js
+++ b/routes/stock-movements.js
@@ -28,10 +28,15 @@ router.post('/bulk', async (req, res) => {
     if (!orderId) return res.status(400).json({ error: 'orderId is required' });
     if (!Array.isArray(items)) return res.status(400).json({ error: 'items must be an array' });
 
+    // Fetch the order to get AccountID/AccountName for keg tracking
+    const allOrders = await getAllRows('ORDERS');
+    const order = allOrders.find(o => o.ID === orderId);
+
     const inventory = await getAllRows('INVENTORY');
     const movDate   = date || new Date().toISOString().split('T')[0];
     const createdAt = new Date().toISOString();
     const movements = [];
+    const kegRecords = [];
 
     for (const item of items) {
       const qty = parseInt(item.quantity);
@@ -59,10 +64,31 @@ router.post('/bulk', async (req, res) => {
         Units:       String(newUnits),
         LastUpdated: movDate,
       });
+
+      // Auto-create keg tracking record for keg-format products
+      if (inv.Format && inv.Format.toLowerCase().includes('keg') && order) {
+        const kegRecord = {
+          ID:               uuidv4(),
+          AccountID:        order.AccountID || '',
+          AccountName:      order.AccountName || '',
+          OrderID:          orderId,
+          InventoryID:      item.inventoryId,
+          ProductName:      inv.Name || '',
+          Format:           inv.Format || '',
+          Quantity:         String(qty),
+          DeliveredDate:    movDate,
+          ReturnedDate:     '',
+          ReturnedQuantity: '0',
+          Notes:            '',
+          CreatedAt:        createdAt,
+        };
+        await addRow('KEG_TRACKING', kegRecord);
+        kegRecords.push(kegRecord);
+      }
     }
 
     await updateRow('ORDERS', orderId, { Delivered: 'true' });
-    res.json({ movements });
+    res.json({ movements, kegRecords });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/server.js
+++ b/server.js
@@ -21,6 +21,7 @@ const dashboardRoutes      = require('./routes/dashboard');
 const webhooksRoutes       = require('./routes/webhooks');
 const stockMovementsRoutes = require('./routes/stock-movements');
 const settingsRoutes       = require('./routes/settings');
+const kegTrackingRoutes    = require('./routes/keg-tracking');
 
 const app  = express();
 const PORT = process.env.PORT || 3000;
@@ -67,6 +68,7 @@ app.use('/api/orders',          requireAuth, ordersRoutes);
 app.use('/api/stock-movements', requireAuth, stockMovementsRoutes);
 app.use('/api/dashboard',       requireAuth, dashboardRoutes);
 app.use('/api/settings',        requireAuth, settingsRoutes);
+app.use('/api/keg-tracking',    requireAuth, kegTrackingRoutes);
 
 // Status endpoint (public – used by the frontend before auth).
 app.get('/api/status', (req, res) => {

--- a/sheets.js
+++ b/sheets.js
@@ -14,6 +14,7 @@ const SHEETS = {
   ORDERS:          'Orders',
   STOCK_MOVEMENTS: 'StockMovements',
   SETTINGS:        'Settings',
+  KEG_TRACKING:    'KegTracking',
 };
 
 // HEADERS defines every column each sheet should have.
@@ -27,6 +28,7 @@ const HEADERS = {
   ORDERS:          ['ID', 'AccountID', 'AccountName', 'Location', 'StaffID', 'StaffName', 'OrderDate', 'DeliveryDate', 'InvoiceNumber', 'OrderAmount', 'TaxAmount', 'Notes', 'Status', 'Delivered', 'CreatedAt'],
   STOCK_MOVEMENTS: ['ID', 'InventoryID', 'InventoryName', 'OrderID', 'Type', 'Quantity', 'Notes', 'Date', 'CreatedAt'],
   SETTINGS:        ['ID', 'Key', 'Value', 'UpdatedAt'],
+  KEG_TRACKING:    ['ID', 'AccountID', 'AccountName', 'OrderID', 'InventoryID', 'ProductName', 'Format', 'Quantity', 'DeliveredDate', 'ReturnedDate', 'ReturnedQuantity', 'Notes', 'CreatedAt'],
 };
 
 // Cached sheet header rows — avoids an extra API call on every write


### PR DESCRIPTION
## Summary
- Adds a new `KegTracking` Google Sheet to automatically track keg deliveries and returns
- Auto-creates keg tracking records when orders containing keg-format products (1/2 Keg, 1/4 Keg, 1/6 Keg) are delivered
- Adds a "Keg Tracking" section to account profiles showing delivery history, return status, and outstanding counts
- Supports partial returns via a "Return Kegs" modal with quantity validation
- Adds a "Kegs Out" stat to the account profile stats row
- Cascade-deletes keg records when an account is deleted

## Test plan
- [x] Deliver an order containing keg products and verify keg tracking records are auto-created
- [x] View account profile and confirm the "Kegs Out" stat and Keg Tracking table appear
- [x] Click "Return Kegs" and verify partial/full return flow works correctly
- [x] Confirm non-keg products do not create keg tracking records
- [x] Delete an account and verify keg tracking records are cascade-deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)