### PR TITLE
Add support for all order fields in webhook endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,11 @@ The endpoint accepts flexible field names to accommodate different source system
 - **Amount:** `OrderAmount`, `order_amount`, `SaleAmount`, `sale_amount`, `amount`, or `subtotal`
 - **Tax:** `TaxAmount`, `tax_amount`, or `tax`
 - **Invoice:** `InvoiceNumber` or `invoice_number`
-- **Status:** `Status` or `status` (Pending, Paid, or Cancelled)
+- **Status:** `Status` or `status` (Pending, Paid, Cancelled, or Pre-Sale)
+- **Location:** `Location` or `location`
+- **Staff:** `StaffID`, `staff_id`, `StaffName`, `staff_name`, `rep`, or `sales_rep`
+- **Products:** `RequestedProducts`, `requested_products`, or `products`
+- **Delivered:** `Delivered` or `delivered` (true/false, defaults to false)
 
 ## Data structure
 

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -21,8 +21,14 @@
  *   amount          | order_amount   | OrderAmount
  *                   | sale_amount    | SaleAmount      → OrderAmount     (pre-tax total)
  *   tax             | tax_amount     | TaxAmount       → TaxAmount
- *   status          | Status                          → Status          (Pending/Paid/Cancelled)
+ *   status          | Status                          → Status          (Pending/Paid/Cancelled/Pre-Sale)
  *   notes           | Notes          | memo            → Notes
+ *   location        | Location                        → Location        (warehouse / taproom name)
+ *   staff_id        | StaffID                         → StaffID         (our internal staff ID)
+ *   staff_name      | StaffName      | rep
+ *                   | sales_rep                       → staff name lookup
+ *   requested_products | RequestedProducts             → RequestedProducts (free-text product list)
+ *   delivered        | Delivered                       → Delivered       (true/false, default false)
  *   account_id      | AccountID                       → AccountID       (our internal ID)
  *   account_name    | AccountName    | customer_name
  *                   | client_name                     → account name lookup
@@ -80,10 +86,15 @@ function normalise(body) {
     taxAmount:     pick(body, 'TaxAmount',     'tax_amount',    'tax'),
     status:        pick(body, 'Status',        'status'),
     notes:         pick(body, 'Notes',         'notes',         'memo'),
+    location:      pick(body, 'Location',      'location'),
+    staffId:       pick(body, 'StaffID',       'staff_id'),
+    staffName:     pick(body, 'StaffName',     'staff_name',    'rep', 'sales_rep'),
+    requestedProducts: pick(body, 'RequestedProducts', 'requested_products', 'products'),
+    delivered:     pick(body, 'Delivered',      'delivered'),
   };
 }
 
-const VALID_STATUSES = new Set(['Pending', 'Paid', 'Cancelled']);
+const VALID_STATUSES = new Set(['Pending', 'Paid', 'Cancelled', 'Pre-Sale']);
 
 // Append current time to a date-only string so same-day orders sort by creation time.
 function withTimestamp(dateStr) {
@@ -124,6 +135,25 @@ router.post('/zapier/order', requireWebhookSecret, async (req, res) => {
       resolvedAccountName = match.Name;
     }
 
+    // Resolve staff (by ID or name lookup)
+    let resolvedStaffId   = f.staffId;
+    let resolvedStaffName = f.staffName;
+
+    if (!resolvedStaffId && resolvedStaffName) {
+      const staff = await getAllRows('STAFF');
+      const match = staff.find(
+        s => s.Name && s.Name.toLowerCase() === resolvedStaffName.toLowerCase()
+      );
+      if (match) {
+        resolvedStaffId   = match.ID;
+        resolvedStaffName = match.Name;
+      }
+    } else if (resolvedStaffId && !resolvedStaffName) {
+      const staff = await getAllRows('STAFF');
+      const match = staff.find(s => s.ID === resolvedStaffId);
+      if (match) resolvedStaffName = match.Name;
+    }
+
     // Date defaults — include timestamp so same-day orders sort by creation time
     const now       = new Date().toISOString();
     const today     = now.split('T')[0];
@@ -140,15 +170,18 @@ router.post('/zapier/order', requireWebhookSecret, async (req, res) => {
       ID:            uuidv4(),
       AccountID:     resolvedAccountId,
       AccountName:   resolvedAccountName,
-      StaffID:       '',
-      StaffName:     '',
+      Location:      f.location || '',
+      StaffID:       resolvedStaffId || '',
+      StaffName:     resolvedStaffName || '',
       OrderDate:     orderDate,
       DeliveryDate:  f.deliveryDate || '',
       InvoiceNumber: f.invoiceNumber || '',
       OrderAmount:   f.orderAmount  || '0',
       TaxAmount:     f.taxAmount    || '0',
       Notes:         f.notes        || '',
+      RequestedProducts: f.requestedProducts || '',
       Status:        status,
+      Delivered:     f.delivered === 'true' ? 'true' : 'false',
       CreatedAt:     new Date().toISOString(),
     };
 


### PR DESCRIPTION
## Summary
- Adds support for `Location`, `StaffID`/`StaffName`, `RequestedProducts`, and `Delivered` fields to the webhook order creation endpoint
- Staff can be resolved by name (case-insensitive lookup) just like accounts, via `StaffName`, `staff_name`, `rep`, or `sales_rep`
- Adds `Pre-Sale` to the valid statuses accepted by the webhook
- Updates README with documentation for the new fields

## Test plan
- [x] POST to `/webhooks/zapier/order` with `Location` field — verify it appears on the created order
- [x] POST with `StaffName` matching an existing staff member — verify `StaffID` and `StaffName` are resolved
- [x] POST with `StaffID` only — verify `StaffName` is auto-populated
- [x] POST with `RequestedProducts` — verify it is stored on the order
- [x] POST with `Delivered: "true"` — verify it is stored as `"true"` (defaults to `"false"`)
- [ ] POST with `Status: "Pre-Sale"` — verify it is accepted (previously rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)