### PR TITLE
Include timestamp in OrderDate for same-day sorting

### DIFF
--- a/public/js/core.js
+++ b/public/js/core.js
@@ -110,9 +110,14 @@ function truncateNote(text, limit = 100) {
   return `<span class="note-text"><span id="${id}_short">${esc(text.substring(0, limit))}… <a href="#" class="note-toggle" onclick="event.preventDefault();document.getElementById('${id}_short').style.display='none';document.getElementById('${id}_full').style.display='inline'">more</a></span><span id="${id}_full" style="display:none">${safe} <a href="#" class="note-toggle" onclick="event.preventDefault();document.getElementById('${id}_full').style.display='none';document.getElementById('${id}_short').style.display='inline'">less</a></span></span>`;
 }
 
+function dateOnly(d) {
+  return d ? d.substring(0, 10) : '';
+}
+
 function formatDate(d) {
   if (!d) return '—';
-  const [y, m, day] = d.split('-');
+  const ds = dateOnly(d);
+  const [y, m, day] = ds.split('-');
   if (!y || !m || !day) return d;
   return `${m}/${day}/${y}`;
 }

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -33,7 +33,7 @@ function orderForm(order = {}, presetAccountId = '') {
     <div class="form-row">
       <div class="form-group">
         <label>Order Date <span class="required">*</span></label>
-        <input class="form-control" id="f-order-date" type="date" value="${esc(order.OrderDate || today())}" />
+        <input class="form-control" id="f-order-date" type="date" value="${esc(dateOnly(order.OrderDate) || today())}" />
       </div>
       <div class="form-group">
         <label>Delivery Date</label>
@@ -302,8 +302,8 @@ function renderOrders() {
   if (accountFilter) filtered = filtered.filter(s => s.AccountID === accountFilter);
   if (staffFilter)   filtered = filtered.filter(s => s.StaffID === staffFilter);
   if (statusFilter)  filtered = filtered.filter(s => s.Status === statusFilter);
-  if (dateFrom) filtered = filtered.filter(s => (s.OrderDate || '') >= dateFrom);
-  if (dateTo)   filtered = filtered.filter(s => (s.OrderDate || '') <= dateTo);
+  if (dateFrom) filtered = filtered.filter(s => dateOnly(s.OrderDate) >= dateFrom);
+  if (dateTo)   filtered = filtered.filter(s => dateOnly(s.OrderDate) <= dateTo);
   if (search) {
     const q = search.toLowerCase();
     filtered = filtered.filter(s =>

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -6,6 +6,14 @@ const { getAllRows, addRow, updateRow, deleteRow } = require('../sheets');
 
 const router = express.Router();
 
+// Append current time to a date-only string so same-day orders sort by creation time.
+// "2026-02-23" → "2026-02-23T14:30:05.123Z"; already-timestamped values pass through.
+function withTimestamp(dateStr) {
+  if (!dateStr) return dateStr;
+  if (dateStr.includes('T')) return dateStr; // already has time
+  return dateStr + 'T' + new Date().toISOString().split('T')[1];
+}
+
 router.get('/', async (req, res) => {
   try {
     const { accountId, staffId, location } = req.query;
@@ -39,7 +47,7 @@ router.post('/', async (req, res) => {
       Location:    Location || '',
       StaffID:     StaffID || '',
       StaffName:   StaffName || '',
-      OrderDate,
+      OrderDate: withTimestamp(OrderDate),
       DeliveryDate: DeliveryDate || '',
       InvoiceNumber: InvoiceNumber || '',
       OrderAmount: OrderAmount || '0',
@@ -71,6 +79,7 @@ router.put('/:id', async (req, res) => {
     const updates = { ...req.body };
     delete updates.ID;
     delete updates.CreatedAt;
+    if (updates.OrderDate) updates.OrderDate = withTimestamp(updates.OrderDate);
     const updated = await updateRow('ORDERS', req.params.id, updates);
     res.json(updated);
   } catch (err) {

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -117,9 +117,11 @@ router.post('/zapier/order', requireWebhookSecret, async (req, res) => {
       resolvedAccountName = match.Name;
     }
 
-    // Date defaults
-    const today     = new Date().toISOString().split('T')[0];
-    const orderDate = f.orderDate || today;
+    // Date defaults — include timestamp so same-day orders sort by creation time
+    const now       = new Date().toISOString();
+    const today     = now.split('T')[0];
+    const rawDate   = f.orderDate || today;
+    const orderDate = rawDate.includes('T') ? rawDate : rawDate + 'T' + now.split('T')[1];
 
     // Status validation
     let status = f.status || 'Pending';


### PR DESCRIPTION
## Summary
- OrderDate now stores full ISO timestamps (e.g. `2026-02-23T14:30:05.123Z`) instead of date-only strings
- Same-day orders now sort by creation time instead of appearing in arbitrary order
- Backend `withTimestamp()` helper appends current time to date-only values; already-timestamped values pass through
- Frontend `dateOnly()` helper strips time for `<input type="date">` fields and date range filtering
- `formatDate()` gracefully handles timestamps by extracting just the date portion
- Webhook route also includes timestamps

Fixes #110

## Test plan
- [ ] Create multiple orders on the same day — they sort newest-first
- [ ] Edit an existing order's date — timestamp preserved
- [ ] Date range filters work correctly (today, last 7 days, custom range)
- [ ] Order form pre-fills date correctly when editing
- [ ] Pre-sale conversion pre-fills today's date correctly
- [ ] Dashboard monthly orders filter still works
- [ ] Existing date-only orders continue to display and sort correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)