### PR TITLE
Show previous return notes in keg return modal

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1039,7 +1039,8 @@ function openReturnKegs(kegId, productName, format, totalQty, alreadyReturned, e
     });
     modal.close();
     toast(`${returnQty} keg${returnQty > 1 ? 's' : ''} marked as returned`);
-    loadAccountProfile(state.accountProfileId);
+    if (state.view === 'account-profile') loadAccountProfile(state.accountProfileId);
+    else loadKegs();
   });
 }
 


### PR DESCRIPTION
## Summary
- When opening "Return Kegs" on a partially returned record, existing notes from prior returns are now displayed in a styled box in the modal
- New notes are appended to existing notes with a ` | ` separator, preserving the full return history
- Notes are passed from both call sites (account profile keg table and kegs list page)

## Test plan
- [x] Open Return Kegs modal on a keg record with no prior notes — no "Previous notes" box should appear
- [x] Return kegs with a note, then open Return Kegs again on the same record — "Previous notes" box should show the prior note
- [x] Add another note on a subsequent return — both notes should be preserved, separated by ` | `
- [x] Verify modal works from both the account profile keg table and the kegs list page

🤖 Generated with [Claude Code](https://claude.com/claude-code)