### PR TITLE
Configure Helmet CSP for inline handlers and CDN resources

### DIFF
--- a/server.js
+++ b/server.js
@@ -49,10 +49,11 @@ app.use(helmet({
   contentSecurityPolicy: {
     directives: {
       defaultSrc:    ["'self'"],
-      scriptSrc:     ["'self'", "'unsafe-inline'"],
+      scriptSrc:     ["'self'", "'unsafe-inline'", "https://unpkg.com"],
       scriptSrcAttr: ["'unsafe-inline'"],
-      styleSrc:      ["'self'", "'unsafe-inline'"],
+      styleSrc:      ["'self'", "'unsafe-inline'", "https://unpkg.com"],
       imgSrc:        ["'self'", "data:", "https:"],
+      connectSrc:    ["'self'"],
     },
   },
 }));


### PR DESCRIPTION
## Summary
- Helmet's default CSP blocks inline event handlers (`script-src-attr: 'none'`) and external CDN scripts, breaking all buttons, filters, and pagination
- Configures CSP to allow inline scripts/event handlers, Leaflet CDN from unpkg.com, and HTTPS images
- Replaces the incomplete fix from #192

## Test plan
- [x] All inline event handlers work (buttons, filters, pagination, dropdowns)
- [ ] Leaflet map view loads correctly
- [ ] OAuth profile photos display
- [ ] CSP header present in responses with correct directives

🤖 Generated with [Claude Code](https://claude.com/claude-code)