### PR TITLE
Migrate data layer from Google Sheets to SQLite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,16 +3,14 @@
 # ============================================================
 # Copy this file to .env and fill in your values.
 
-# Google Sheets Spreadsheet ID
-# Found in the URL: https://docs.google.com/spreadsheets/d/[SPREADSHEET_ID]/edit
-SPREADSHEET_ID=your_spreadsheet_id_here
+# ── Database ──────────────────────────────────────────────────────
+# Path to the SQLite database file (optional, defaults to ./data/brewery.db)
+# DB_PATH=./data/brewery.db
 
-# Google Service Account Authentication
-# Option 1: Path to your service account JSON key file (relative to project root)
-GOOGLE_KEY_FILE=credentials.json
-
-# Option 2: Inline JSON credentials (useful for cloud/production deployments)
-# GOOGLE_SERVICE_ACCOUNT_KEY={"type":"service_account","project_id":"...","private_key_id":"...","private_key":"-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----\n","client_email":"your-sa@your-project.iam.gserviceaccount.com","client_id":"...","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token"}
+# ── Legacy Google Sheets (only needed for migrate-to-sqlite.js) ──
+# SPREADSHEET_ID=your_spreadsheet_id_here
+# GOOGLE_KEY_FILE=credentials.json
+# GOOGLE_SERVICE_ACCOUNT_KEY=...
 
 # Server port (optional, defaults to 3000)
 PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 .env
 credentials.json
 *.log
