### PR TITLE
Fix sidebar submenu flash on page load

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -52,7 +52,7 @@
               <a class="nav-subitem" data-view="products" href="#products">Products</a>
             </div>
           </div>
-          <div class="nav-group open" data-group="accounts">
+          <div class="nav-group" data-group="accounts">
             <a class="nav-item has-submenu" data-view="accounts" href="#accounts">
               <span class="nav-icon">&#9632;</span> Accounts
               <span class="nav-arrow">&#9656;</span>


### PR DESCRIPTION
## Summary
- Fixes regression of #106 — sidebar accounts submenu briefly flashes open then collapses on every page load
- Removes hardcoded `open` class from the accounts nav-group in `index.html`
- JavaScript already handles opening the correct submenu based on the current view

## Test plan
- [ ] Hard-refresh the app — no submenu should flash on load
- [ ] Navigate to Accounts — the accounts submenu opens
- [ ] Navigate to Inventory — the inventory submenu opens, accounts closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)