### PR TITLE
Disable product quantity editing on paid orders

### DIFF
--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -218,7 +218,7 @@ function productPickerHtml(items, quantities = {}, readOnly = false) {
         </tbody>
       </table>
     </div>
-    ${oosHidden.length ? `<label style="cursor:pointer;font-size:0.85rem">
+    ${!readOnly && oosHidden.length ? `<label style="cursor:pointer;font-size:0.85rem">
       <input type="checkbox" id="op-show-oos" style="margin-right:6px"
         onchange="document.querySelectorAll('#order-products-wrap tr[data-product-stock=out]').forEach(r=>r.style.display=this.checked?'':'none')" />
       Show out-of-stock products (${oosHidden.length})


### PR DESCRIPTION
## Summary
- Product quantities are now read-only when editing a paid order
- Unpaid orders (Pending, Cancelled, Pre-Sale) still allow editing quantities
- Read-only quantities display as plain text instead of input fields

Fixes #143

## Test plan
- [x] Edit a paid order — product quantities should be displayed as text, not editable inputs
- [x] Edit a pending order — product quantities should still be editable
- [x] Verify amount auto-recalc is skipped for paid orders

🤖 Generated with [Claude Code](https://claude.com/claude-code)