### PR TITLE
Add merge accounts feature

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -258,6 +258,7 @@ function renderAccounts() {
                 <button class="btn btn-ghost btn-sm" onclick="loadAccountProfile('${esc(a.ID)}')">View</button>
                 <button class="btn btn-ghost btn-sm" onclick="openLogOutreach('${esc(a.ID)}')">+ Log</button>
                 <button class="btn btn-ghost btn-sm" onclick="openEditAccount('${esc(a.ID)}')">Edit</button>
+                <button class="btn btn-ghost btn-sm" onclick="openMergeAccount('${esc(a.ID)}')">Merge</button>
                 <button class="btn btn-ghost btn-sm text-danger" data-name="${esc(a.Name)}" onclick="deleteAccount('${esc(a.ID)}', this.dataset.name)">Del</button>
               </td>
             </tr>`).join('')}
@@ -464,6 +465,7 @@ async function loadAccountProfile(accountId) {
         <button class="btn btn-ghost btn-sm" onclick="openAddTodo('${esc(accountId)}')">+ Add Todo</button>
         <button class="btn btn-ghost btn-sm" onclick="openAddOrder('${esc(accountId)}')">+ Log Order</button>
         ${state.emailConfigured && accountHasEmail(acct) ? `<button class="btn btn-secondary btn-sm" onclick="openEmailCompose('${esc(accountId)}')">Email</button>` : ''}
+        <button class="btn btn-ghost btn-sm" onclick="openMergeAccount('${esc(accountId)}')">Merge</button>
         <button class="btn btn-primary btn-sm" onclick="openEditAccount('${esc(accountId)}')">Edit Account</button>
       </div>
     </div>
@@ -921,4 +923,124 @@ function openBulkEmail() {
       toast('Failed to send email: ' + (err.message || 'Unknown error'), 'error');
     }
   }, 'Send');
+}
+
+// ── Merge Account ─────────────────────────────────────────────────
+
+async function openMergeAccount(targetId) {
+  if (state.accounts.length === 0) state.accounts = await api.get('/api/accounts');
+  const target = state.accounts.find(a => a.ID === targetId);
+  if (!target) { toast('Account not found', 'error'); return; }
+
+  const formHtml = `
+    <p class="text-sm" style="margin-bottom:16px">Merge another account into <strong>${esc(target.Name)}</strong>. All records from the selected account will be transferred here, and the selected account will be deleted.</p>
+    <div class="form-group">
+      <label>Search for account to merge in</label>
+      <div style="position:relative">
+        <input class="form-control" id="merge-search" placeholder="Type to search accounts..." autocomplete="off" />
+        <div id="merge-dropdown" style="position:absolute;top:100%;left:0;right:0;z-index:10;max-height:200px;overflow-y:auto;background:var(--bg-primary);border:1px solid var(--border);border-top:none;border-radius:0 0 8px 8px;display:none"></div>
+      </div>
+    </div>
+    <div id="merge-selected" style="display:none;margin-bottom:16px">
+      <div style="display:flex;align-items:center;gap:8px;padding:8px 12px;background:var(--bg-secondary);border-radius:6px">
+        <span id="merge-selected-name" class="fw-600"></span>
+        <a href="#" id="merge-clear" class="text-sm" style="margin-left:auto" onclick="event.preventDefault();clearMergeSelection()">Clear</a>
+      </div>
+    </div>
+    <div id="merge-preview" style="display:none;margin-bottom:8px">
+      <div style="padding:12px;background:#fff3e0;border-radius:6px;border:1px solid #ffe0b2">
+        <div class="fw-600 text-sm" style="margin-bottom:8px">Records that will be transferred:</div>
+        <div id="merge-preview-counts" class="text-sm"></div>
+        <div class="text-sm text-danger" style="margin-top:8px">The source account will be permanently deleted.</div>
+      </div>
+    </div>`;
+
+  let selectedSourceId = null;
+
+  modal.open('Merge Account', formHtml, async () => {
+    if (!selectedSourceId) { toast('Select an account to merge', 'error'); return; }
+
+    try {
+      const result = await api.post(`/api/accounts/${encodeURIComponent(targetId)}/merge`, { sourceAccountId: selectedSourceId });
+      modal.close();
+      const m = result.merged;
+      const parts = [];
+      if (m.outreach)  parts.push(`${m.outreach} outreach`);
+      if (m.reminders) parts.push(`${m.reminders} reminder${m.reminders !== 1 ? 's' : ''}`);
+      if (m.orders)    parts.push(`${m.orders} order${m.orders !== 1 ? 's' : ''}`);
+      if (m.kegs)      parts.push(`${m.kegs} keg record${m.kegs !== 1 ? 's' : ''}`);
+      if (m.tapHandles) parts.push(`${m.tapHandles} tap handle${m.tapHandles !== 1 ? 's' : ''}`);
+      if (m.emails)    parts.push(`${m.emails} email${m.emails !== 1 ? 's' : ''}`);
+      toast(parts.length > 0 ? 'Merged: ' + parts.join(', ') : 'Accounts merged successfully');
+      state.accounts = [];
+      if (state.view === 'account-profile') loadAccountProfile(targetId);
+      else loadAccounts();
+    } catch (err) {
+      toast('Merge failed: ' + (err.message || 'Unknown error'), 'error');
+    }
+  }, 'Merge Accounts');
+
+  // Style submit button as danger
+  document.getElementById('modal-submit-btn').className = 'btn btn-danger';
+
+  // Wire up search
+  const searchInput = document.getElementById('merge-search');
+  const dropdown = document.getElementById('merge-dropdown');
+
+  searchInput.addEventListener('input', () => {
+    const q = searchInput.value.toLowerCase().trim();
+    if (!q) { dropdown.style.display = 'none'; return; }
+    const matches = state.accounts
+      .filter(a => a.ID !== targetId && a.Name.toLowerCase().includes(q))
+      .slice(0, 20);
+    if (matches.length === 0) {
+      dropdown.innerHTML = '<div style="padding:8px 12px" class="text-muted text-sm">No matches</div>';
+    } else {
+      dropdown.innerHTML = matches.map(a =>
+        `<div class="merge-option" style="padding:8px 12px;cursor:pointer" onmouseover="this.style.background='var(--bg-secondary)'" onmouseout="this.style.background=''" data-id="${esc(a.ID)}">${esc(a.Name)} <span class="text-muted text-sm">${esc(a.City || '')}${a.City && a.State ? ', ' : ''}${esc(a.State || '')}</span></div>`
+      ).join('');
+    }
+    dropdown.style.display = 'block';
+  });
+
+  dropdown.addEventListener('click', async (e) => {
+    const opt = e.target.closest('.merge-option');
+    if (!opt) return;
+    const sourceId = opt.dataset.id;
+    const source = state.accounts.find(a => a.ID === sourceId);
+    if (!source) return;
+
+    selectedSourceId = sourceId;
+    searchInput.style.display = 'none';
+    dropdown.style.display = 'none';
+    document.getElementById('merge-selected').style.display = 'block';
+    document.getElementById('merge-selected-name').textContent = source.Name;
+
+    // Fetch preview
+    document.getElementById('merge-preview').style.display = 'block';
+    document.getElementById('merge-preview-counts').textContent = 'Loading...';
+    try {
+      const p = await api.get(`/api/accounts/${encodeURIComponent(targetId)}/merge-preview?sourceId=${encodeURIComponent(sourceId)}`);
+      const lines = [];
+      if (p.outreach)   lines.push(`${p.outreach} outreach entr${p.outreach === 1 ? 'y' : 'ies'}`);
+      if (p.reminders)  lines.push(`${p.reminders} reminder${p.reminders === 1 ? '' : 's'}`);
+      if (p.orders)     lines.push(`${p.orders} order${p.orders === 1 ? '' : 's'}`);
+      if (p.kegs)       lines.push(`${p.kegs} keg record${p.kegs === 1 ? '' : 's'}`);
+      if (p.tapHandles) lines.push(`${p.tapHandles} tap handle record${p.tapHandles === 1 ? '' : 's'}`);
+      if (p.emails)     lines.push(`${p.emails} email log${p.emails === 1 ? '' : 's'}`);
+      document.getElementById('merge-preview-counts').textContent = lines.length > 0 ? lines.join(', ') : 'No associated records (account metadata will still be merged)';
+    } catch (err) {
+      document.getElementById('merge-preview-counts').textContent = 'Failed to load preview';
+    }
+  });
+
+  // clearMergeSelection is global so the onclick can find it
+  window.clearMergeSelection = () => {
+    selectedSourceId = null;
+    searchInput.style.display = '';
+    searchInput.value = '';
+    dropdown.style.display = 'none';
+    document.getElementById('merge-selected').style.display = 'none';
+    document.getElementById('merge-preview').style.display = 'none';
+  };
 }

--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -118,4 +118,148 @@ router.delete('/:id', async (req, res) => {
   }
 });
 
+// ── Merge ─────────────────────────────────────────────────────────
+
+router.get('/:id/merge-preview', async (req, res) => {
+  try {
+    const sourceId = req.query.sourceId;
+    if (!sourceId) return res.status(400).json({ error: 'sourceId is required' });
+
+    const [outreach, reminders, orders, kegs, tapHandles, emailLog] = await Promise.all([
+      getAllRows('OUTREACH'),
+      getAllRows('REMINDERS'),
+      getAllRows('ORDERS'),
+      getAllRows('KEG_TRACKING'),
+      getAllRows('TAP_HANDLES'),
+      getAllRows('EMAIL_LOG'),
+    ]);
+
+    res.json({
+      outreach:   outreach.filter(r => r.AccountID === sourceId).length,
+      reminders:  reminders.filter(r => r.AccountID === sourceId).length,
+      orders:     orders.filter(r => r.AccountID === sourceId).length,
+      kegs:       kegs.filter(r => r.AccountID === sourceId).length,
+      tapHandles: tapHandles.filter(r => r.AccountID === sourceId).length,
+      emails:     emailLog.filter(r => (r.AccountIDs || '').split(',').map(s => s.trim()).includes(sourceId)).length,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/:id/merge', async (req, res) => {
+  try {
+    const targetId = req.params.id;
+    const { sourceAccountId } = req.body;
+    if (!sourceAccountId) return res.status(400).json({ error: 'sourceAccountId is required' });
+
+    const accounts = await getAllRows('ACCOUNTS');
+    const target = accounts.find(a => a.ID === targetId);
+    const source = accounts.find(a => a.ID === sourceAccountId);
+    if (!target) return res.status(404).json({ error: 'Target account not found' });
+    if (!source) return res.status(404).json({ error: 'Source account not found' });
+
+    const counts = { outreach: 0, reminders: 0, orders: 0, kegs: 0, tapHandles: 0, emails: 0 };
+
+    // Reassign OUTREACH
+    const outreach = await getAllRows('OUTREACH');
+    for (const r of outreach) {
+      if (r.AccountID === sourceAccountId) {
+        await updateRow('OUTREACH', r.ID, { AccountID: targetId, AccountName: target.Name });
+        counts.outreach++;
+      }
+    }
+
+    // Reassign REMINDERS
+    const reminders = await getAllRows('REMINDERS');
+    for (const r of reminders) {
+      if (r.AccountID === sourceAccountId) {
+        await updateRow('REMINDERS', r.ID, { AccountID: targetId, AccountName: target.Name });
+        counts.reminders++;
+      }
+    }
+
+    // Reassign ORDERS
+    const orders = await getAllRows('ORDERS');
+    for (const r of orders) {
+      if (r.AccountID === sourceAccountId) {
+        await updateRow('ORDERS', r.ID, { AccountID: targetId, AccountName: target.Name });
+        counts.orders++;
+      }
+    }
+
+    // Reassign KEG_TRACKING
+    const kegs = await getAllRows('KEG_TRACKING');
+    for (const r of kegs) {
+      if (r.AccountID === sourceAccountId) {
+        await updateRow('KEG_TRACKING', r.ID, { AccountID: targetId, AccountName: target.Name });
+        counts.kegs++;
+      }
+    }
+
+    // Reassign TAP_HANDLES
+    const tapHandles = await getAllRows('TAP_HANDLES');
+    for (const r of tapHandles) {
+      if (r.AccountID === sourceAccountId) {
+        await updateRow('TAP_HANDLES', r.ID, { AccountID: targetId, AccountName: target.Name });
+        counts.tapHandles++;
+      }
+    }
+
+    // Reassign EMAIL_LOG — replace sourceId with targetId in comma-separated AccountIDs
+    const emailLog = await getAllRows('EMAIL_LOG');
+    for (const r of emailLog) {
+      const ids = (r.AccountIDs || '').split(',').map(s => s.trim()).filter(Boolean);
+      if (ids.includes(sourceAccountId)) {
+        const updated = [...new Set(ids.map(id => id === sourceAccountId ? targetId : id))];
+        await updateRow('EMAIL_LOG', r.ID, { AccountIDs: updated.join(', ') });
+        counts.emails++;
+      }
+    }
+
+    // Merge account metadata onto target (fill empty fields only)
+    const updates = {};
+
+    const fillFields = ['ContactName', 'Email', 'Phone', 'Address', 'City', 'State', 'Zip', 'ABCLicense'];
+    for (const field of fillFields) {
+      if (!target[field] && source[field]) {
+        updates[field] = source[field];
+      }
+    }
+
+    // Tags — union
+    let targetTags = []; try { targetTags = JSON.parse(target.Tags || '[]'); } catch (e) { /* ignore */ }
+    let sourceTags = []; try { sourceTags = JSON.parse(source.Tags || '[]'); } catch (e) { /* ignore */ }
+    const mergedTags = [...new Set([...targetTags, ...sourceTags])];
+    updates.Tags = JSON.stringify(mergedTags);
+
+    // AdditionalEmails — union; include source's primary Email if different from target's
+    let targetExtra = []; try { targetExtra = JSON.parse(target.AdditionalEmails || '[]'); } catch (e) { /* ignore */ }
+    let sourceExtra = []; try { sourceExtra = JSON.parse(source.AdditionalEmails || '[]'); } catch (e) { /* ignore */ }
+    const allExtra = [...targetExtra, ...sourceExtra];
+    if (source.Email && source.Email !== target.Email) allExtra.push(source.Email);
+    updates.AdditionalEmails = JSON.stringify([...new Set(allExtra.filter(Boolean))]);
+
+    // Notes — append
+    if (source.Notes) {
+      const sep = target.Notes ? '\n---\nMerged from ' + source.Name + ':\n' : '';
+      updates.Notes = (target.Notes || '') + sep + source.Notes;
+    }
+
+    // LastContacted — use more recent
+    if (source.LastContacted && (!target.LastContacted || source.LastContacted > target.LastContacted)) {
+      updates.LastContacted = source.LastContacted;
+    }
+
+    await updateRow('ACCOUNTS', targetId, updates);
+
+    // Delete source account
+    await deleteRow('ACCOUNTS', sourceAccountId);
+
+    res.json({ success: true, merged: counts });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- Adds ability to merge duplicate accounts, consolidating all associated records (outreach, reminders, orders, kegs, tap handles, email logs) from a source account into a target account
- Intelligently merges account metadata: fills empty fields from source, unions tags and additional emails, appends notes with separator, keeps the more recent LastContacted date
- Accessible from both the accounts list table and account profile header via a new "Merge" button

## Test plan
- [x] Create two accounts, each with outreach logs, orders, kegs, tap handles, and reminders
- [x] Open one account's profile, click "Merge", search for the second account
- [x] Verify preview counts are correct before confirming
- [x] Click "Merge Accounts" and verify success toast with counts
- [x] Verify target account profile shows all combined records
- [x] Verify source account no longer appears in the accounts list
- [x] Verify merged metadata (tags combined, notes appended, empty fields filled)
- [x] Try merging an account with no related records — verify it works cleanly

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)