### PR TITLE
Fix submenu flash on initial page load

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -45,7 +45,7 @@
           <a class="nav-item" data-view="inventory" href="#inventory">
             <span class="nav-icon">&#9632;</span> Inventory
           </a>
-          <div class="nav-group open" data-group="accounts">
+          <div class="nav-group" data-group="accounts">
             <a class="nav-item has-submenu" data-view="accounts" href="#accounts">
               <span class="nav-icon">&#9632;</span> Accounts
               <span class="nav-arrow">&#9656;</span>


### PR DESCRIPTION
## Summary
- Removed hardcoded `open` class from the `.nav-group` element in HTML
- Submenus now start closed (`max-height: 0`) and JavaScript opens the correct one based on the active view during navigation
- Previously the Accounts submenu rendered fully expanded then animated closed on every page load, causing a visible flash

Fixes #106

## Test plan
- [ ] Load the app on the dashboard — no submenu flash visible
- [ ] Navigate to Accounts — submenu opens smoothly
- [ ] Navigate to Map — Accounts submenu stays open
- [ ] Navigate away from Accounts views — submenu closes smoothly
- [ ] Reload the page on `#accounts` — submenu opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)