+data/*.db
+data/*.db-*

--- a/migrate-to-sqlite.js
+++ b/migrate-to-sqlite.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * One-time migration: Google Sheets → SQLite
+ *
+ * Usage:  node migrate-to-sqlite.js
+ *
+ * Prerequisites:
+ *   - .env must still have SPREADSHEET_ID and Google credentials configured
+ *   - npm install must have been run (needs googleapis + better-sqlite3)
+ *
+ * This script:
+ *   1. Connects to Google Sheets using the original sheets module
+ *   2. Reads all rows from every table
+ *   3. Creates the SQLite database and tables
+ *   4. Inserts all rows into SQLite
+ *   5. Prints a summary
+ *
+ * Safe to re-run — uses INSERT OR REPLACE so existing rows are overwritten.
+ */
+
+require('dotenv').config();
+
+const Database = require('better-sqlite3');
+const path     = require('path');
+const fs       = require('fs');
+
+// Import from the original Google Sheets module.
+// Try sheets.js.bak first (if already renamed), then fall back to sheets.js.
+let sheetsModule;
+try {
+  sheetsModule = require('./sheets.js.bak');
+} catch (_) {
+  sheetsModule = require('./sheets');
+}
+const { initializeSheets: initSheets, getAllRows: getSheetsRows, SHEETS, HEADERS } = sheetsModule;
+
+const DB_PATH = process.env.DB_PATH || path.join(__dirname, 'data', 'brewery.db');
+
+async function migrate() {
+  console.log('=== Google Sheets → SQLite Migration ===\n');
+
+  // ── Step 1: Connect to Google Sheets ─────────────────────────────
+  console.log('Connecting to Google Sheets...');
+  await initSheets();
+  console.log('Connected.\n');
+
+  // ── Step 2: Read all data ────────────────────────────────────────
+  console.log('Reading data from Google Sheets...');
+  const allData = {};
+  for (const key of Object.keys(SHEETS)) {
+    const rows = await getSheetsRows(key);
+    allData[key] = rows;
+    console.log(`  ${SHEETS[key]}: ${rows.length} rows`);
+  }
+
+  const totalRows = Object.values(allData).reduce((sum, rows) => sum + rows.length, 0);
+  console.log(`\nTotal: ${totalRows} rows across ${Object.keys(SHEETS).length} tables.\n`);
+
+  // ── Step 3: Create SQLite database ───────────────────────────────
+  const dir = path.dirname(DB_PATH);
+  fs.mkdirSync(dir, { recursive: true });
+
+  // Back up existing DB file if present
+  if (fs.existsSync(DB_PATH)) {
+    const backup = DB_PATH + '.bak.' + Date.now();
+    fs.copyFileSync(DB_PATH, backup);
+    console.log(`Backed up existing DB to ${path.basename(backup)}`);
+  }
+
+  const db = new Database(DB_PATH);
+  db.pragma('journal_mode = WAL');
+
+  // ── Step 4: Create tables and insert data ────────────────────────
+  console.log('Creating SQLite tables and inserting data...');
+
+  for (const [key, tableName] of Object.entries(SHEETS)) {
+    const columns = HEADERS[key];
+
+    // Create table
+    const colDefs = columns.map(col =>
+      col === 'ID'
+        ? '"ID" TEXT PRIMARY KEY'
+        : `"${col}" TEXT DEFAULT ''`
+    ).join(', ');
+    db.exec(`CREATE TABLE IF NOT EXISTS "${tableName}" (${colDefs})`);
+
+    // Insert rows using a transaction for performance
+    const rows = allData[key];
+    if (rows.length > 0) {
+      const colNames     = columns.map(c => `"${c}"`).join(', ');
+      const placeholders = columns.map(() => '?').join(', ');
+      const insert = db.prepare(
+        `INSERT OR REPLACE INTO "${tableName}" (${colNames}) VALUES (${placeholders})`
+      );
+
+      const insertMany = db.transaction((rows) => {
+        for (const row of rows) {
+          const values = columns.map(col => row[col] != null ? String(row[col]) : '');
+          insert.run(...values);
+        }
+      });
+
+      insertMany(rows);
+      console.log(`  ${tableName}: ${rows.length} rows inserted`);
+    } else {
+      console.log(`  ${tableName}: empty (table created)`);
+    }
+  }
+
+  db.close();
+
+  // ── Done ─────────────────────────────────────────────────────────
+  console.log(`\nMigration complete! Database: ${DB_PATH}`);
+  console.log(`\nNext steps:`);
+  console.log(`  1. mv sheets.js sheets.js.bak`);
+  console.log(`  2. mv db.js sheets.js`);
+  console.log(`  3. Restart the server`);
+}
+
+migrate().catch(err => {
+  console.error('\nMigration failed:', err.message);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "brewery-distro",
       "version": "1.0.0",
       "dependencies": {
+        "better-sqlite3": "^12.6.2",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-session": "^1.19.0",
@@ -101,6 +102,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
+      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -121,6 +136,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -171,6 +206,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -242,6 +301,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -287,6 +352,30 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -304,6 +393,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dotenv": {
@@ -356,6 +454,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -399,6 +506,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -476,6 +592,12 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -524,6 +646,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -615,6 +743,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
@@ -812,6 +946,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
@@ -823,6 +977,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -991,6 +1151,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
@@ -1007,10 +1179,31 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -1020,6 +1213,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-fetch": {
@@ -1145,6 +1350,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1236,6 +1450,33 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1255,6 +1496,16 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/qs": {
       "version": "6.14.2",
@@ -1304,6 +1555,35 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1347,7 +1627,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1479,6 +1758,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -1501,6 +1825,24 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -1512,6 +1854,34 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/to-regex-range": {
@@ -1551,6 +1921,18 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -1605,6 +1987,12 @@
       "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
       "license": "BSD"
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1651,6 +2039,12 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "nodemon server.js"
   },
   "dependencies": {
+    "better-sqlite3": "^12.6.2",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-session": "^1.19.0",

--- a/server.js
+++ b/server.js
@@ -77,8 +77,8 @@ app.use('/api/tap-handles',     requireAuth, tapHandlesRoutes);
 // Status endpoint (public – used by the frontend before auth).
 app.get('/api/status', (req, res) => {
   res.json({
-    configured:    !!(process.env.SPREADSHEET_ID && (process.env.GOOGLE_KEY_FILE || process.env.GOOGLE_SERVICE_ACCOUNT_KEY)),
-    spreadsheetId: process.env.SPREADSHEET_ID || null,
+    configured: true,
+    dataSource: 'sqlite',
   });
 });
 
@@ -93,10 +93,10 @@ app.get('*', requireAuth, (req, res) => {
 // ── Server startup ─────────────────────────────────────────────────────────
 async function start() {
   try {
-    console.log('Connecting to Google Sheets...');
+    console.log('Initializing database...');
     await initializeSheets();
     await migrateInventoryToProducts();
-    console.log('Google Sheets initialized successfully.');
+    console.log('Database initialized successfully.');
     app.listen(PORT, () => {
       console.log(`Brewery Distribution app running at http://localhost:${PORT}`);
     });

--- a/sheets.js
+++ b/sheets.js
@@ -1,9 +1,13 @@
 'use strict';
 
-const { google } = require('googleapis');
+const Database = require('better-sqlite3');
+const path     = require('path');
+const fs       = require('fs');
 require('dotenv').config();
 
-const SPREADSHEET_ID = process.env.SPREADSHEET_ID;
+const DB_PATH = process.env.DB_PATH || path.join(__dirname, 'data', 'brewery.db');
+
+// ── Sheet / table definitions ─────────────────────────────────────────
 
 const SHEETS = {
   PRODUCTS:        'Products',
@@ -19,8 +23,8 @@ const SHEETS = {
   TAP_HANDLES:     'TapHandles',
 };
 
-// HEADERS defines every column each sheet should have.
-// On startup, any missing columns are automatically appended (migration-safe).
+// HEADERS defines every column each table should have.
+// On startup, any missing columns are automatically added (migration-safe).
 const HEADERS = {
   PRODUCTS:  ['ID', 'Name', 'Style', 'ABV', 'Format', 'PricePerUnit', 'Notes', 'CreatedAt'],
   INVENTORY: ['ID', 'Name', 'Location', 'Style', 'ABV', 'Format', 'Units', 'PricePerUnit', 'LowStockThreshold', 'Notes', 'LastUpdated', 'ProductID', 'ProductName'],
@@ -35,231 +39,129 @@ const HEADERS = {
   TAP_HANDLES:     ['ID', 'AccountID', 'AccountName', 'Quantity', 'DeployedDate', 'CollectedDate', 'CollectedQuantity', 'Notes', 'CreatedAt'],
 };
 
-// Cached sheet header rows — avoids an extra API call on every write
-const headerCache = {};
+// ── Database connection ───────────────────────────────────────────────
 
-// Cached numeric sheet IDs needed for row deletion batchUpdate
-const sheetIdCache = {};
+let _db;
 
-// Convert 0-based column index to spreadsheet letter (0→A, 25→Z, 26→AA…)
-function indexToCol(i) {
-  let col = '';
-  let n = i + 1;
-  while (n > 0) {
-    const r = (n - 1) % 26;
-    col = String.fromCharCode(65 + r) + col;
-    n = Math.floor((n - 1) / 26);
+function getDb() {
+  if (!_db) {
+    const dir = path.dirname(DB_PATH);
+    fs.mkdirSync(dir, { recursive: true });
+    _db = new Database(DB_PATH);
+    _db.pragma('journal_mode = WAL');
+    _db.pragma('foreign_keys = OFF');
   }
-  return col;
+  return _db;
 }
 
-async function getSheetHeaders(sheetName, forceRefresh = false) {
-  if (!forceRefresh && headerCache[sheetName]) return headerCache[sheetName];
-  const client = await getClient();
-  const res = await client.spreadsheets.values.get({
-    spreadsheetId: SPREADSHEET_ID,
-    range: `${sheetName}!A1:1`,
-  });
-  const headers = (res.data.values || [[]])[0] || [];
-  headerCache[sheetName] = headers;
-  return headers;
-}
+// ── Initialization ────────────────────────────────────────────────────
 
-async function getAuth() {
-  if (process.env.GOOGLE_SERVICE_ACCOUNT_KEY) {
-    const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_KEY);
-    return new google.auth.GoogleAuth({
-      credentials,
-      scopes: ['https://www.googleapis.com/auth/spreadsheets'],
-    });
-  }
-  return new google.auth.GoogleAuth({
-    keyFile: process.env.GOOGLE_KEY_FILE || 'credentials.json',
-    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
-  });
-}
+function initializeSheets() {
+  const db = getDb();
 
-async function getClient() {
-  const auth = await getAuth();
-  return google.sheets({ version: 'v4', auth });
-}
+  for (const [key, tableName] of Object.entries(SHEETS)) {
+    const columns = HEADERS[key];
 
-async function getSpreadsheetSheets() {
-  const client = await getClient();
-  const res = await client.spreadsheets.get({ spreadsheetId: SPREADSHEET_ID });
-  for (const sheet of res.data.sheets) {
-    sheetIdCache[sheet.properties.title] = sheet.properties.sheetId;
-  }
-  return res.data.sheets.map(s => s.properties.title);
-}
+    // Build column definitions — all TEXT, ID is PRIMARY KEY
+    const colDefs = columns.map(col =>
+      col === 'ID'
+        ? '"ID" TEXT PRIMARY KEY'
+        : `"${col}" TEXT DEFAULT ''`
+    ).join(', ');
 
-async function initializeSheets() {
-  if (!SPREADSHEET_ID) {
-    throw new Error('SPREADSHEET_ID is not set in environment variables.');
-  }
+    db.exec(`CREATE TABLE IF NOT EXISTS "${tableName}" (${colDefs})`);
 
-  const client = await getClient();
-  const existingSheets = await getSpreadsheetSheets();
-  const toCreate = Object.values(SHEETS).filter(name => !existingSheets.includes(name));
-
-  if (toCreate.length > 0) {
-    await client.spreadsheets.batchUpdate({
-      spreadsheetId: SPREADSHEET_ID,
-      requestBody: {
-        requests: toCreate.map(title => ({ addSheet: { properties: { title } } })),
-      },
-    });
-    // Refresh cache after creating new sheets
-    await getSpreadsheetSheets();
-  }
-
-  // Write or migrate headers for every sheet
-  for (const [key, sheetName] of Object.entries(SHEETS)) {
-    const existing = await getSheetHeaders(sheetName, true);
-    const expected = HEADERS[key];
-
-    if (existing.length === 0) {
-      // Brand-new or empty sheet — write full header row
-      await client.spreadsheets.values.update({
-        spreadsheetId: SPREADSHEET_ID,
-        range: `${sheetName}!A1`,
-        valueInputOption: 'RAW',
-        requestBody: { values: [expected] },
-      });
-      headerCache[sheetName] = expected;
-    } else {
-      // Existing sheet — append any new columns that aren't present yet
-      const missing = expected.filter(h => !existing.includes(h));
-      if (missing.length > 0) {
-        const startCol = indexToCol(existing.length);
-        await client.spreadsheets.values.update({
-          spreadsheetId: SPREADSHEET_ID,
-          range: `${sheetName}!${startCol}1`,
-          valueInputOption: 'RAW',
-          requestBody: { values: [missing] },
-        });
-        headerCache[sheetName] = [...existing, ...missing];
-        console.log(`  Migrated ${sheetName}: added columns [${missing.join(', ')}]`);
+    // Migration-safe: add any new columns that don't exist yet
+    const existingCols = db.pragma(`table_info("${tableName}")`).map(c => c.name);
+    for (const col of columns) {
+      if (!existingCols.includes(col)) {
+        db.exec(`ALTER TABLE "${tableName}" ADD COLUMN "${col}" TEXT DEFAULT ''`);
+        console.log(`  Migrated ${tableName}: added column ${col}`);
       }
     }
   }
 }
 
-async function getRawRows(sheetName) {
-  const client = await getClient();
-  const res = await client.spreadsheets.values.get({
-    spreadsheetId: SPREADSHEET_ID,
-    range: `${sheetName}!A:Z`,
+// ── CRUD operations ───────────────────────────────────────────────────
+
+function getAllRows(sheetKey) {
+  const db = getDb();
+  const tableName = SHEETS[sheetKey];
+  const columns = HEADERS[sheetKey];
+
+  const rows = db.prepare(`SELECT * FROM "${tableName}"`).all();
+
+  // Convert all values to strings to match previous Google Sheets behavior
+  return rows.map(row => {
+    const obj = {};
+    for (const col of columns) {
+      obj[col] = row[col] != null ? String(row[col]) : '';
+    }
+    return obj;
   });
-  return res.data.values || [];
 }
 
-function rowsToObjects(rows) {
-  if (!rows || rows.length < 2) return [];
-  const headers = rows[0];
-  return rows.slice(1)
-    .filter(row => row.some(cell => cell !== '' && cell !== undefined))
-    .map(row => {
-      const obj = {};
-      headers.forEach((h, i) => {
-        obj[h] = row[i] !== undefined ? String(row[i]) : '';
-      });
-      return obj;
-    });
-}
+function addRow(sheetKey, data) {
+  const db = getDb();
+  const tableName = SHEETS[sheetKey];
+  const columns = HEADERS[sheetKey];
 
-function objectToRow(obj, headers) {
-  return headers.map(h => (obj[h] !== undefined && obj[h] !== null) ? String(obj[h]) : '');
-}
+  const presentCols = columns.filter(col => data[col] != null);
+  const colNames    = presentCols.map(c => `"${c}"`).join(', ');
+  const placeholders = presentCols.map(() => '?').join(', ');
+  const values       = presentCols.map(col => String(data[col]));
 
-async function getAllRows(sheetKey) {
-  const rows = await getRawRows(SHEETS[sheetKey]);
-  return rowsToObjects(rows);
-}
-
-async function addRow(sheetKey, data) {
-  const client = await getClient();
-  const sheetName = SHEETS[sheetKey];
-  // Always use the actual sheet header order so columns align correctly
-  const headers = await getSheetHeaders(sheetName);
-  const row = headers.map(h => (data[h] != null) ? String(data[h]) : '');
-
-  await client.spreadsheets.values.append({
-    spreadsheetId: SPREADSHEET_ID,
-    range: `${sheetName}!A:A`,
-    valueInputOption: 'RAW',
-    insertDataOption: 'INSERT_ROWS',
-    requestBody: { values: [row] },
-  });
+  db.prepare(`INSERT INTO "${tableName}" (${colNames}) VALUES (${placeholders})`).run(...values);
 
   return data;
 }
 
-async function updateRow(sheetKey, id, updates) {
-  const client = await getClient();
-  const sheetName = SHEETS[sheetKey];
-  const rows = await getRawRows(sheetName);
+function updateRow(sheetKey, id, updates) {
+  const db = getDb();
+  const tableName = SHEETS[sheetKey];
+  const columns = HEADERS[sheetKey];
 
-  if (rows.length < 2) throw new Error('Record not found');
+  // Fetch existing row
+  const existing = db.prepare(`SELECT * FROM "${tableName}" WHERE "ID" = ?`).get(id);
+  if (!existing) throw new Error(`Record with ID ${id} not found`);
 
-  // Use the sheet's own first row as the authoritative column order
-  const sheetHeaders = rows[0];
-  const dataIndex = rows.findIndex((row, i) => i > 0 && row[0] === id);
-  if (dataIndex === -1) throw new Error(`Record with ID ${id} not found`);
+  // Merge updates into existing (all values as strings)
+  const merged = {};
+  for (const col of columns) {
+    merged[col] = existing[col] != null ? String(existing[col]) : '';
+  }
+  for (const [key, val] of Object.entries(updates)) {
+    if (columns.includes(key)) {
+      merged[key] = val != null ? String(val) : '';
+    }
+  }
 
-  const existing = {};
-  sheetHeaders.forEach((h, i) => { existing[h] = rows[dataIndex][i] || ''; });
-  const updated = { ...existing, ...updates };
-  const newRow = sheetHeaders.map(h => (updated[h] != null) ? String(updated[h]) : '');
+  // Build SET clause for all non-ID columns
+  const setCols   = columns.filter(c => c !== 'ID');
+  const setClause = setCols.map(c => `"${c}" = ?`).join(', ');
+  const setValues = setCols.map(c => merged[c]);
 
-  const sheetRow = dataIndex + 1; // 1-indexed sheet row
-  await client.spreadsheets.values.update({
-    spreadsheetId: SPREADSHEET_ID,
-    range: `${sheetName}!A${sheetRow}`,
-    valueInputOption: 'RAW',
-    requestBody: { values: [newRow] },
-  });
+  db.prepare(`UPDATE "${tableName}" SET ${setClause} WHERE "ID" = ?`).run(...setValues, id);
 
-  return updated;
+  return merged;
 }
 
-async function deleteRow(sheetKey, id) {
-  const client = await getClient();
-  const sheetName = SHEETS[sheetKey];
-  const rows = await getRawRows(sheetName);
+function deleteRow(sheetKey, id) {
+  const db = getDb();
+  const tableName = SHEETS[sheetKey];
 
-  const dataIndex = rows.findIndex((row, i) => i > 0 && row[0] === id);
-  if (dataIndex === -1) throw new Error(`Record with ID ${id} not found`);
+  const existing = db.prepare(`SELECT "ID" FROM "${tableName}" WHERE "ID" = ?`).get(id);
+  if (!existing) throw new Error(`Record with ID ${id} not found`);
 
-  // Get numeric sheet ID from cache or fetch it
-  if (!sheetIdCache[sheetName]) {
-    await getSpreadsheetSheets();
-  }
-  const sheetId = sheetIdCache[sheetName];
-
-  await client.spreadsheets.batchUpdate({
-    spreadsheetId: SPREADSHEET_ID,
-    requestBody: {
-      requests: [{
-        deleteDimension: {
-          range: {
-            sheetId,
-            dimension: 'ROWS',
-            startIndex: dataIndex,     // 0-indexed
-            endIndex: dataIndex + 1,
-          },
-        },
-      }],
-    },
-  });
-
+  db.prepare(`DELETE FROM "${tableName}" WHERE "ID" = ?`).run(id);
   return true;
 }
 
-// One-time migration: split old INVENTORY rows into PRODUCTS + per-location inventory
-async function migrateInventoryToProducts() {
+// ── Inventory → Products migration (one-time, idempotent) ─────────────
+
+function migrateInventoryToProducts() {
   const { v4: uuidv4 } = require('uuid');
-  const inventoryRows = await getAllRows('INVENTORY');
+  const inventoryRows = getAllRows('INVENTORY');
   if (inventoryRows.length === 0) return;
 
   // Detect old format: has Style data but no ProductID
@@ -289,7 +191,7 @@ async function migrateInventoryToProducts() {
 
   // Write products
   for (const product of productMap.values()) {
-    await addRow('PRODUCTS', product);
+    addRow('PRODUCTS', product);
   }
   console.log(`  Created ${productMap.size} products`);
 
@@ -299,7 +201,7 @@ async function migrateInventoryToProducts() {
     const key = [row.Name || '', row.Style || '', row.ABV || '', row.Format || '', row.PricePerUnit || ''].join('|||');
     const product = productMap.get(key);
     if (product) {
-      await updateRow('INVENTORY', row.ID, {
+      updateRow('INVENTORY', row.ID, {
         ProductID: product.ID,
         ProductName: product.Name,
       });

--- a/sheets.js.bak
+++ b/sheets.js.bak
@@ -1,0 +1,311 @@
+'use strict';
+
+const { google } = require('googleapis');
+require('dotenv').config();
+
+const SPREADSHEET_ID = process.env.SPREADSHEET_ID;
+
+const SHEETS = {
+  PRODUCTS:        'Products',
+  INVENTORY:       'Inventory',
+  ACCOUNTS:        'Accounts',
+  OUTREACH:        'Outreach',
+  REMINDERS:       'Reminders',
+  STAFF:           'Staff',
+  ORDERS:          'Orders',
+  STOCK_MOVEMENTS: 'StockMovements',
+  SETTINGS:        'Settings',
+  KEG_TRACKING:    'KegTracking',
+  TAP_HANDLES:     'TapHandles',
+};
+
+// HEADERS defines every column each sheet should have.
+// On startup, any missing columns are automatically appended (migration-safe).
+const HEADERS = {
+  PRODUCTS:  ['ID', 'Name', 'Style', 'ABV', 'Format', 'PricePerUnit', 'Notes', 'CreatedAt'],
+  INVENTORY: ['ID', 'Name', 'Location', 'Style', 'ABV', 'Format', 'Units', 'PricePerUnit', 'LowStockThreshold', 'Notes', 'LastUpdated', 'ProductID', 'ProductName'],
+  ACCOUNTS:  ['ID', 'Name', 'Type', 'ContactName', 'Email', 'Phone', 'PreferredMethod', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'CreatedAt'],
+  OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
+  REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
+  STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt'],
+  ORDERS:          ['ID', 'AccountID', 'AccountName', 'Location', 'StaffID', 'StaffName', 'OrderDate', 'DeliveryDate', 'InvoiceNumber', 'OrderAmount', 'TaxAmount', 'Notes', 'RequestedProducts', 'Status', 'Delivered', 'CreatedAt'],
+  STOCK_MOVEMENTS: ['ID', 'InventoryID', 'InventoryName', 'OrderID', 'Type', 'Quantity', 'Notes', 'Date', 'CreatedAt'],
+  SETTINGS:        ['ID', 'Key', 'Value', 'UpdatedAt'],
+  KEG_TRACKING:    ['ID', 'AccountID', 'AccountName', 'OrderID', 'InventoryID', 'ProductName', 'Format', 'Quantity', 'DeliveredDate', 'ReturnedDate', 'ReturnedQuantity', 'Notes', 'CreatedAt'],
+  TAP_HANDLES:     ['ID', 'AccountID', 'AccountName', 'Quantity', 'DeployedDate', 'CollectedDate', 'CollectedQuantity', 'Notes', 'CreatedAt'],
+};
+
+// Cached sheet header rows — avoids an extra API call on every write
+const headerCache = {};
+
+// Cached numeric sheet IDs needed for row deletion batchUpdate
+const sheetIdCache = {};
+
+// Convert 0-based column index to spreadsheet letter (0→A, 25→Z, 26→AA…)
+function indexToCol(i) {
+  let col = '';
+  let n = i + 1;
+  while (n > 0) {
+    const r = (n - 1) % 26;
+    col = String.fromCharCode(65 + r) + col;
+    n = Math.floor((n - 1) / 26);
+  }
+  return col;
+}
+
+async function getSheetHeaders(sheetName, forceRefresh = false) {
+  if (!forceRefresh && headerCache[sheetName]) return headerCache[sheetName];
+  const client = await getClient();
+  const res = await client.spreadsheets.values.get({
+    spreadsheetId: SPREADSHEET_ID,
+    range: `${sheetName}!A1:1`,
+  });
+  const headers = (res.data.values || [[]])[0] || [];
+  headerCache[sheetName] = headers;
+  return headers;
+}
+
+async function getAuth() {
+  if (process.env.GOOGLE_SERVICE_ACCOUNT_KEY) {
+    const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_KEY);
+    return new google.auth.GoogleAuth({
+      credentials,
+      scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+    });
+  }
+  return new google.auth.GoogleAuth({
+    keyFile: process.env.GOOGLE_KEY_FILE || 'credentials.json',
+    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+  });
+}
+
+async function getClient() {
+  const auth = await getAuth();
+  return google.sheets({ version: 'v4', auth });
+}
+
+async function getSpreadsheetSheets() {
+  const client = await getClient();
+  const res = await client.spreadsheets.get({ spreadsheetId: SPREADSHEET_ID });
+  for (const sheet of res.data.sheets) {
+    sheetIdCache[sheet.properties.title] = sheet.properties.sheetId;
+  }
+  return res.data.sheets.map(s => s.properties.title);
+}
+
+async function initializeSheets() {
+  if (!SPREADSHEET_ID) {
+    throw new Error('SPREADSHEET_ID is not set in environment variables.');
+  }
+
+  const client = await getClient();
+  const existingSheets = await getSpreadsheetSheets();
+  const toCreate = Object.values(SHEETS).filter(name => !existingSheets.includes(name));
+
+  if (toCreate.length > 0) {
+    await client.spreadsheets.batchUpdate({
+      spreadsheetId: SPREADSHEET_ID,
+      requestBody: {
+        requests: toCreate.map(title => ({ addSheet: { properties: { title } } })),
+      },
+    });
+    // Refresh cache after creating new sheets
+    await getSpreadsheetSheets();
+  }
+
+  // Write or migrate headers for every sheet
+  for (const [key, sheetName] of Object.entries(SHEETS)) {
+    const existing = await getSheetHeaders(sheetName, true);
+    const expected = HEADERS[key];
+
+    if (existing.length === 0) {
+      // Brand-new or empty sheet — write full header row
+      await client.spreadsheets.values.update({
+        spreadsheetId: SPREADSHEET_ID,
+        range: `${sheetName}!A1`,
+        valueInputOption: 'RAW',
+        requestBody: { values: [expected] },
+      });
+      headerCache[sheetName] = expected;
+    } else {
+      // Existing sheet — append any new columns that aren't present yet
+      const missing = expected.filter(h => !existing.includes(h));
+      if (missing.length > 0) {
+        const startCol = indexToCol(existing.length);
+        await client.spreadsheets.values.update({
+          spreadsheetId: SPREADSHEET_ID,
+          range: `${sheetName}!${startCol}1`,
+          valueInputOption: 'RAW',
+          requestBody: { values: [missing] },
+        });
+        headerCache[sheetName] = [...existing, ...missing];
+        console.log(`  Migrated ${sheetName}: added columns [${missing.join(', ')}]`);
+      }
+    }
+  }
+}
+
+async function getRawRows(sheetName) {
+  const client = await getClient();
+  const res = await client.spreadsheets.values.get({
+    spreadsheetId: SPREADSHEET_ID,
+    range: `${sheetName}!A:Z`,
+  });
+  return res.data.values || [];
+}
+
+function rowsToObjects(rows) {
+  if (!rows || rows.length < 2) return [];
+  const headers = rows[0];
+  return rows.slice(1)
+    .filter(row => row.some(cell => cell !== '' && cell !== undefined))
+    .map(row => {
+      const obj = {};
+      headers.forEach((h, i) => {
+        obj[h] = row[i] !== undefined ? String(row[i]) : '';
+      });
+      return obj;
+    });
+}
+
+function objectToRow(obj, headers) {
+  return headers.map(h => (obj[h] !== undefined && obj[h] !== null) ? String(obj[h]) : '');
+}
+
+async function getAllRows(sheetKey) {
+  const rows = await getRawRows(SHEETS[sheetKey]);
+  return rowsToObjects(rows);
+}
+
+async function addRow(sheetKey, data) {
+  const client = await getClient();
+  const sheetName = SHEETS[sheetKey];
+  // Always use the actual sheet header order so columns align correctly
+  const headers = await getSheetHeaders(sheetName);
+  const row = headers.map(h => (data[h] != null) ? String(data[h]) : '');
+
+  await client.spreadsheets.values.append({
+    spreadsheetId: SPREADSHEET_ID,
+    range: `${sheetName}!A:A`,
+    valueInputOption: 'RAW',
+    insertDataOption: 'INSERT_ROWS',
+    requestBody: { values: [row] },
+  });
+
+  return data;
+}
+
+async function updateRow(sheetKey, id, updates) {
+  const client = await getClient();
+  const sheetName = SHEETS[sheetKey];
+  const rows = await getRawRows(sheetName);
+
+  if (rows.length < 2) throw new Error('Record not found');
+
+  // Use the sheet's own first row as the authoritative column order
+  const sheetHeaders = rows[0];
+  const dataIndex = rows.findIndex((row, i) => i > 0 && row[0] === id);
+  if (dataIndex === -1) throw new Error(`Record with ID ${id} not found`);
+
+  const existing = {};
+  sheetHeaders.forEach((h, i) => { existing[h] = rows[dataIndex][i] || ''; });
+  const updated = { ...existing, ...updates };
+  const newRow = sheetHeaders.map(h => (updated[h] != null) ? String(updated[h]) : '');
+
+  const sheetRow = dataIndex + 1; // 1-indexed sheet row
+  await client.spreadsheets.values.update({
+    spreadsheetId: SPREADSHEET_ID,
+    range: `${sheetName}!A${sheetRow}`,
+    valueInputOption: 'RAW',
+    requestBody: { values: [newRow] },
+  });
+
+  return updated;
+}
+
+async function deleteRow(sheetKey, id) {
+  const client = await getClient();
+  const sheetName = SHEETS[sheetKey];
+  const rows = await getRawRows(sheetName);
+
+  const dataIndex = rows.findIndex((row, i) => i > 0 && row[0] === id);
+  if (dataIndex === -1) throw new Error(`Record with ID ${id} not found`);
+
+  // Get numeric sheet ID from cache or fetch it
+  if (!sheetIdCache[sheetName]) {
+    await getSpreadsheetSheets();
+  }
+  const sheetId = sheetIdCache[sheetName];
+
+  await client.spreadsheets.batchUpdate({
+    spreadsheetId: SPREADSHEET_ID,
+    requestBody: {
+      requests: [{
+        deleteDimension: {
+          range: {
+            sheetId,
+            dimension: 'ROWS',
+            startIndex: dataIndex,     // 0-indexed
+            endIndex: dataIndex + 1,
+          },
+        },
+      }],
+    },
+  });
+
+  return true;
+}
+
+// One-time migration: split old INVENTORY rows into PRODUCTS + per-location inventory
+async function migrateInventoryToProducts() {
+  const { v4: uuidv4 } = require('uuid');
+  const inventoryRows = await getAllRows('INVENTORY');
+  if (inventoryRows.length === 0) return;
+
+  // Detect old format: has Style data but no ProductID
+  const needsMigration = inventoryRows.some(r => r.Style && !r.ProductID);
+  if (!needsMigration) return;
+
+  console.log('Migrating INVENTORY to PRODUCTS + per-location inventory...');
+
+  // Extract unique products by compound key
+  const productMap = new Map();
+  for (const row of inventoryRows) {
+    if (row.ProductID) continue; // already migrated
+    const key = [row.Name || '', row.Style || '', row.ABV || '', row.Format || '', row.PricePerUnit || ''].join('|||');
+    if (!productMap.has(key)) {
+      productMap.set(key, {
+        ID: uuidv4(),
+        Name: row.Name || '',
+        Style: row.Style || '',
+        ABV: row.ABV || '',
+        Format: row.Format || '',
+        PricePerUnit: row.PricePerUnit || '',
+        Notes: row.Notes || '',
+        CreatedAt: new Date().toISOString(),
+      });
+    }
+  }
+
+  // Write products
+  for (const product of productMap.values()) {
+    await addRow('PRODUCTS', product);
+  }
+  console.log(`  Created ${productMap.size} products`);
+
+  // Update inventory rows with ProductID reference
+  for (const row of inventoryRows) {
+    if (row.ProductID) continue;
+    const key = [row.Name || '', row.Style || '', row.ABV || '', row.Format || '', row.PricePerUnit || ''].join('|||');
+    const product = productMap.get(key);
+    if (product) {
+      await updateRow('INVENTORY', row.ID, {
+        ProductID: product.ID,
+        ProductName: product.Name,
+      });
+    }
+  }
+  console.log('  Updated inventory rows with ProductID references');
+}
+
+module.exports = { initializeSheets, migrateInventoryToProducts, getAllRows, addRow, updateRow, deleteRow, SHEETS, HEADERS };


### PR DESCRIPTION
## Summary
- Replaces the Google Sheets API backend with a local SQLite database (`better-sqlite3`) for faster queries, no external dependencies, and no API rate limits
- New `sheets.js` maintains the exact same exports (`SHEETS`, `HEADERS`, `initializeSheets`, `getAllRows`, `addRow`, `updateRow`, `deleteRow`) — **zero changes to any route file or frontend code**
- Includes a one-time `migrate-to-sqlite.js` script to pull existing data from Google Sheets into SQLite
- Original Google Sheets implementation preserved as `sheets.js.bak` for the migration script

## Migration steps
1. Run `node migrate-to-sqlite.js` (requires original Google Sheets credentials in `.env`)
2. Restart the server — it now reads/writes from `data/brewery.db`

## Test plan
- [x] Fresh start: delete any existing `data/brewery.db`, start server, verify tables are created and app loads
- [x] CRUD on all entities: products, inventory, accounts, orders, staff, todos, outreach, keg tracking, tap handles
- [x] Delivery confirmation: stock movements created, inventory decremented
- [x] Settings page: locations save and persist across restarts
- [x] Dashboard loads with correct stats
- [x] Migration script: if Google Sheets credentials are available, run `node migrate-to-sqlite.js` and verify row counts match

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)