### PR TITLE
Support multiple domains in GOOGLE_ALLOWED_DOMAIN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,8 +40,9 @@ GOOGLE_CLIENT_SECRET=your_google_oauth_client_secret_here
 # For production set the full URL, e.g. https://app.yourdomain.com/auth/google/callback
 # GOOGLE_CALLBACK_URL=https://app.yourdomain.com/auth/google/callback
 
-# Restrict sign-in to a single Google Workspace domain (recommended).
-# Only users whose Google account belongs to this domain will be allowed in.
+# Restrict sign-in to one or more Google Workspace domains (recommended).
+# Only users whose Google account belongs to a listed domain will be allowed in.
+# Separate multiple domains with commas (e.g. yourcompany.com,sales.yourcompany.com).
 # Leave blank to allow any Google account (not recommended for internal tools).
 GOOGLE_ALLOWED_DOMAIN=yourcompany.com
 

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -8,7 +8,8 @@ const router = express.Router();
 
 // ── Passport configuration ─────────────────────────────────────────────────
 
-const ALLOWED_DOMAIN = process.env.GOOGLE_ALLOWED_DOMAIN || '';
+const ALLOWED_DOMAINS = (process.env.GOOGLE_ALLOWED_DOMAIN || '')
+  .split(',').map(d => d.trim().toLowerCase()).filter(Boolean);
 const oauthConfigured = !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET);
 
 if (oauthConfigured) {
@@ -17,17 +18,18 @@ if (oauthConfigured) {
       clientID:     process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
       callbackURL:  process.env.GOOGLE_CALLBACK_URL || '/auth/google/callback',
-      // hd restricts the Google sign-in picker to the workspace domain,
-      // but we also verify it server-side in the verify callback below.
-      hd: ALLOWED_DOMAIN || undefined,
+      // hd restricts the Google sign-in picker to the workspace domain.
+      // Only works with a single domain; when multiple are configured we
+      // omit it and rely on server-side verification below.
+      hd: ALLOWED_DOMAINS.length === 1 ? ALLOWED_DOMAINS[0] : undefined,
     },
     function verify(accessToken, refreshToken, profile, done) {
       // Enforce Google Workspace domain restriction.
-      if (ALLOWED_DOMAIN) {
-        const hostedDomain = profile._json && profile._json.hd;
-        if (hostedDomain !== ALLOWED_DOMAIN) {
+      if (ALLOWED_DOMAINS.length > 0) {
+        const hostedDomain = ((profile._json && profile._json.hd) || '').toLowerCase();
+        if (!ALLOWED_DOMAINS.includes(hostedDomain)) {
           return done(null, false, {
-            message: `Access restricted to @${ALLOWED_DOMAIN} accounts.`,
+            message: `Access restricted to @${ALLOWED_DOMAINS.join(', @')} accounts.`,
           });
         }
       }


### PR DESCRIPTION
## Summary
- `GOOGLE_ALLOWED_DOMAIN` now accepts comma-separated domains (e.g. `brewery.com,sales.brewery.com`)
- Users on any listed domain can log in; users on unlisted domains are still rejected
- When multiple domains are configured, the Google sign-in picker `hd` hint is omitted (it only supports one value) and domain validation is done entirely server-side
- Single-domain config continues to work exactly as before
- Updated `.env.example` documentation

Fixes #127

## Test plan
- [x] Single domain: `GOOGLE_ALLOWED_DOMAIN=brewery.com` — only `@brewery.com` users can log in
- [x] Multiple domains: `GOOGLE_ALLOWED_DOMAIN=brewery.com,sales.brewery.com` — users on either domain can log in
- [x] Unlisted domain user is still rejected with an error message
- [x] Empty/unset `GOOGLE_ALLOWED_DOMAIN` — any Google account can log in

🤖 Generated with [Claude Code](https://claude.com/claude-code)