### PR TITLE
Fix Google OAuth behind reverse proxy (DigitalOcean)

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,6 +29,11 @@ const emailRoutes          = require('./routes/email');
 const app  = express();
 const PORT = process.env.PORT || 3000;
 
+// Trust first proxy (DigitalOcean App Platform, Heroku, etc.)
+// Required so Express correctly sees HTTPS behind a load-balancer,
+// which in turn makes secure cookies and OAuth callback URLs work.
+app.set('trust proxy', 1);
+
 // ── Body parsing ──────────────────────────────────────────────────────────
 app.use(express.json());
 


### PR DESCRIPTION
## Summary
- Adds `app.set('trust proxy', 1)` so Express correctly detects HTTPS behind DigitalOcean App Platform's load balancer
- Without this, `secure: true` session cookies are never set and Passport constructs OAuth callback URLs with `http://` instead of `https://`, causing sign-in to fail

## Setup reminder
After deploying, ensure these environment variables are set in DigitalOcean:
- `GOOGLE_CALLBACK_URL` = `https://<your-domain>/auth/google/callback`
- `SESSION_SECRET` = a strong random string
- `NODE_ENV` = `production`

And in Google Cloud Console, add the same callback URL to **Authorised redirect URIs** under your OAuth 2.0 Client ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)