### PR TITLE
Add billing contact fields to accounts

### DIFF
--- a/db.js
+++ b/db.js
@@ -30,7 +30,7 @@ const TABLES = {
 const HEADERS = {
   PRODUCTS:  ['ID', 'Name', 'Style', 'ABV', 'Format', 'PricePerUnit', 'Notes', 'CreatedAt'],
   INVENTORY: ['ID', 'Name', 'Location', 'Style', 'ABV', 'Format', 'Units', 'PricePerUnit', 'LowStockThreshold', 'Notes', 'LastUpdated', 'ProductID', 'ProductName'],
-  ACCOUNTS:  ['ID', 'Name', 'Type', 'Tags', 'ContactName', 'Email', 'AdditionalEmails', 'Phone', 'PreferredMethod', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'ChargeDeposits', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'CreatedAt'],
+  ACCOUNTS:  ['ID', 'Name', 'Type', 'Tags', 'ContactName', 'Email', 'AdditionalEmails', 'Phone', 'PreferredMethod', 'BillingContactName', 'BillingEmail', 'BillingPhone', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'ChargeDeposits', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'CreatedAt'],
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
   REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
   STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt'],

--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -102,6 +102,22 @@ function accountForm(acct = {}) {
       <span class="text-muted text-sm">Extra email addresses that will also receive emails sent to this account.</span>
     </div>
     <hr class="form-divider" />
+    <div class="form-section-title">Billing Contact</div>
+    <div class="form-group">
+      <label>Billing Contact Name</label>
+      <input class="form-control" id="f-billing-contact" value="${esc(acct.BillingContactName)}" placeholder="Billing contact name" />
+    </div>
+    <div class="form-row">
+      <div class="form-group">
+        <label>Billing Email</label>
+        <input class="form-control" id="f-billing-email" type="email" value="${esc(acct.BillingEmail)}" placeholder="billing@venue.com" />
+      </div>
+      <div class="form-group">
+        <label>Billing Phone</label>
+        <input class="form-control" id="f-billing-phone" type="tel" value="${esc(formatPhone(acct.BillingPhone))}" placeholder="(555) 000-0000" onblur="this.value=formatPhone(this.value)" />
+      </div>
+    </div>
+    <hr class="form-divider" />
     <div class="form-section-title">Location</div>
     <div class="form-group">
       <label>Address</label>
@@ -353,6 +369,9 @@ async function loadAccountProfile(accountId) {
     accountHasEmail(acct) ? `<div class="profile-info-item"><span class="profile-info-label">Email</span><span>${esc(acct.Email || '')}${(() => { const ae = parseAdditionalEmails(acct); return ae.length > 0 ? (acct.Email ? '<br>' : '') + ae.map(e => esc(e)).join('<br>') : ''; })()}</span></div>` : '',
     acct.Phone        ? `<div class="profile-info-item"><span class="profile-info-label">Phone</span><span>${esc(formatPhone(acct.Phone))}</span></div>` : '',
     acct.PreferredMethod ? `<div class="profile-info-item"><span class="profile-info-label">Preferred</span><span>${methodBadge(acct.PreferredMethod)}</span></div>` : '',
+    acct.BillingContactName ? `<div class="profile-info-item"><span class="profile-info-label">Billing Contact</span><span>${esc(acct.BillingContactName)}</span></div>` : '',
+    acct.BillingEmail ? `<div class="profile-info-item"><span class="profile-info-label">Billing Email</span><span>${esc(acct.BillingEmail)}</span></div>` : '',
+    acct.BillingPhone ? `<div class="profile-info-item"><span class="profile-info-label">Billing Phone</span><span>${esc(formatPhone(acct.BillingPhone))}</span></div>` : '',
     (acct.Address || acct.City) ? `<div class="profile-info-item"><span class="profile-info-label">Address</span><span>${esc(acct.Address || '')}${acct.Address && (acct.City || acct.State || acct.Zip) ? ', ' : ''}${[acct.City, (acct.State && acct.Zip ? acct.State + ' ' + acct.Zip : acct.State || acct.Zip)].filter(Boolean).map(esc).join(', ')}</span></div>` : '',
     acct.ABCLicense   ? `<div class="profile-info-item"><span class="profile-info-label">ABC License</span><span>${esc(acct.ABCLicense)}</span></div>` : '',
     (() => { let tags = []; try { tags = JSON.parse(acct.Tags || '[]'); } catch (e) {} return tags.length > 0 ? `<div class="profile-info-item"><span class="profile-info-label">Tags</span><span class="tag-badges">${tags.map(t => '<span class="badge badge-tag">' + esc(t) + '</span>').join(' ')}</span></div>` : ''; })(),
@@ -781,6 +800,7 @@ function openAddAccount() {
       Name: name, Type: val('f-type'), Tags: collectSelectedTags(), Status: val('f-status'),
       ContactName: val('f-contact'), PreferredMethod: val('f-method'),
       Email: val('f-email'), AdditionalEmails: collectAdditionalEmails(), Phone: val('f-phone'),
+      BillingContactName: val('f-billing-contact'), BillingEmail: val('f-billing-email'), BillingPhone: val('f-billing-phone'),
       Address: val('f-address'), City: val('f-city'), State: val('f-state'), Zip: val('f-zip'),
       ABCLicense: val('f-abc-license'),
       ChargeDeposits: document.getElementById('f-charge-deposits').checked ? 'true' : 'false',
@@ -804,6 +824,7 @@ function openEditAccount(id) {
       Name: name, Type: val('f-type'), Tags: collectSelectedTags(), Status: val('f-status'),
       ContactName: val('f-contact'), PreferredMethod: val('f-method'),
       Email: val('f-email'), AdditionalEmails: collectAdditionalEmails(), Phone: val('f-phone'),
+      BillingContactName: val('f-billing-contact'), BillingEmail: val('f-billing-email'), BillingPhone: val('f-billing-phone'),
       Address: val('f-address'), City: val('f-city'), State: val('f-state'), Zip: val('f-zip'),
       ABCLicense: val('f-abc-license'),
       ChargeDeposits: document.getElementById('f-charge-deposits').checked ? 'true' : 'false',

--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -22,7 +22,7 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
   try {
-    const { Name, Type, Tags, ContactName, Email, AdditionalEmails, Phone, PreferredMethod, Address, City, State, Zip, ABCLicense, Status, Notes, StaffID, StaffName } = req.body;
+    const { Name, Type, Tags, ContactName, Email, AdditionalEmails, Phone, PreferredMethod, BillingContactName, BillingEmail, BillingPhone, Address, City, State, Zip, ABCLicense, Status, Notes, StaffID, StaffName } = req.body;
     if (!Name) return res.status(400).json({ error: 'Account name is required' });
 
     const account = {
@@ -35,6 +35,9 @@ router.post('/', async (req, res) => {
       AdditionalEmails: AdditionalEmails || '[]',
       Phone: Phone || '',
       PreferredMethod: PreferredMethod || 'Email',
+      BillingContactName: BillingContactName || '',
+      BillingEmail: BillingEmail || '',
+      BillingPhone: BillingPhone || '',
       Address: Address || '',
       City: City || '',
       State: State || '',
@@ -220,7 +223,7 @@ router.post('/:id/merge', async (req, res) => {
     // Merge account metadata onto target (fill empty fields only)
     const updates = {};
 
-    const fillFields = ['ContactName', 'Email', 'Phone', 'Address', 'City', 'State', 'Zip', 'ABCLicense'];
+    const fillFields = ['ContactName', 'Email', 'Phone', 'BillingContactName', 'BillingEmail', 'BillingPhone', 'Address', 'City', 'State', 'Zip', 'ABCLicense'];
     for (const field of fillFields) {
       if (!target[field] && source[field]) {
         updates[field] = source[field];


### PR DESCRIPTION
## Summary
- Adds `BillingContactName`, `BillingEmail`, and `BillingPhone` fields to accounts for tracking a separate billing/invoicing contact distinct from the primary outreach contact
- New columns auto-migrate on startup via `ensureColumns()`
- Billing contact fields carry over during account merges (fill-if-empty logic)

## Changes
- `db.js`: Added 3 billing columns to ACCOUNTS headers
- `routes/accounts.js`: Added billing fields to POST route and merge fill-fields
- `public/js/accounts.js`: Added billing contact form section, profile display rows, and form submission fields

## Test plan
- [x] Start server — confirm 3 new billing columns auto-created in DB
- [x] Add account with billing contact fields — verify saved and visible in profile
- [x] Edit account — verify billing fields persist
- [x] Merge where source has billing contact and target doesn't — verify fields carry over

🤖 Generated with [Claude Code](https://claude.com/claude-code)