### PR TITLE
Show overdue deliveries in dashboard and use full CreatedAt timestamps

### DIFF
--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -42,7 +42,7 @@ router.post('/', async (req, res) => {
       LastContacted: '',
       StaffID: StaffID || '',
       StaffName: StaffName || '',
-      CreatedAt: new Date().toISOString().split('T')[0],
+      CreatedAt: new Date().toISOString(),
     };
 
     await addRow('ACCOUNTS', account);

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -47,7 +47,7 @@ router.post('/', async (req, res) => {
       Notes:     Notes     || '',
       Status:    Status    || 'Pending',
       Delivered: Delivered || 'false',
-      CreatedAt: new Date().toISOString().split('T')[0],
+      CreatedAt: new Date().toISOString(),
     };
 
     await addRow('ORDERS', order);

--- a/routes/outreach.js
+++ b/routes/outreach.js
@@ -35,7 +35,7 @@ router.post('/', async (req, res) => {
       Notes: Notes || '',
       FollowUpDate: FollowUpDate || '',
       FollowUpStatus: FollowUpStatus || (FollowUpDate ? 'Pending' : 'None'),
-      CreatedAt: new Date().toISOString().split('T')[0],
+      CreatedAt: new Date().toISOString(),
     };
 
     await addRow('OUTREACH', entry);

--- a/routes/reminders.js
+++ b/routes/reminders.js
@@ -62,7 +62,7 @@ router.post('/', async (req, res) => {
       StaffName: StaffName || '',
       Recurrence: recurrence,
       RecurrenceParentID: RecurrenceParentID || '',
-      CreatedAt: new Date().toISOString().split('T')[0],
+      CreatedAt: new Date().toISOString(),
     };
 
     await addRow('REMINDERS', reminder);
@@ -95,7 +95,7 @@ router.put('/:id', async (req, res) => {
         StaffName: updated.StaffName || '',
         Recurrence: updated.Recurrence,
         RecurrenceParentID: updated.RecurrenceParentID || updated.ID,
-        CreatedAt: new Date().toISOString().split('T')[0],
+        CreatedAt: new Date().toISOString(),
       };
       await addRow('REMINDERS', next);
       return res.json({ ...updated, _nextReminder: next });

--- a/routes/staff.js
+++ b/routes/staff.js
@@ -28,7 +28,7 @@ router.post('/', async (req, res) => {
       Role: Role || '',
       Active: 'true',
       Notes: Notes || '',
-      CreatedAt: new Date().toISOString().split('T')[0],
+      CreatedAt: new Date().toISOString(),
     };
 
     await addRow('STAFF', member);


### PR DESCRIPTION
## Summary
- Undelivered orders with a **past** delivery date now appear in the **Overdue** widget and **My Todos** overdue section, ensuring missed deliveries stay visible
- All `CreatedAt` fields now store full ISO timestamps (e.g. `2026-02-22T16:34:35.123Z`) instead of date-only strings, enabling proper chronological sorting of records created on the same day

## Test plan
- [ ] Create an order with a past delivery date and don't mark it delivered — verify it appears in the Overdue widget
- [ ] Assign the order to a staff member — verify it appears in their My Todos as overdue
- [ ] Mark it delivered — verify it disappears from both widgets
- [ ] Create multiple records (accounts, orders, todos, etc.) and verify they sort correctly by creation time

🤖 Generated with [Claude Code](https://claude.com/claude-code)