### PR TITLE
Fix Helmet CSP script-src-attr blocking inline handlers

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,10 +48,11 @@ app.disable('x-powered-by');
 app.use(helmet({
   contentSecurityPolicy: {
     directives: {
-      defaultSrc: ["'self'"],
-      scriptSrc:  ["'self'", "'unsafe-inline'"],
-      styleSrc:   ["'self'", "'unsafe-inline'"],
-      imgSrc:     ["'self'", "data:", "https:"],
+      defaultSrc:    ["'self'"],
+      scriptSrc:     ["'self'", "'unsafe-inline'"],
+      scriptSrcAttr: ["'unsafe-inline'"],
+      styleSrc:      ["'self'", "'unsafe-inline'"],
+      imgSrc:        ["'self'", "data:", "https:"],
     },
   },
 }));


### PR DESCRIPTION
## Summary
- Helmet's default CSP includes `script-src-attr: 'none'` which blocks inline event handler attributes (`onclick`, `onchange`, `oninput`) even when `script-src` allows `'unsafe-inline'`
- Adds `scriptSrcAttr: ["'unsafe-inline'"]` to override the default and unblock all inline handlers

Follows up on #191 which fixed `script-src` but missed the separate `script-src-attr` directive.

## Test plan
- [ ] Verify all inline event handlers work: button clicks, filter dropdowns, search inputs, pagination controls
- [ ] Confirm CSP header includes `script-src-attr 'unsafe-inline'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)