### PR TITLE
Add Individual account type for keg tracking

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ACCOUNT_TYPES = ['Bar', 'Restaurant', 'Retail Store', 'Grocery Store', 'Hotel', 'Event Venue', 'Other'];
+const ACCOUNT_TYPES = ['Bar', 'Restaurant', 'Retail Store', 'Grocery Store', 'Hotel', 'Event Venue', 'Individual', 'Other'];
 const CONTACT_METHODS = ['Email', 'Phone', 'SMS', 'In-Person', 'Any'];
 const ACCOUNT_STATUSES = ['Active', 'Prospect', 'Inactive'];
 


### PR DESCRIPTION
## Summary
- Added **Individual** to the account types dropdown, placed before "Other"
- Enables tracking keg purchases by individuals (e.g. someone buying a keg for home use) using the existing account and keg tracking system

Closes #77

## Test plan
- [ ] Create a new account — verify "Individual" appears in the Type dropdown
- [ ] Filter accounts by type — verify "Individual" appears in the filter dropdown
- [ ] Create an Individual account and add keg tracking records to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)