### PR TITLE
Fix Helmet CSP blocking inline event handlers

### DIFF
--- a/server.js
+++ b/server.js
@@ -45,7 +45,16 @@ app.set('trust proxy', 1);
 
 // ── Security headers ─────────────────────────────────────────────────────
 app.disable('x-powered-by');
-app.use(helmet());
+app.use(helmet({
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc:  ["'self'", "'unsafe-inline'"],
+      styleSrc:   ["'self'", "'unsafe-inline'"],
+      imgSrc:     ["'self'", "data:", "https:"],
+    },
+  },
+}));
 
 // ── Rate limiting ────────────────────────────────────────────────────────
 app.use('/auth',     rateLimit({ windowMs: 60_000, max: 10,  standardHeaders: true, legacyHeaders: false }));


### PR DESCRIPTION
## Summary
- The `helmet()` middleware added in #189 uses a default Content-Security-Policy that sets `script-src 'self'`, which blocks all inline `onclick`, `onchange`, and `oninput` handlers — breaking every button and action link in the app
- Configures Helmet's CSP to allow `'unsafe-inline'` for scripts and styles while keeping all other security headers (X-Frame-Options, X-Content-Type-Options, HSTS, etc.)
- Allows `https:` and `data:` image sources for OAuth profile photos

## Test plan
- [x] Verify all button clicks work (Add, Edit, Delete actions across all views)
- [x] Verify filter dropdowns and search inputs trigger correctly
- [x] Verify pagination controls work
- [x] Verify modal open/close functions
- [x] Check response headers still include other Helmet protections (X-Frame-Options, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)