### PR TITLE
Fix phone/email detected as account name in PDF import

### DIFF
--- a/lib/pdf-parser.js
+++ b/lib/pdf-parser.js
@@ -20,6 +20,8 @@ async function extractInvoiceData(pdfBuffer, accounts, inventory) {
     accountId: '',
     accountName: '',
     contactName: '',
+    phone: '',
+    email: '',
     accountMatch: 'none',
     abcLicense: extractABCLicense(text),
     orderAmount: '',
@@ -50,6 +52,17 @@ async function extractInvoiceData(pdfBuffer, accounts, inventory) {
     parsed.accountId = bestMatch.accountId;
     parsed.accountName = bestMatch.accountName;
     parsed.accountMatch = bestMatch.match;
+  }
+
+  // Extract phone and email from customer section
+  const contactInfo = extractContactInfo(text);
+  parsed.phone = contactInfo.phone;
+  parsed.email = contactInfo.email;
+
+  // If no account name was found, fall back to using the contact name
+  if (!parsed.accountName && parsed.contactName) {
+    parsed.accountName = parsed.contactName;
+    parsed.accountMatch = 'none';
   }
 
   // Extract line items
@@ -233,6 +246,9 @@ function extractAccountCandidates(text) {
   const lines = text.split('\n').map(l => l.trim()).filter(Boolean);
   // Strip ABC suffix: handles "- ABC #18833", "- ABC 01006032201", and ", ABC" (trailing, number on next line)
   const cleanABC = s => s.replace(/\s*[-,]\s*ABC\s*#?\s*:?\s*\d*.*$/i, '').trim();
+  // Detect phone numbers and email addresses — these should never be account names
+  const isPhone = s => /^[\s(]*\+?\d[\d\s().#*x\-]{6,}$/.test(s.trim());
+  const isEmail = s => /@/.test(s);
 
   // Strategy 1: Look for "Bill to:", "Sold to:", "Customer:", "Client:", "Ship to:" with inline value
   const inlinePatterns = [
@@ -242,7 +258,7 @@ function extractAccountCandidates(text) {
     const m = text.match(p);
     if (m) {
       const name = cleanABC(m[1].split(/\n/)[0].replace(/\s*(address|phone|email|fax|attn).*$/i, '').trim());
-      if (name) return [name];
+      if (name && !isPhone(name) && !isEmail(name)) return [name];
     }
   }
 
@@ -255,7 +271,8 @@ function extractAccountCandidates(text) {
       for (let j = 1; j <= 3 && i + j < lines.length; j++) {
         const line = lines[i + j];
         if (!line) continue;
-        if (/@/.test(line)) continue;                   // skip email
+        if (isEmail(line)) continue;                    // skip email
+        if (isPhone(line)) continue;                    // skip phone number
         // Skip address lines (start with digit AND contain street keywords) but not business names like "25 Steak and Social"
         if (/^\d/.test(line) && /\b(Ave|St|Blvd|Rd|Dr|Ln|Ct|Way|Hwy|Suite|Street|Avenue|Road|Drive|Lane|Highway|PO\s*Box)\b/i.test(line)) continue;
         // Skip city/state/zip lines like "Hutchinson, KS 67502"
@@ -279,10 +296,37 @@ function extractAccountCandidates(text) {
   const broadMatch = text.match(/customer[^\n]*\n\s*([^\n]+)/i);
   if (broadMatch) {
     const name = cleanABC(broadMatch[1].trim());
-    if (name && !/@/.test(name) && name.length > 1) return [name];
+    if (name && !isEmail(name) && !isPhone(name) && name.length > 1) return [name];
   }
 
   return [];
+}
+
+/**
+ * Extract phone and email from the customer section of the invoice.
+ * These are filtered out of account name candidates but should be
+ * captured as contact info for the account.
+ */
+function extractContactInfo(text) {
+  const result = { phone: '', email: '' };
+  const lines = text.split('\n').map(l => l.trim()).filter(Boolean);
+  const isPhone = s => /^[\s(]*\+?\d[\d\s().#*x\-]{6,}$/.test(s.trim());
+  for (let i = 0; i < lines.length; i++) {
+    if (/^customer/i.test(lines[i])) {
+      for (let j = 1; j <= 5 && i + j < lines.length; j++) {
+        const line = lines[i + j];
+        if (!result.email && /@/.test(line)) {
+          result.email = line.trim();
+        }
+        if (!result.phone && isPhone(line)) {
+          result.phone = line.trim();
+        }
+        if (/^(item|product|description|#|page\s|pdf\s|service|due|\$)/i.test(line)) break;
+      }
+      break;
+    }
+  }
+  return result;
 }
 
 function extractLineItems(lines) {

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -1119,6 +1119,16 @@ function renderImportPreview() {
           </div>
           <div class="form-row">
             <div class="form-group">
+              <label>Phone</label>
+              <input class="form-control form-control-sm" id="imp-phone-${idx}" value="${esc(p.phone)}" placeholder="Phone number" />
+            </div>
+            <div class="form-group">
+              <label>Email</label>
+              <input class="form-control form-control-sm" id="imp-email-${idx}" value="${esc(p.email)}" placeholder="Email address" />
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-group">
               <label>Invoice #</label>
               <input class="form-control form-control-sm" id="imp-inv-${idx}" value="${esc(p.invoiceNumber)}" />
             </div>
@@ -1229,6 +1239,8 @@ async function confirmImport() {
       AccountName: accountName,
       newAccountName: newAccountName || '',
       contactName: val(`imp-contact-${idx}`) || '',
+      phone: val(`imp-phone-${idx}`) || '',
+      email: val(`imp-email-${idx}`) || '',
       abcLicense: val(`imp-abc-${idx}`) || '',
       Location: state.location || '',
       OrderDate: val(`imp-date-${idx}`) || p.orderDate || today(),

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -197,9 +197,9 @@ router.post('/import/confirm', async (req, res) => {
               Type: 'Bar',
               Tags: '[]',
               ContactName: def.contactName || '',
-              Email: '',
+              Email: def.email || '',
               AdditionalEmails: '[]',
-              Phone: '',
+              Phone: def.phone || '',
               PreferredMethod: 'Email',
               Address: '',
               City: '',
@@ -222,13 +222,15 @@ router.post('/import/confirm', async (req, res) => {
         }
 
         // 0b. Update existing account with extracted fields if they're currently empty
-        if (def.AccountID && (def.abcLicense || def.contactName)) {
+        if (def.AccountID && (def.abcLicense || def.contactName || def.phone || def.email)) {
           const allAccounts = await getAllRows('ACCOUNTS');
           const acct = allAccounts.find(a => a.ID === def.AccountID);
           if (acct) {
             const updates = {};
             if (def.abcLicense && !acct.ABCLicense) updates.ABCLicense = def.abcLicense;
             if (def.contactName && !acct.ContactName) updates.ContactName = def.contactName;
+            if (def.phone && !acct.Phone) updates.Phone = def.phone;
+            if (def.email && !acct.Email) updates.Email = def.email;
             if (Object.keys(updates).length > 0) {
               await updateRow('ACCOUNTS', def.AccountID, updates);
             }


### PR DESCRIPTION
## Summary
- Filter phone numbers and email addresses from account name candidates during PDF invoice parsing
- Extract phone and email from the customer section and save as contact info on the account
- Fall back to contact name as account name when no business name is found
- Show phone/email fields in the import preview UI so users can review/edit before creating

When invoices had no business name in the customer section, phone numbers were being picked up as the account name. Now all 3 extraction strategies in `extractAccountCandidates()` filter out phone numbers and emails, a new `extractContactInfo()` function captures them separately, and they flow through the preview UI to the account record.

## Test plan
- [x] Import a PDF where the customer section has a phone number but no business name — phone should NOT become the account name; contact name should be used instead
- [x] Phone and email from the customer section should appear in the import preview form fields
- [x] After import with "Create New Account", the account should have Phone and Email populated
- [x] Existing accounts matched during import should get Phone/Email filled if currently empty
- [x] Normal invoices with business name + contact should continue working as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)