### PR TITLE
Add account tags for multi-category grouping (fixes #75)

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -4,7 +4,14 @@ const ACCOUNT_TYPES = ['Bar', 'Restaurant', 'Retail Store', 'Grocery Store', 'Ho
 const CONTACT_METHODS = ['Email', 'Phone', 'SMS', 'In-Person', 'Any'];
 const ACCOUNT_STATUSES = ['Active', 'Prospect', 'Inactive'];
 
+function collectSelectedTags() {
+  const checkboxes = document.querySelectorAll('#f-tags input[type="checkbox"]:checked');
+  return JSON.stringify(Array.from(checkboxes).map(cb => cb.value));
+}
+
 function accountForm(acct = {}) {
+  let acctTags = [];
+  try { acctTags = JSON.parse(acct.Tags || '[]'); } catch (e) { acctTags = []; }
   return `
     ${acct.ID ? `<div class="form-group">
       <label>Account ID</label>
@@ -28,6 +35,15 @@ function accountForm(acct = {}) {
         </select>
       </div>
     </div>
+    ${ACCOUNT_TAGS.length > 0 ? `<div class="form-group">
+      <label>Tags</label>
+      <div id="f-tags" class="checkbox-group">
+        ${ACCOUNT_TAGS.map(t => {
+          const checked = acctTags.includes(t) ? 'checked' : '';
+          return '<label class="checkbox-label"><input type="checkbox" value="' + esc(t) + '" ' + checked + ' /> ' + esc(t) + '</label>';
+        }).join('')}
+      </div>
+    </div>` : ''}
     <div class="form-group">
       <label>Assigned Sales Rep</label>
       <select class="form-control" id="f-staff">
@@ -117,6 +133,7 @@ function renderAccounts() {
   state.navFilters = {};
   const typeFilter   = (document.getElementById('acct-type')   || {}).value ?? nav.type   ?? '';
   const statusFilter = (document.getElementById('acct-status') || {}).value ?? nav.status ?? '';
+  const tagFilter    = (document.getElementById('acct-tag')    || {}).value ?? nav.tag    ?? '';
   const search       = (document.getElementById('acct-search') || {}).value ?? nav.search ?? '';
 
   let filtered = accounts;
@@ -127,6 +144,13 @@ function renderAccounts() {
     filtered = filtered.filter(a => a.Status === statusFilter);
   } else {
     filtered = filtered.filter(a => a.Status !== 'Inactive');
+  }
+  if (tagFilter) {
+    filtered = filtered.filter(a => {
+      let tags = [];
+      try { tags = JSON.parse(a.Tags || '[]'); } catch (e) { tags = []; }
+      return tags.includes(tagFilter);
+    });
   }
   if (search) {
     const q = search.toLowerCase();
@@ -177,6 +201,10 @@ function renderAccounts() {
         <option value="">All (excl. Inactive)</option>
         ${ACCOUNT_STATUSES.map(s => `<option value="${s}" ${statusFilter === s ? 'selected' : ''}>${s}</option>`).join('')}
       </select>
+      ${ACCOUNT_TAGS.length > 0 ? `<select id="acct-tag" onchange="_paginationReset('accounts'); renderAccounts()">
+        <option value="">All Tags</option>
+        ${ACCOUNT_TAGS.map(t => '<option value="' + esc(t) + '"' + (tagFilter === t ? ' selected' : '') + '>' + esc(t) + '</option>').join('')}
+      </select>` : ''}
     </div>
     <div class="table-wrap">
       <table>
@@ -191,7 +219,7 @@ function renderAccounts() {
           ${pg.total === 0 ? `<tr><td colspan="${state.emailConfigured ? 9 : 8}" class="empty-state">No accounts found.</td></tr>` :
             pg.rows.map(a => `<tr>
               ${state.emailConfigured ? `<td><input type="checkbox" class="acct-select" data-account-id="${esc(a.ID)}" onchange="updateBulkEmailBar()" /></td>` : ''}
-              <td class="fw-600"><span class="td-link" onclick="loadAccountProfile('${esc(a.ID)}')">${esc(a.Name)}</span><br><span class="text-muted text-sm">${esc(a.City)}${a.City && (a.State || a.Zip) ? ', ' : ''}${esc(a.State)}${a.State && a.Zip ? ' ' : ''}${esc(a.Zip)}</span></td>
+              <td class="fw-600"><span class="td-link" onclick="loadAccountProfile('${esc(a.ID)}')">${esc(a.Name)}</span><br><span class="text-muted text-sm">${esc(a.City)}${a.City && (a.State || a.Zip) ? ', ' : ''}${esc(a.State)}${a.State && a.Zip ? ' ' : ''}${esc(a.Zip)}</span>${(() => { let t = []; try { t = JSON.parse(a.Tags || '[]'); } catch(e) {} return t.length > 0 ? '<div class="tag-badges">' + t.map(x => '<span class="badge badge-tag">' + esc(x) + '</span>').join(' ') + '</div>' : ''; })()}</td>
               <td>${esc(a.Type)}</td>
               <td>${esc(a.ContactName) || '—'}</td>
               <td>${methodBadge(a.PreferredMethod)}</td>
@@ -282,6 +310,7 @@ async function loadAccountProfile(accountId) {
     acct.PreferredMethod ? `<div class="profile-info-item"><span class="profile-info-label">Preferred</span><span>${methodBadge(acct.PreferredMethod)}</span></div>` : '',
     (acct.Address || acct.City) ? `<div class="profile-info-item"><span class="profile-info-label">Address</span><span>${esc(acct.Address || '')}${acct.Address && (acct.City || acct.State || acct.Zip) ? ', ' : ''}${[acct.City, (acct.State && acct.Zip ? acct.State + ' ' + acct.Zip : acct.State || acct.Zip)].filter(Boolean).map(esc).join(', ')}</span></div>` : '',
     acct.ABCLicense   ? `<div class="profile-info-item"><span class="profile-info-label">ABC License</span><span>${esc(acct.ABCLicense)}</span></div>` : '',
+    (() => { let tags = []; try { tags = JSON.parse(acct.Tags || '[]'); } catch (e) {} return tags.length > 0 ? `<div class="profile-info-item"><span class="profile-info-label">Tags</span><span class="tag-badges">${tags.map(t => '<span class="badge badge-tag">' + esc(t) + '</span>').join(' ')}</span></div>` : ''; })(),
     acct.StaffName    ? `<div class="profile-info-item"><span class="profile-info-label">Sales Rep</span><span>${esc(acct.StaffName)}</span></div>` : '',
     acct.LastContacted ? `<div class="profile-info-item"><span class="profile-info-label">Last Contact</span><span>${formatDate(acct.LastContacted)}</span></div>` : '',
     acct.Notes        ? `<div class="profile-info-item profile-info-full"><span class="profile-info-label">Notes</span><span>${esc(acct.Notes)}</span></div>` : '',
@@ -399,7 +428,7 @@ async function loadAccountProfile(accountId) {
         <button class="btn btn-ghost btn-sm" onclick="loadAccounts()">&#8592; Accounts</button>
         <div>
           <h2>${esc(acct.Name)}</h2>
-          <p class="subtitle">${esc(acct.Type)} &mdash; ${statusBadge(acct.Status)}</p>
+          <p class="subtitle">${esc(acct.Type)} &mdash; ${statusBadge(acct.Status)}${(() => { let tags = []; try { tags = JSON.parse(acct.Tags || '[]'); } catch(e) {} return tags.length > 0 ? ' &mdash; ' + tags.map(t => '<span class="badge badge-tag">' + esc(t) + '</span>').join(' ') : ''; })()}</p>
         </div>
       </div>
       <div class="view-header-actions">
@@ -651,7 +680,7 @@ function openAddAccount() {
     const staffId = val('f-staff');
     const staffName = staffId ? (state.staff.find(s => s.ID === staffId) || {}).Name || '' : '';
     await api.post('/api/accounts', {
-      Name: name, Type: val('f-type'), Status: val('f-status'),
+      Name: name, Type: val('f-type'), Tags: collectSelectedTags(), Status: val('f-status'),
       ContactName: val('f-contact'), PreferredMethod: val('f-method'),
       Email: val('f-email'), Phone: val('f-phone'),
       Address: val('f-address'), City: val('f-city'), State: val('f-state'), Zip: val('f-zip'),
@@ -673,7 +702,7 @@ function openEditAccount(id) {
     const staffId = val('f-staff');
     const staffName = staffId ? (state.staff.find(s => s.ID === staffId) || {}).Name || '' : '';
     await api.put(`/api/accounts/${id}`, {
-      Name: name, Type: val('f-type'), Status: val('f-status'),
+      Name: name, Type: val('f-type'), Tags: collectSelectedTags(), Status: val('f-status'),
       ContactName: val('f-contact'), PreferredMethod: val('f-method'),
       Email: val('f-email'), Phone: val('f-phone'),
       Address: val('f-address'), City: val('f-city'), State: val('f-state'), Zip: val('f-zip'),

--- a/public/js/core.js
+++ b/public/js/core.js
@@ -1,7 +1,8 @@
 'use strict';
 
 // ── State ────────────────────────────────────────────────────────
-let LOCATIONS = []; // Populated from settings on init
+let LOCATIONS = [];      // Populated from settings on init
+let ACCOUNT_TAGS = [];   // Populated from settings on init
 
 const FORMATS = ['1/6 Keg', '1/4 Keg', '1/2 Keg', '12oz Can (case/24)', '16oz Can (case/24)', '22oz Bottle (case/12)', '750ml Bottle (case/12)', 'Other'];
 const STYLES  = ['IPA', 'Double IPA', 'Pale Ale', 'Lager', 'Pilsner', 'Wheat', 'Hefeweizen', 'Stout', 'Porter', 'Sour', 'Saison', 'Amber', 'Brown Ale', 'Barleywine', 'Scottish', 'English Mild', 'Kölsch', 'Golden Ale', 'Other'];

--- a/public/js/init.js
+++ b/public/js/init.js
@@ -95,6 +95,9 @@ function applySettings(settings) {
     state.location = LOCATIONS[0];
     localStorage.setItem('brewLocation', state.location);
   }
+  if (Array.isArray(settings.accountTags) && settings.accountTags.length > 0) {
+    ACCOUNT_TAGS = settings.accountTags;
+  }
   if (settings.companyName) {
     const el = document.getElementById('brand-title');
     if (el) el.textContent = settings.companyName;

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -11,6 +11,7 @@ function renderSettings() {
   const s = state.settings;
   const companyName = s.companyName || '';
   const locations = Array.isArray(s.locations) ? s.locations : [...LOCATIONS];
+  const accountTags = Array.isArray(s.accountTags) ? s.accountTags : [];
 
   setContent(`
     <div class="view-header">
@@ -50,6 +51,31 @@ function renderSettings() {
                     <div class="settings-location-actions">
                       <button class="btn btn-ghost btn-sm" onclick="openRenameLocation(${i}, '${esc(loc)}')">Rename</button>
                       <button class="btn btn-ghost btn-sm text-danger" onclick="removeLocation(${i}, '${esc(loc)}')">Remove</button>
+                    </div>
+                  </li>`).join('')}
+              </ul>`
+          }
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <h3>Account Tags</h3>
+          <button class="btn btn-ghost btn-sm" onclick="openAddAccountTag()">+ Add Tag</button>
+        </div>
+        <div style="padding:0 18px 18px">
+          <p class="text-sm text-muted" style="margin-bottom:12px">
+            Categorize accounts by purchase behavior, territory, or other criteria. Tags can be assigned to accounts in the account form.
+          </p>
+          ${accountTags.length === 0
+            ? '<p class="empty-state">No tags configured.</p>'
+            : `<ul class="settings-location-list">
+                ${accountTags.map((t, i) => `
+                  <li class="settings-location-item">
+                    <span class="settings-location-name">${esc(t)}</span>
+                    <div class="settings-location-actions">
+                      <button class="btn btn-ghost btn-sm" onclick="openRenameAccountTag(${i}, '${esc(t)}')">Rename</button>
+                      <button class="btn btn-ghost btn-sm text-danger" onclick="removeAccountTag(${i}, '${esc(t)}')">Remove</button>
                     </div>
                   </li>`).join('')}
               </ul>`
@@ -131,6 +157,65 @@ function removeLocation(index, name) {
     }
     modal.close();
     toast('Location removed');
+    renderSettings();
+  });
+}
+
+// ── Account Tags ──────────────────────────────────────────────────
+
+function openAddAccountTag() {
+  modal.open('Add Account Tag', `
+    <div class="form-group">
+      <label>Tag Name <span class="required">*</span></label>
+      <input class="form-control" id="f-account-tag-name" placeholder='e.g. Kegs Only, Territory A' />
+    </div>
+  `, async () => {
+    const name = val('f-account-tag-name');
+    if (!name) { toast('Tag name is required', 'error'); return; }
+    const current = Array.isArray(state.settings.accountTags) ? [...state.settings.accountTags] : [];
+    if (current.includes(name)) { toast('Tag already exists', 'error'); return; }
+    current.push(name);
+    const updated = await api.put('/api/settings', { accountTags: current });
+    state.settings = updated;
+    applySettings(updated);
+    modal.close();
+    toast('Tag added');
+    renderSettings();
+  });
+}
+
+function openRenameAccountTag(index, oldName) {
+  modal.open('Rename Account Tag', `
+    <div class="form-group">
+      <label>New Name <span class="required">*</span></label>
+      <input class="form-control" id="f-account-tag-name" value="${esc(oldName)}" />
+    </div>
+    <p class="text-sm text-muted" style="margin-top:8px">All accounts with this tag will be updated.</p>
+  `, async () => {
+    const newName = val('f-account-tag-name');
+    if (!newName) { toast('Tag name is required', 'error'); return; }
+    const current = Array.isArray(state.settings.accountTags) ? [...state.settings.accountTags] : [];
+    if (current.includes(newName) && newName !== oldName) { toast('Tag already exists', 'error'); return; }
+    current[index] = newName;
+    const updated = await api.put('/api/settings/rename-account-tag', { oldName, newName, accountTags: current });
+    state.settings = updated;
+    applySettings(updated);
+    modal.close();
+    const info = updated._renamed || {};
+    toast(`Tag renamed — ${info.accountsUpdated || 0} account(s) updated`);
+    renderSettings();
+  });
+}
+
+function removeAccountTag(index, name) {
+  const current = Array.isArray(state.settings.accountTags) ? [...state.settings.accountTags] : [];
+  modal.confirm('Remove Tag', `Remove "${name}"? Existing accounts with this tag will not be affected.`, async () => {
+    current.splice(index, 1);
+    const updated = await api.put('/api/settings', { accountTags: current });
+    state.settings = updated;
+    applySettings(updated);
+    modal.close();
+    toast('Tag removed');
     renderSettings();
   });
 }

--- a/public/style.css
+++ b/public/style.css
@@ -687,6 +687,44 @@ tbody td {
 .badge-type-presale   { background: #e8eaf6; color: #283593; }
 .badge-type-other     { background: #eceff1; color: #455a64; }
 
+/* Account tag badges */
+.badge-tag {
+  background: #e8eaf6;
+  color: #283593;
+  text-transform: none;
+  font-size: 10px;
+  letter-spacing: 0;
+}
+
+.tag-badges {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  margin-top: 2px;
+}
+
+/* Checkbox group (multi-select for tags in forms) */
+.checkbox-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  padding: 8px 0;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.checkbox-label input[type="checkbox"] {
+  margin: 0;
+  cursor: pointer;
+}
+
 /* Staff active badges */
 .badge-staff-active   { background: var(--success-bg); color: var(--success-text); }
 .badge-staff-inactive { background: var(--neutral-bg); color: var(--neutral-text); }

--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -22,13 +22,14 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
   try {
-    const { Name, Type, ContactName, Email, Phone, PreferredMethod, Address, City, State, Zip, ABCLicense, Status, Notes, StaffID, StaffName } = req.body;
+    const { Name, Type, Tags, ContactName, Email, Phone, PreferredMethod, Address, City, State, Zip, ABCLicense, Status, Notes, StaffID, StaffName } = req.body;
     if (!Name) return res.status(400).json({ error: 'Account name is required' });
 
     const account = {
       ID: await getNextAccountId(),
       Name: Name.trim(),
       Type: Type || 'Bar',
+      Tags: Tags || '[]',
       ContactName: ContactName || '',
       Email: Email || '',
       Phone: Phone || '',

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -19,6 +19,10 @@ router.get('/', async (req, res) => {
       try { settings.locations = JSON.parse(settings.locations); }
       catch (e) { settings.locations = []; }
     }
+    if (settings.accountTags) {
+      try { settings.accountTags = JSON.parse(settings.accountTags); }
+      catch (e) { settings.accountTags = []; }
+    }
     res.json(settings);
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -55,6 +59,10 @@ router.put('/', async (req, res) => {
     if (result.locations) {
       try { result.locations = JSON.parse(result.locations); }
       catch (e) { result.locations = []; }
+    }
+    if (result.accountTags) {
+      try { result.accountTags = JSON.parse(result.accountTags); }
+      catch (e) { result.accountTags = []; }
     }
     res.json(result);
   } catch (err) {
@@ -108,7 +116,62 @@ router.put('/rename-location', async (req, res) => {
       try { result.locations = JSON.parse(result.locations); }
       catch (e) { result.locations = []; }
     }
+    if (result.accountTags) {
+      try { result.accountTags = JSON.parse(result.accountTags); }
+      catch (e) { result.accountTags = []; }
+    }
     result._renamed = { inventoryUpdated, ordersUpdated };
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// PUT /api/settings/rename-account-tag — renames a tag and updates all associated accounts
+router.put('/rename-account-tag', async (req, res) => {
+  try {
+    const { oldName, newName, accountTags } = req.body;
+    if (!oldName || !newName) return res.status(400).json({ error: 'oldName and newName are required' });
+
+    // Update the account tags list in settings
+    const settingsRows = await getAllRows('SETTINGS');
+    const existingByKey = {};
+    for (const row of settingsRows) existingByKey[row.Key] = row;
+    const tagsValue = JSON.stringify(accountTags);
+    const now = new Date().toISOString().split('T')[0];
+    if (existingByKey.accountTags) {
+      await updateRow('SETTINGS', existingByKey.accountTags.ID, { Value: tagsValue, UpdatedAt: now });
+    } else {
+      await addRow('SETTINGS', { ID: uuidv4(), Key: 'accountTags', Value: tagsValue, UpdatedAt: now });
+    }
+
+    // Update all account records that have the old tag
+    const accounts = await getAllRows('ACCOUNTS');
+    let accountsUpdated = 0;
+    for (const acct of accounts) {
+      let tags = [];
+      try { tags = JSON.parse(acct.Tags || '[]'); } catch (e) { tags = []; }
+      const idx = tags.indexOf(oldName);
+      if (idx !== -1) {
+        tags[idx] = newName;
+        await updateRow('ACCOUNTS', acct.ID, { Tags: JSON.stringify(tags) });
+        accountsUpdated++;
+      }
+    }
+
+    // Return updated settings
+    const updated = await getAllRows('SETTINGS');
+    const result = {};
+    for (const row of updated) result[row.Key] = row.Value;
+    if (result.locations) {
+      try { result.locations = JSON.parse(result.locations); }
+      catch (e) { result.locations = []; }
+    }
+    if (result.accountTags) {
+      try { result.accountTags = JSON.parse(result.accountTags); }
+      catch (e) { result.accountTags = []; }
+    }
+    result._renamed = { accountsUpdated };
     res.json(result);
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/sheets.js
+++ b/sheets.js
@@ -29,7 +29,7 @@ const SHEETS = {
 const HEADERS = {
   PRODUCTS:  ['ID', 'Name', 'Style', 'ABV', 'Format', 'PricePerUnit', 'Notes', 'CreatedAt'],
   INVENTORY: ['ID', 'Name', 'Location', 'Style', 'ABV', 'Format', 'Units', 'PricePerUnit', 'LowStockThreshold', 'Notes', 'LastUpdated', 'ProductID', 'ProductName'],
-  ACCOUNTS:  ['ID', 'Name', 'Type', 'ContactName', 'Email', 'Phone', 'PreferredMethod', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'CreatedAt'],
+  ACCOUNTS:  ['ID', 'Name', 'Type', 'Tags', 'ContactName', 'Email', 'Phone', 'PreferredMethod', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'CreatedAt'],
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
   REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
   STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt'],


### PR DESCRIPTION
## Summary
- Adds a **tagging system** for accounts — a secondary categorization alongside the existing Type field (Bar, Restaurant, etc. remain unchanged)
- Tags are configurable in **Settings** (add, rename, remove) and assigned via checkboxes in the account form
- Each account supports **multiple tags** (e.g. "Kegs Only" + "Territory A")
- Renaming a tag cascades the update to all accounts that have it
- The accounts list gains a **tag filter dropdown** and shows tag badges inline under account names
- Account profiles display tags in both the header subtitle and info section

## Changes (8 files)
- **`sheets.js`** — Add `Tags` column to ACCOUNTS table headers (auto-migrated on startup)
- **`routes/settings.js`** — Parse `accountTags` JSON in all responses; add `PUT /rename-account-tag` endpoint with cascade
- **`routes/accounts.js`** — Accept `Tags` field in account creation
- **`public/js/core.js`** — Add `ACCOUNT_TAGS` global variable
- **`public/js/init.js`** — Load `ACCOUNT_TAGS` from settings in `applySettings()`
- **`public/js/settings.js`** — Account Tags management card (add/rename/remove)
- **`public/js/accounts.js`** — Tag checkboxes in form, tag filter + badges in list, tags in profile view
- **`public/style.css`** — `.badge-tag`, `.tag-badges`, `.checkbox-group` styles

## Test plan
- [x] Open Settings → verify "Account Tags" card appears
- [x] Add tags (e.g. "Kegs Only", "Territory A") → verify they appear in the list
- [x] Rename a tag → verify all accounts with that tag are updated (toast shows count)
- [x] Remove a tag → verify it disappears from the settings list
- [x] Edit an account → verify tag checkboxes appear; check some tags and save
- [x] Reload page → verify tags persist on the account
- [x] Accounts list → verify tag filter dropdown appears; filtering by tag works
- [x] Accounts list → verify tag badges show under account names
- [x] Account profile → verify tags show in header subtitle and info section
- [x] Verify existing account Type field (Bar, Restaurant, etc.) is unchanged

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)