### PR TITLE
Add automatic tax calculation for orders

### DIFF
--- a/db.js
+++ b/db.js
@@ -31,7 +31,7 @@ const TABLES = {
 const HEADERS = {
   PRODUCTS:  ['ID', 'Name', 'Style', 'ABV', 'Format', 'PricePerUnit', 'Notes', 'CreatedAt'],
   INVENTORY: ['ID', 'Name', 'Location', 'Style', 'ABV', 'Format', 'Units', 'PricePerUnit', 'LowStockThreshold', 'Notes', 'LastUpdated', 'ProductID', 'ProductName'],
-  ACCOUNTS:  ['ID', 'Name', 'Type', 'Tags', 'ContactName', 'Email', 'AdditionalEmails', 'Phone', 'PreferredMethod', 'BillingContactName', 'BillingEmail', 'BillingPhone', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'ChargeDeposits', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'QboCustomerId', 'CreatedAt'],
+  ACCOUNTS:  ['ID', 'Name', 'Type', 'Tags', 'ContactName', 'Email', 'AdditionalEmails', 'Phone', 'PreferredMethod', 'BillingContactName', 'BillingEmail', 'BillingPhone', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'ChargeDeposits', 'Taxable', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'QboCustomerId', 'CreatedAt'],
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
   REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
   STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt'],

--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -147,6 +147,12 @@ function accountForm(acct = {}) {
         Charge keg deposits for this account
       </label>
     </div>
+    <div class="form-group">
+      <label class="checkbox-label">
+        <input type="checkbox" id="f-taxable" ${acct.Taxable === 'true' ? 'checked' : ''} />
+        Charge tax for this account
+      </label>
+    </div>
     <hr class="form-divider" />
     <div class="form-group">
       <label>Notes</label>
@@ -828,6 +834,7 @@ function openAddAccount() {
       Address: val('f-address'), City: val('f-city'), State: val('f-state'), Zip: val('f-zip'),
       ABCLicense: val('f-abc-license'),
       ChargeDeposits: document.getElementById('f-charge-deposits').checked ? 'true' : 'false',
+      Taxable: document.getElementById('f-taxable').checked ? 'true' : 'false',
       Notes: val('f-notes'), StaffID: staffId, StaffName: staffName,
     });
     modal.close();
@@ -853,6 +860,7 @@ function openEditAccount(id) {
       Address: val('f-address'), City: val('f-city'), State: val('f-state'), Zip: val('f-zip'),
       ABCLicense: val('f-abc-license'),
       ChargeDeposits: document.getElementById('f-charge-deposits').checked ? 'true' : 'false',
+      Taxable: document.getElementById('f-taxable').checked ? 'true' : 'false',
       Notes: val('f-notes'), StaffID: staffId, StaffName: staffName,
     });
     modal.close();

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -103,7 +103,7 @@ function orderForm(order = {}, presetAccountId = '', readOnly = false) {
     <div class="form-row">
       <div class="form-group">
         <label>Account <span class="required">*</span></label>
-        <select class="form-control" id="f-account" ${presetAccountId || readOnly ? 'disabled' : ''} onchange="initOrderDepositCheckbox()">
+        <select class="form-control" id="f-account" ${presetAccountId || readOnly ? 'disabled' : ''} onchange="initOrderDepositCheckbox(); initOrderTaxCheckbox()">
           <option value="">-- Select Account --</option>
           ${accountOptions(selAcctId)}
         </select>
@@ -152,6 +152,12 @@ function orderForm(order = {}, presetAccountId = '', readOnly = false) {
         <input type="checkbox" id="f-charge-deposits" onchange="toggleOrderDeposits()" ${order.DepositAmount && parseFloat(order.DepositAmount) > 0 ? 'checked' : ''} />
         Charge keg deposits for this order
       </label>
+    </div>
+    <div class="form-group">
+      <label class="checkbox-label">
+        <input type="checkbox" id="f-charge-tax" onchange="toggleOrderTax()" ${order.TaxAmount && parseFloat(order.TaxAmount) > 0 ? 'checked' : ''} />
+        Charge tax for this order
+      </label>
     </div>`}
     <hr class="form-divider" />
     <div class="form-section-title">Products</div>
@@ -162,7 +168,7 @@ function orderForm(order = {}, presetAccountId = '', readOnly = false) {
     <div class="form-row">
       <div class="form-group">
         <label>Order Amount ($) <span class="required">*</span></label>
-        <input class="form-control" id="f-amount" type="number" step="0.01" min="0" value="${esc(order.OrderAmount || '')}" placeholder="0.00"${dis} />
+        <input class="form-control" id="f-amount" type="number" step="0.01" min="0" value="${esc(order.OrderAmount || '')}" placeholder="0.00"${dis} oninput="recalcTaxFromAmount()" />
       </div>
       <div class="form-group">
         <label>Tax Amount ($)</label>
@@ -263,6 +269,46 @@ function initOrderDepositCheckbox(presetAccountId) {
     cb.checked = acct.ChargeDeposits === 'true';
     toggleOrderDeposits();
   }
+}
+
+function toggleOrderTax() {
+  const checked = document.getElementById('f-charge-tax')?.checked;
+  const taxEl = document.getElementById('f-tax');
+  const rate = getTaxRate();
+  if (taxEl) {
+    if (checked && rate > 0) {
+      taxEl.readOnly = true;
+      taxEl.style.background = '#f5f5f5';
+    } else {
+      taxEl.readOnly = false;
+      taxEl.style.background = '';
+    }
+  }
+  if (!checked && taxEl) {
+    taxEl.value = '';
+  }
+  recalcOrderAmount();
+}
+
+function initOrderTaxCheckbox(presetAccountId) {
+  const acctId = presetAccountId || val('f-account');
+  if (!acctId) return;
+  const acct = state.accounts.find(a => a.ID === acctId);
+  const cb = document.getElementById('f-charge-tax');
+  if (cb && acct) {
+    cb.checked = acct.Taxable === 'true';
+    toggleOrderTax();
+  }
+}
+
+function recalcTaxFromAmount() {
+  const checked = document.getElementById('f-charge-tax')?.checked;
+  if (!checked) return;
+  const rate = getTaxRate();
+  if (rate <= 0) return;
+  const amount = parseFloat(val('f-amount')) || 0;
+  const taxEl = document.getElementById('f-tax');
+  if (taxEl) taxEl.value = amount > 0 ? (amount * rate / 100).toFixed(2) : '';
 }
 
 function sortOrders(col) {
@@ -472,6 +518,14 @@ function recalcOrderAmount() {
   }
   const depEl = document.getElementById('f-deposit-amount');
   if (depEl) depEl.value = chargeDeposits && depositTotal > 0 ? depositTotal.toFixed(2) : '';
+  // Auto-calculate tax if charge-tax is checked
+  const chargeTax = document.getElementById('f-charge-tax')?.checked;
+  const taxRate = getTaxRate();
+  if (chargeTax && taxRate > 0) {
+    const orderAmount = parseFloat(val('f-amount')) || 0;
+    const taxEl = document.getElementById('f-tax');
+    if (taxEl) taxEl.value = orderAmount > 0 ? (orderAmount * taxRate / 100).toFixed(2) : '';
+  }
 }
 
 function collectOrderProducts() {
@@ -756,6 +810,7 @@ async function openAddOrder(presetAccountId = '') {
   setTimeout(() => initMentions('f-notes'), 0);
   await refreshOrderProducts();
   initOrderDepositCheckbox(presetAccountId);
+  initOrderTaxCheckbox(presetAccountId);
 }
 
 async function openEditOrder(id) {
@@ -801,6 +856,15 @@ async function openEditOrder(id) {
     await refreshOrderProductsFromItems(orderItems, isPaid);
   } else {
     await refreshOrderProducts(order.RequestedProducts, isPaid);
+  }
+  // Set tax field readonly state for non-paid orders with auto-calculated tax
+  if (!isPaid) {
+    const chargeTaxCb = document.getElementById('f-charge-tax');
+    const taxEl = document.getElementById('f-tax');
+    if (chargeTaxCb && chargeTaxCb.checked && getTaxRate() > 0 && taxEl) {
+      taxEl.readOnly = true;
+      taxEl.style.background = '#f5f5f5';
+    }
   }
 }
 
@@ -921,6 +985,8 @@ async function convertPreSale(id) {
   });
   setTimeout(() => initMentions('f-notes'), 0);
   await refreshOrderProducts(ps.RequestedProducts);
+  initOrderDepositCheckbox(ps.AccountID);
+  initOrderTaxCheckbox(ps.AccountID);
 }
 
 async function cancelPreSale(id) {

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -17,6 +17,11 @@ function getDepositForFormat(format) {
   return parseFloat(deposits[format]) || 0;
 }
 
+function getTaxRate() {
+  if (!state.settings || !state.settings.taxRate) return 0;
+  return parseFloat(state.settings.taxRate) || 0;
+}
+
 function renderSettings() {
   const s = state.settings;
   const companyName = s.companyName || '';
@@ -114,6 +119,26 @@ function renderSettings() {
               </div>
             </div>`).join('')}
           <button class="btn btn-primary" style="margin-top:12px" onclick="saveKegDeposits()">Save</button>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header"><h3>Tax Rate</h3></div>
+        <div style="padding:0 18px 18px">
+          <p class="text-sm text-muted" style="margin-bottom:12px">
+            Set the tax rate for orders. Accounts can be marked as taxable, and orders for those accounts will auto-calculate tax.
+          </p>
+          <div class="form-row" style="align-items:center;margin-bottom:8px">
+            <div style="flex:1">
+              <div style="position:relative">
+                <input class="form-control" id="settings-tax-rate"
+                  type="number" step="0.01" min="0" max="100" value="${esc(s.taxRate || '')}" placeholder="0.00"
+                  style="padding-right:30px" />
+                <span style="position:absolute;right:10px;top:50%;transform:translateY(-50%);color:var(--text-muted)">%</span>
+              </div>
+            </div>
+          </div>
+          <button class="btn btn-primary" onclick="saveTaxRate()">Save</button>
         </div>
       </div>
 
@@ -218,6 +243,19 @@ function saveKegDeposits() {
   api.put('/api/settings', { kegDeposits: deposits }).then(updated => {
     state.settings = updated;
     toast('Keg deposit rates saved');
+  }).catch(err => toast(err.message, 'error'));
+}
+
+// ── Tax Rate ──────────────────────────────────────────────────────
+
+function saveTaxRate() {
+  const v = val('settings-tax-rate');
+  const rate = parseFloat(v) || 0;
+  if (rate < 0 || rate > 100) { toast('Tax rate must be between 0 and 100', 'error'); return; }
+  const value = rate > 0 ? rate.toString() : '';
+  api.put('/api/settings', { taxRate: value }).then(updated => {
+    state.settings = updated;
+    toast('Tax rate saved');
   }).catch(err => toast(err.message, 'error'));
 }
 


### PR DESCRIPTION
## Summary
- Adds configurable **Tax Rate** setting in Settings (between Keg Deposits and QuickBooks cards)
- Adds **Taxable** checkbox on account forms to mark accounts as taxable by default
- Adds **Charge tax** checkbox on order forms that auto-calculates tax from order amount × tax rate
- Follows the same per-account default pattern used by keg deposits (`ChargeDeposits` → `Taxable`)

## Details
- `db.js`: Added `Taxable` column to ACCOUNTS (auto-migrated on startup)
- `settings.js`: `getTaxRate()` helper, Tax Rate card with % input, `saveTaxRate()` with 0-100 validation
- `accounts.js`: Taxable checkbox in account form + save in add/edit
- `orders.js`: Charge tax checkbox, `toggleOrderTax()`, `initOrderTaxCheckbox()`, `recalcTaxFromAmount()`, tax calc in `recalcOrderAmount()`, init calls in `openAddOrder`/`convertPreSale`/`openEditOrder`

## Behavior
- Taxable accounts auto-check "Charge tax" on new orders; tax field becomes readonly and auto-calculates
- Non-taxable accounts leave checkbox unchecked; tax field stays editable for manual entry
- Switching accounts updates the checkbox based on the new account's Taxable flag
- Unchecking clears tax and makes the field editable again
- No tax rate configured → checkbox checks but no calculation, field stays editable
- No changes to pre-sales, PDF import, or QBO sync (reads `TaxAmount` as-is)
- Also fixes existing gap: deposit checkbox now auto-initializes on pre-sale conversion

Closes #200

## Test plan
- [x] Tax Rate card appears in Settings, saves/persists correctly
- [x] Taxable checkbox appears on account form, saves and persists on edit
- [x] New order for taxable account: checkbox auto-checks, tax auto-calculates, tax field readonly
- [x] New order for non-taxable account: checkbox unchecked, tax field editable
- [x] Switching accounts updates checkbox based on new account's Taxable flag
- [x] Unchecking tax clears field and makes it editable
- [x] Editing existing order: checkbox pre-checked if TaxAmount > 0, readonly state correct
- [x] Converting pre-sale: tax and deposit checkboxes auto-initialize from account
- [x] No tax rate set: checkbox checks but no calculation, field stays editable
- [x] PDF import unchanged
- [x] QBO sync works with auto-calculated tax

🤖 Generated with [Claude Code](https://claude.com/claude-code)