### PR TITLE
Make webhook endpoint generic — remove Zapier branding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,12 +11,10 @@
 PORT=3000
 
 # ── Webhooks ──────────────────────────────────────────────────────
-# Secret token that authorises incoming Zapier webhook calls.
+# Secret token that authorises incoming webhook calls.
 # Set this to a long random string (e.g. openssl rand -hex 32).
-# If left unset, the /webhooks/zapier/order endpoint returns 503.
-#
-# In Zapier:  Action → Webhooks by Zapier → POST
-#             Add header:  Authorization: Bearer <this value>
+# If left unset, the /webhooks/order endpoint returns 503.
+# Include as a Bearer token in the Authorization header.
 WEBHOOK_SECRET=your_webhook_secret_here
 
 # ── Google OAuth (Login / Authentication) ─────────────────────────

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A web app for managing self-distribution operations for a small microbrewery. Tr
 - **Staff** — Manage sales reps with assignment to accounts and orders.
 - **Multi-Location** — Configure multiple warehouse/taproom locations. Inventory, orders, and the dashboard filter by location.
 - **Map** — Visual map of account locations.
-- **Zapier Webhook** — Accept incoming orders from external systems (POS, accounting) via a webhook endpoint.
+- **Webhooks** — Accept incoming orders from external systems (POS, accounting, Zapier, Make, n8n, etc.) via a webhook endpoint.
 
 ## Setup
 
@@ -51,7 +51,7 @@ PORT=3000                          # Server port (default: 3000)
 DB_PATH=./data/brewery.db         # SQLite database path (default: ./data/brewery.db)
 GOOGLE_ALLOWED_DOMAIN=company.com  # Restrict login to a Google Workspace domain
 GOOGLE_CALLBACK_URL=https://...    # Full OAuth callback URL for production
-WEBHOOK_SECRET=a_long_random_string  # Enables the Zapier webhook endpoint
+WEBHOOK_SECRET=a_long_random_string  # Enables the webhook endpoint
 ```
 
 ### 3. Install and run
@@ -82,11 +82,11 @@ npm run dev   # uses nodemon for auto-reload
 | `DB_PATH` | No | Path to SQLite database file (default: `./data/brewery.db`) |
 | `GOOGLE_ALLOWED_DOMAIN` | No | Restrict sign-in to a single Google Workspace domain |
 | `GOOGLE_CALLBACK_URL` | No | Full OAuth callback URL for production deployments |
-| `WEBHOOK_SECRET` | No | Bearer token for authenticating Zapier webhook calls |
+| `WEBHOOK_SECRET` | No | Bearer token for authenticating webhook calls |
 
-## Zapier webhook
+## Webhooks
 
-When `WEBHOOK_SECRET` is set, the app exposes a `POST /webhooks/zapier/order` endpoint that accepts orders from external systems. Include the secret as a Bearer token in the Authorization header.
+When `WEBHOOK_SECRET` is set, the app exposes a `POST /webhooks/order` endpoint that accepts orders from external systems. Include the secret as a Bearer token in the Authorization header.
 
 The endpoint accepts flexible field names to accommodate different source systems:
 

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -1,16 +1,14 @@
 'use strict';
 
 /**
- * Zapier Webhook — Order Creation
+ * Webhook — Order Creation
  *
- * Endpoint:  POST /webhooks/zapier/order
+ * Endpoint:  POST /webhooks/order
  * Auth:      Authorization: Bearer <WEBHOOK_SECRET>
  *
- * Zapier setup:
- *   Action:  Webhooks by Zapier → POST
- *   URL:     https://<your-domain>/webhooks/zapier/order
- *   Headers: Authorization: Bearer <your WEBHOOK_SECRET value>
- *   Payload format: JSON (data below)
+ * Send a JSON POST request with the WEBHOOK_SECRET as a Bearer token
+ * in the Authorization header. Works with any HTTP client, automation
+ * platform (Zapier, Make, n8n, etc.), or custom script.
  *
  * Accepted fields (all optional except at least one of account_name / AccountName / AccountID):
  *
@@ -92,9 +90,9 @@ function withTimestamp(dateStr) {
   return dateStr + 'T' + new Date().toISOString().split('T')[1];
 }
 
-// ── POST /webhooks/zapier/order ───────────────────────────────────
+// ── POST /webhooks/order ──────────────────────────────────────────
 
-router.post('/zapier/order', requireWebhookSecret, async (req, res) => {
+router.post('/order', requireWebhookSecret, async (req, res) => {
   try {
     const f = normalise(req.body);
 


### PR DESCRIPTION
## Summary
- Renames route from `POST /webhooks/zapier/order` to `POST /webhooks/order`
- Removes all Zapier-specific branding from docblocks, `.env.example`, and `README.md`
- Updates documentation to describe the endpoint as a generic webhook compatible with any HTTP client or automation platform (Zapier, Make, n8n, custom scripts, etc.)

Closes #177

## Test plan
- [x] Grep codebase for "zapier" / "Zapier" — only incidental mentions in example lists remain
- [x] Start server with `WEBHOOK_SECRET` set and confirm `POST /webhooks/order` returns 201
- [x] Confirm old path `POST /webhooks/zapier/order` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)