### PR TITLE
Remove hardcoded Hutchinson/Mission location defaults

### DIFF
--- a/public/js/core.js
+++ b/public/js/core.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // ── State ────────────────────────────────────────────────────────
-let LOCATIONS = ['Hutchinson', 'Mission']; // Defaults; overwritten by settings on init
+let LOCATIONS = []; // Populated from settings on init
 
 const FORMATS = ['1/6 Keg', '1/4 Keg', '1/2 Keg', '12oz Can (case/24)', '16oz Can (case/24)', '22oz Bottle (case/12)', '750ml Bottle (case/12)', 'Other'];
 const STYLES  = ['IPA', 'Double IPA', 'Pale Ale', 'Lager', 'Pilsner', 'Wheat', 'Hefeweizen', 'Stout', 'Porter', 'Sour', 'Saison', 'Amber', 'Brown Ale', 'Barleywine', 'Scottish', 'English Mild', 'Kölsch', 'Golden Ale', 'Other'];

--- a/routes/products.js
+++ b/routes/products.js
@@ -37,7 +37,7 @@ router.post('/', async (req, res) => {
     // Read locations from settings
     const settings = await getAllRows('SETTINGS');
     const locRow = settings.find(s => s.Key === 'locations');
-    let locations = ['Hutchinson', 'Mission']; // defaults
+    let locations = []; // populated from settings
     if (locRow) {
       try { locations = JSON.parse(locRow.Value); } catch (e) { /* use defaults */ }
     }


### PR DESCRIPTION
## Summary
- Replaces hardcoded `["Hutchinson", "Mission"]` location defaults with empty arrays in two files
- Locations are loaded from the Settings table on init, so the hardcoded brewery-specific names were unnecessary
- A fresh install with no locations configured will simply show no locations until the user adds them via Settings

Fixes #125

## Test plan
- [x] App loads without errors with locations configured in Settings
- [x] Location switcher still works correctly
- [x] Creating a new product still auto-creates inventory rows at each configured location

🤖 Generated with [Claude Code](https://claude.com/claude-code)