### PR TITLE
Store and display product format on order items

### DIFF
--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -293,6 +293,7 @@ function orderItemsReadOnlyHtml(orderItems) {
     const total = parseFloat(item.LineTotal || 0);
     return `<tr>
       <td class="fw-600">${esc(item.ProductName || '—')}</td>
+      <td class="text-sm">${esc(item.Format) || '—'}</td>
       <td class="text-sm">${qty}</td>
       <td class="text-sm">${price ? '$' + price.toFixed(2) : '—'}</td>
       <td class="text-sm">${total ? '$' + total.toFixed(2) : '—'}</td>
@@ -301,7 +302,7 @@ function orderItemsReadOnlyHtml(orderItems) {
   return `
     <div class="table-wrap" style="margin-bottom:8px">
       <table>
-        <thead><tr><th>Product</th><th>Qty</th><th>Unit Price</th><th>Total</th></tr></thead>
+        <thead><tr><th>Product</th><th>Format</th><th>Qty</th><th>Unit Price</th><th>Total</th></tr></thead>
         <tbody>${rows.join('')}</tbody>
       </table>
     </div>`;
@@ -352,6 +353,7 @@ function collectOrderItems() {
         items.push({
           InventoryID: item.ID,
           ProductName: item.Name,
+          Format: item.Format || '',
           Quantity: qty,
           UnitPrice: price.toFixed(2),
           LineTotal: (qty * price).toFixed(2),

--- a/routes/order-items.js
+++ b/routes/order-items.js
@@ -37,7 +37,7 @@ router.get('/counts', async (req, res) => {
 // POST /api/order-items — create a single item
 router.post('/', async (req, res) => {
   try {
-    const { OrderID, InventoryID, ProductName, Quantity, UnitPrice, LineTotal } = req.body;
+    const { OrderID, InventoryID, ProductName, Format, Quantity, UnitPrice, LineTotal } = req.body;
     if (!OrderID) return res.status(400).json({ error: 'OrderID is required' });
 
     const item = {
@@ -45,6 +45,7 @@ router.post('/', async (req, res) => {
       OrderID,
       InventoryID: InventoryID || '',
       ProductName: ProductName || '',
+      Format: Format || '',
       Quantity: Quantity || '0',
       UnitPrice: UnitPrice || '0',
       LineTotal: LineTotal || '0',
@@ -73,6 +74,7 @@ router.post('/bulk', async (req, res) => {
         OrderID: raw.OrderID || '',
         InventoryID: raw.InventoryID || '',
         ProductName: raw.ProductName || '',
+        Format: raw.Format || '',
         Quantity: String(raw.Quantity || '0'),
         UnitPrice: String(raw.UnitPrice || '0'),
         LineTotal: String(raw.LineTotal || '0'),

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -294,6 +294,7 @@ router.post('/import/confirm', async (req, res) => {
               OrderID: order.ID,
               InventoryID: inventoryId,
               ProductName: li.productName || '',
+              Format: li.format || '',
               Quantity: String(li.quantity || '0'),
               UnitPrice: String(li.unitPrice || '0'),
               LineTotal: String(li.lineTotal || '0'),

--- a/sheets.js
+++ b/sheets.js
@@ -40,7 +40,7 @@ const HEADERS = {
   KEG_TRACKING:    ['ID', 'AccountID', 'AccountName', 'OrderID', 'InventoryID', 'ProductName', 'Format', 'Quantity', 'DeliveredDate', 'ReturnedDate', 'ReturnedQuantity', 'Notes', 'CreatedAt'],
   TAP_HANDLES:     ['ID', 'AccountID', 'AccountName', 'Quantity', 'DeployedDate', 'CollectedDate', 'CollectedQuantity', 'Notes', 'CreatedAt'],
   EMAIL_LOG:       ['ID', 'SenderName', 'SenderEmail', 'Recipients', 'Subject', 'Body', 'Type', 'AccountIDs', 'Status', 'Error', 'CreatedAt'],
-  ORDER_ITEMS:     ['ID', 'OrderID', 'InventoryID', 'ProductName', 'Quantity', 'UnitPrice', 'LineTotal', 'CreatedAt'],
+  ORDER_ITEMS:     ['ID', 'OrderID', 'InventoryID', 'ProductName', 'Format', 'Quantity', 'UnitPrice', 'LineTotal', 'CreatedAt'],
 };
 
 // ── Database connection ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `Format` column to the `ORDER_ITEMS` table schema
- Save product format when creating order items during invoice import, manual order creation, and bulk creation
- Display the Format column in the read-only order items view for paid/imported orders

Previously, format info (e.g. "1/6 Keg", "16oz Case") was extracted from invoices and used for matching, but was never persisted in the order items table — so it couldn't be displayed when viewing orders.

Closes #156

## Test plan
- [ ] Import a PDF invoice — verify order items are created with correct Format values
- [ ] View a paid/imported order — Format column should appear in the products table
- [ ] Create a manual order with products — verify Format is saved to order items
- [ ] Existing orders without Format should show "—" gracefully in the Format column

🤖 Generated with [Claude Code](https://claude.com/claude-code)