### PR TITLE
Add auto-deploy workflow on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy to DigitalOcean
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DROPLET_HOST }}
+          username: ${{ secrets.DROPLET_USER }}
+          key: ${{ secrets.DROPLET_SSH_KEY }}
+          script: |
+            cd ~/brewery-distro
+            git pull origin main
+            npm install --production
+            pm2 restart brewery-distro


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`.github/workflows/deploy.yml`) that auto-deploys to the DigitalOcean Droplet whenever changes are merged into `main`
- Uses SSH to connect, pull latest code, install dependencies, and restart PM2

## Setup required
Add these secrets in **GitHub repo → Settings → Secrets → Actions**:

| Secret | Value |
|---|---|
| `DROPLET_HOST` | Droplet IP address |
| `DROPLET_USER` | `brewery` |
| `DROPLET_SSH_KEY` | SSH private key (see below) |

### Generate the SSH key on the droplet:
```bash
su - brewery
ssh-keygen -t ed25519 -C "github-deploy" -f ~/.ssh/github_deploy -N ""
cat ~/.ssh/github_deploy.pub >> ~/.ssh/authorized_keys
chmod 600 ~/.ssh/authorized_keys
cat ~/.ssh/github_deploy   # copy this as DROPLET_SSH_KEY
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)