### PR TITLE
Show order line items regardless of stock status

### DIFF
--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -186,6 +186,9 @@ function productPickerHtml(items, quantities = {}) {
   }
   const inStock = items.filter(i => parseInt(i.Units || '0') > 0);
   const outOfStock = items.filter(i => parseInt(i.Units || '0') <= 0);
+  // Out-of-stock items that are already on this order should always be visible
+  const oosWithQty = outOfStock.filter(i => quantities[i.ID] > 0);
+  const oosHidden = outOfStock.filter(i => !quantities[i.ID]);
 
   const row = (item, hidden) => {
     const price = parseFloat(item.PricePerUnit || 0);
@@ -207,14 +210,15 @@ function productPickerHtml(items, quantities = {}) {
         <thead><tr><th>Product</th><th>Format</th><th>Price</th><th>In Stock</th><th>Qty</th></tr></thead>
         <tbody>
           ${inStock.map(i => row(i, false)).join('')}
-          ${outOfStock.map(i => row(i, true)).join('')}
+          ${oosWithQty.map(i => row(i, false)).join('')}
+          ${oosHidden.map(i => row(i, true)).join('')}
         </tbody>
       </table>
     </div>
-    ${outOfStock.length ? `<label style="cursor:pointer;font-size:0.85rem">
+    ${oosHidden.length ? `<label style="cursor:pointer;font-size:0.85rem">
       <input type="checkbox" id="op-show-oos" style="margin-right:6px"
         onchange="document.querySelectorAll('#order-products-wrap tr[data-product-stock=out]').forEach(r=>r.style.display=this.checked?'':'none')" />
-      Show out-of-stock products (${outOfStock.length})
+      Show out-of-stock products (${oosHidden.length})
     </label>` : ''}`;
 }
 


### PR DESCRIPTION
## Summary
- Out-of-stock products that already have a quantity on the current order are now always visible in the product picker when editing
- Only out-of-stock items with no existing quantity remain hidden behind the "Show out-of-stock" toggle
- The toggle count updates to only reflect truly hidden items

Fixes #141

## Test plan
- [x] Create an order with products, then set those products' stock to 0
- [x] Edit the order — the products should still be visible with their quantities
- [x] Verify the "Show out-of-stock" toggle only counts/controls items not already on the order

🤖 Generated with [Claude Code](https://claude.com/claude-code)