### PR TITLE
Preserve pagination when editing an account via modal (#173)

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -151,8 +151,8 @@ function sortAccounts(col) {
   renderAccounts();
 }
 
-async function loadAccounts() {
-  _paginationReset('accounts');
+async function loadAccounts(preservePage = false) {
+  if (!preservePage) _paginationReset('accounts');
   showLoading();
   const [accounts, staff] = await Promise.all([api.get('/api/accounts'), api.get('/api/staff')]);
   state.accounts = accounts;
@@ -810,7 +810,7 @@ function openEditAccount(id) {
     modal.close();
     toast('Account updated');
     if (state.view === 'account-profile') loadAccountProfile(state.accountProfileId);
-    else loadAccounts();
+    else loadAccounts(true);
   });
 }
 


### PR DESCRIPTION
Pass preservePage=true to loadAccounts() after a modal edit so the user stays on their current page instead of being reset to page 1.

https://claude.ai/code/session_01HZYXzPuSYTjeMqirqtjKjp