### PR TITLE
Add support for multiple email addresses on staff

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -31,7 +31,7 @@ async function loadDashboard() {
     }));
 
   // Identify current staff member by matching email
-  const currentStaff = staff.find(s => s.Email && s.Email === state.userEmail);
+  const currentStaff = staff.find(s => s.Email && s.Email.split(',').map(e => e.trim().toLowerCase()).includes((state.userEmail || '').toLowerCase()));
   const currentStaffId = currentStaff ? currentStaff.ID : null;
 
   // Split pending deliveries into overdue vs upcoming

--- a/public/js/staff.js
+++ b/public/js/staff.js
@@ -20,7 +20,7 @@ function staffForm(member = {}) {
     <div class="form-row">
       <div class="form-group">
         <label>Email</label>
-        <input class="form-control" id="f-email" type="email" value="${esc(member.Email)}" placeholder="alex@brewery.com" />
+        <input class="form-control" id="f-email" type="text" value="${esc(member.Email)}" placeholder="alex@brewery.com, alex@gmail.com" />
       </div>
       <div class="form-group">
         <label>Phone</label>


### PR DESCRIPTION
## Summary
- Staff email field now accepts multiple comma-separated email addresses (e.g. `alex@brewery.com, alex@gmail.com`)
- Changed input type from `email` to `text` so the browser doesn't reject comma-separated values
- Updated dashboard staff matching to check all emails when identifying the logged-in user for "My Todos"
- No database migration needed — existing single emails continue to work as-is

Fixes #121

## Test plan
- [x] Edit a staff member and enter two comma-separated emails — saves correctly
- [x] Dashboard "My Todos" works when logged in with either email address
- [x] Staff list table displays the comma-separated emails correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)