### PR TITLE
Add new beer styles to product dropdown

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -308,7 +308,7 @@ function staffOptions(selectedId = '') {
 // ── Inventory View ────────────────────────────────────────────────
 
 const FORMATS = ['1/2 Keg', '1/4 Keg', '1/6 Keg', '12oz Can (case/24)', '16oz Can (case/24)', '22oz Bottle (case/12)', '750ml Bottle (case/12)', 'Other'];
-const STYLES  = ['IPA', 'Double IPA', 'Pale Ale', 'Lager', 'Pilsner', 'Wheat', 'Hefeweizen', 'Stout', 'Porter', 'Sour', 'Saison', 'Amber', 'Brown Ale', 'Barleywine', 'Other'];
+const STYLES  = ['IPA', 'Double IPA', 'Pale Ale', 'Lager', 'Pilsner', 'Wheat', 'Hefeweizen', 'Stout', 'Porter', 'Sour', 'Saison', 'Amber', 'Brown Ale', 'Barleywine', 'Scottish', 'English Mild', 'Kölsch', 'Golden Ale', 'Other'];
 
 function inventoryForm(item = {}) {
   const isEdit = !!item.ID;


### PR DESCRIPTION
## Summary
- Adds four new styles to the product style dropdown: Scottish, English Mild, Kölsch, and Golden Ale

## Test plan
- [ ] Open Add/Edit Product form and verify new styles appear in the Style dropdown
- [ ] Verify "Other" remains as the last option

🤖 Generated with [Claude Code](https://claude.com/claude-code)