### PR TITLE
Fix browser back/forward button navigation

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -211,6 +211,9 @@ function renderAccounts() {
 async function loadAccountProfile(accountId) {
   state.view = 'account-profile';
   state.accountProfileId = accountId;
+  // Update hash for back/forward navigation and deep-linking
+  const profileHash = '#account/' + encodeURIComponent(accountId);
+  if (window.location.hash !== profileHash) window.location.hash = profileHash;
   // Keep 'accounts' nav item highlighted
   document.querySelectorAll('.nav-item').forEach(el => {
     el.classList.toggle('active', el.dataset.view === 'accounts');

--- a/public/js/init.js
+++ b/public/js/init.js
@@ -18,12 +18,29 @@ function navigate(view, filters = {}) {
   document.querySelectorAll('.nav-item').forEach(el => {
     el.classList.toggle('active', el.dataset.view === view);
   });
-  window.location.hash = view;
+  const newHash = '#' + view;
+  if (window.location.hash !== newHash) window.location.hash = view;
   const loader = VIEW_LOADERS[view];
   if (loader) loader().catch(err => {
     toast(err.message, 'error');
     setContent(`<div class="empty-state text-danger" style="padding:40px">Error: ${esc(err.message)}</div>`);
   });
+}
+
+function handleHashChange() {
+  const raw = window.location.hash.replace('#', '');
+  // Account profile: #account/<id>
+  const acctMatch = raw.match(/^account\/(.+)$/);
+  if (acctMatch) {
+    const id = decodeURIComponent(acctMatch[1]);
+    if (state.view === 'account-profile' && state.accountProfileId === id) return;
+    loadAccountProfile(id);
+    return;
+  }
+  // Main views
+  const view = VIEW_LOADERS[raw] ? raw : 'dashboard';
+  if (state.view === view) return;
+  navigate(view);
 }
 
 // ── Location ──────────────────────────────────────────────────────
@@ -141,9 +158,17 @@ async function init() {
     document.getElementById('sidebar-status-text').textContent = 'Offline';
   }
 
+  // Handle browser back/forward navigation
+  window.addEventListener('hashchange', handleHashChange);
+
   // Load view from hash or default to dashboard
   const hash = window.location.hash.replace('#', '');
-  navigate(VIEW_LOADERS[hash] ? hash : 'dashboard');
+  const acctMatch = hash.match(/^account\/(.+)$/);
+  if (acctMatch) {
+    loadAccountProfile(decodeURIComponent(acctMatch[1]));
+  } else {
+    navigate(VIEW_LOADERS[hash] ? hash : 'dashboard');
+  }
 }
 
 document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- Added a `hashchange` event listener so the browser back and forward buttons correctly re-render the active view
- Account profiles now update the URL hash to `#account/<id>`, making them part of browser history and enabling deep-linking (bookmarkable profile URLs)
- Guard clauses prevent redundant re-renders when the view is already current
- Initial page load now supports `#account/<id>` hashes for deep-linking

Closes #83

## Test plan
- [x] Navigate between views (Dashboard → Orders → Inventory) then click browser Back — verify each previous view loads correctly
- [x] Click browser Forward after going Back — verify it navigates forward properly
- [x] Click into an account profile, then click Back — verify it returns to the accounts list
- [x] From an account profile, click a nav item, then Back — verify it returns to the profile
- [x] Copy a `#account/<id>` URL and open in a new tab — verify the profile loads directly
- [x] Verify nav sidebar highlights correctly through all back/forward transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)