### PR TITLE
Add Reports screen with charts and data tables

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -80,6 +80,9 @@
           <a class="nav-item" data-view="staff" href="#staff">
             <span class="nav-icon">&#9632;</span> Staff
           </a>
+          <a class="nav-item" data-view="reports" href="#reports">
+            <span class="nav-icon">&#9632;</span> Reports
+          </a>
           <a class="nav-item" data-view="settings" href="#settings">
             <span class="nav-icon">&#9632;</span> Settings
           </a>
@@ -135,6 +138,7 @@
 
   </div>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="https://unpkg.com/chart.js@4/dist/chart.umd.min.js"></script>
   <!-- Core: state, utilities, API, modal, pagination, form helpers -->
   <script src="js/core.js"></script>
   <script src="js/mentions.js"></script>
@@ -152,6 +156,7 @@
   <script src="js/kegs.js"></script>
   <script src="js/tap-handles.js"></script>
   <script src="js/map.js"></script>
+  <script src="js/reports.js"></script>
 
   <!-- Init: must load last (VIEW_LOADERS references all load functions) -->
   <script src="js/init.js"></script>

--- a/public/js/init.js
+++ b/public/js/init.js
@@ -11,6 +11,7 @@ const VIEW_LOADERS = {
   kegs:          loadKegs,
   'tap-handles': loadTapHandles,
   staff:         loadStaff,
+  reports:       loadReports,
   settings:      loadSettings,
   map:           loadMap,
 };

--- a/public/js/reports.js
+++ b/public/js/reports.js
@@ -1,0 +1,457 @@
+'use strict';
+
+// ── Reports Module ────────────────────────────────────────────────
+
+let _reportsPreset = 'this-month';
+let _reportsStart = '';
+let _reportsEnd = '';
+let _reportsData = null;
+let _reportCharts = {};
+
+function _destroyReportCharts() {
+  for (const key of Object.keys(_reportCharts)) {
+    if (_reportCharts[key]) { _reportCharts[key].destroy(); delete _reportCharts[key]; }
+  }
+}
+
+async function loadReports() {
+  // Compute date range from preset
+  if (_reportsPreset !== 'custom') {
+    const [s, e] = dateRange(_reportsPreset);
+    _reportsStart = s;
+    _reportsEnd = e;
+  }
+  if (!_reportsStart || !_reportsEnd) {
+    const [s, e] = dateRange('this-month');
+    _reportsStart = s;
+    _reportsEnd = e;
+  }
+
+  showLoading();
+
+  try {
+    const params = new URLSearchParams({ start: _reportsStart, end: _reportsEnd });
+    if (state.location) params.set('location', state.location);
+    _reportsData = await api.get('/api/reports?' + params.toString());
+    renderReports();
+  } catch (err) {
+    setContent(`<div class="empty-state text-danger" style="padding:40px">Error loading reports: ${esc(err.message)}</div>`);
+  }
+}
+
+function renderReports() {
+  _destroyReportCharts();
+  const data = _reportsData;
+  if (!data) return;
+
+  const presetOptions = [
+    ['this-month', 'This Month'],
+    ['last-month', 'Last Month'],
+    ['last7', 'Last 7 Days'],
+    ['last30', 'Last 30 Days'],
+    ['this-year', 'This Year'],
+    ['last-year', 'Last Year'],
+    ['custom', 'Custom Range'],
+  ];
+
+  const customInputs = _reportsPreset === 'custom'
+    ? ` <input type="date" id="reports-start" value="${esc(_reportsStart)}" onchange="_reportsCustomDate()">
+       <input type="date" id="reports-end" value="${esc(_reportsEnd)}" onchange="_reportsCustomDate()">`
+    : '';
+
+  const s = data.salesSummary.totals;
+
+  setContent(`
+    <div class="view-header">
+      <div>
+        <h2>Reports</h2>
+        <div class="subtitle">${esc(formatDate(_reportsStart))} — ${esc(formatDate(_reportsEnd))}</div>
+      </div>
+      <div class="view-header-actions">
+        <button class="btn btn-secondary" onclick="_reportsExportCsv()">Export CSV</button>
+      </div>
+    </div>
+
+    <div class="filter-bar">
+      <select id="reports-preset" onchange="_reportsPresetChange(this.value)">
+        ${presetOptions.map(([v, l]) => `<option value="${v}" ${v === _reportsPreset ? 'selected' : ''}>${l}</option>`).join('')}
+      </select>
+      ${customInputs}
+    </div>
+
+    <div class="stats-grid">
+      <div class="stat-card">
+        <div class="stat-value">${s.orderCount}</div>
+        <div class="stat-label">Orders</div>
+      </div>
+      <div class="stat-card accent">
+        <div class="stat-value">${fmtMoney(s.orderAmount)}</div>
+        <div class="stat-label">Revenue</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">${fmtMoney(s.taxAmount)}</div>
+        <div class="stat-label">Tax Collected</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">${fmtMoney(s.depositAmount)}</div>
+        <div class="stat-label">Deposits</div>
+      </div>
+    </div>
+
+    <div class="reports-grid">
+      ${_renderSalesChart(data)}
+      ${_renderTopProducts(data)}
+      ${_renderAccountActivity(data)}
+      ${_renderStockMovements(data)}
+      ${_renderSalesByRep(data)}
+    </div>
+  `);
+
+  // Render charts after DOM is ready
+  requestAnimationFrame(() => {
+    _buildSalesChart(data);
+    _buildTopProductsChart(data);
+    _buildAccountActivityChart(data);
+    _buildStockMovementsChart(data);
+    _buildSalesByRepChart(data);
+  });
+}
+
+// ── Date range controls ─────────────────────────────────────────
+
+function _reportsPresetChange(preset) {
+  _reportsPreset = preset;
+  if (preset !== 'custom') {
+    loadReports();
+  } else {
+    renderReports();
+  }
+}
+
+function _reportsCustomDate() {
+  const s = val('reports-start');
+  const e = val('reports-end');
+  if (s && e && s <= e) {
+    _reportsStart = s;
+    _reportsEnd = e;
+    loadReports();
+  }
+}
+
+// ── Chart colors ────────────────────────────────────────────────
+
+const _chartColors = {
+  green:  '#2e7d32',
+  amber:  '#e07b00',
+  dark:   '#1b5e20',
+  danger: '#c62828',
+  blue:   '#1565c0',
+  purple: '#6a1b9a',
+};
+
+// ── Sales Summary ───────────────────────────────────────────────
+
+function _renderSalesChart(data) {
+  const buckets = data.salesSummary.buckets;
+  if (!buckets.length) return _emptyCard('Sales Over Time', 'full-width');
+  return `
+    <div class="card full-width">
+      <div class="card-header"><h3>Sales Over Time</h3></div>
+      <canvas id="chart-sales" height="300"></canvas>
+      <details class="report-table-toggle">
+        <summary>View Table</summary>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Period</th><th>Orders</th><th>Revenue</th><th>Tax</th><th>Deposits</th></tr></thead>
+            <tbody>
+              ${buckets.map(b => `<tr>
+                <td>${esc(b.bucket)}</td><td>${b.orderCount}</td><td>${fmtMoney(b.orderAmount)}</td>
+                <td>${fmtMoney(b.taxAmount)}</td><td>${fmtMoney(b.depositAmount)}</td>
+              </tr>`).join('')}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </div>`;
+}
+
+function _buildSalesChart(data) {
+  const buckets = data.salesSummary.buckets;
+  if (!buckets.length) return;
+  const ctx = document.getElementById('chart-sales');
+  if (!ctx) return;
+  _reportCharts.sales = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: buckets.map(b => b.bucket),
+      datasets: [
+        { label: 'Revenue', data: buckets.map(b => b.orderAmount), backgroundColor: _chartColors.green },
+        { label: 'Tax', data: buckets.map(b => b.taxAmount), backgroundColor: _chartColors.amber },
+      ],
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { position: 'top' } },
+      scales: {
+        x: { stacked: true },
+        y: { stacked: true, ticks: { callback: v => '$' + v.toLocaleString() } },
+      },
+    },
+  });
+}
+
+// ── Top Products ────────────────────────────────────────────────
+
+function _renderTopProducts(data) {
+  const products = data.topProducts;
+  if (!products.length) return _emptyCard('Top Products');
+  const top15 = products.slice(0, 15);
+  return `
+    <div class="card">
+      <div class="card-header"><h3>Top Products</h3><span class="text-muted text-sm">${products.length} products</span></div>
+      <canvas id="chart-products" height="300"></canvas>
+      <details class="report-table-toggle">
+        <summary>View Table</summary>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Product</th><th>Format</th><th>Qty Sold</th><th>Revenue</th><th>Avg Price</th><th>Orders</th></tr></thead>
+            <tbody>
+              ${products.map(p => `<tr>
+                <td>${esc(p.productName)}</td><td>${esc(p.format)}</td><td>${p.quantitySold}</td>
+                <td>${fmtMoney(p.revenue)}</td><td>${fmtMoney(p.avgPrice)}</td><td>${p.orderCount}</td>
+              </tr>`).join('')}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </div>`;
+}
+
+function _buildTopProductsChart(data) {
+  const products = data.topProducts.slice(0, 15);
+  if (!products.length) return;
+  const ctx = document.getElementById('chart-products');
+  if (!ctx) return;
+  _reportCharts.products = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: products.map(p => p.productName + (p.format ? ' (' + p.format + ')' : '')),
+      datasets: [{ label: 'Qty Sold', data: products.map(p => p.quantitySold), backgroundColor: _chartColors.green }],
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false, indexAxis: 'y',
+      plugins: { legend: { display: false } },
+    },
+  });
+}
+
+// ── Account Activity ────────────────────────────────────────────
+
+function _renderAccountActivity(data) {
+  const accounts = data.accountActivity;
+  if (!accounts.length) return _emptyCard('Account Activity');
+  return `
+    <div class="card">
+      <div class="card-header"><h3>Account Activity</h3><span class="text-muted text-sm">${accounts.length} accounts</span></div>
+      <canvas id="chart-accounts" height="300"></canvas>
+      <details class="report-table-toggle">
+        <summary>View Table</summary>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Account</th><th>Type</th><th>Orders</th><th>Total Spent</th><th>Avg Order</th><th>Last Order</th></tr></thead>
+            <tbody>
+              ${accounts.map(a => `<tr>
+                <td>${esc(a.name)}</td><td>${esc(a.type)}</td><td>${a.orderCount}</td>
+                <td>${fmtMoney(a.totalSpent)}</td><td>${fmtMoney(a.avgOrder)}</td><td>${formatDate(a.lastOrderDate)}</td>
+              </tr>`).join('')}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </div>`;
+}
+
+function _buildAccountActivityChart(data) {
+  const accounts = data.accountActivity.slice(0, 15);
+  if (!accounts.length) return;
+  const ctx = document.getElementById('chart-accounts');
+  if (!ctx) return;
+  _reportCharts.accounts = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: accounts.map(a => a.name),
+      datasets: [{ label: 'Total Spent', data: accounts.map(a => a.totalSpent), backgroundColor: _chartColors.amber }],
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false, indexAxis: 'y',
+      plugins: { legend: { display: false } },
+      scales: { x: { ticks: { callback: v => '$' + v.toLocaleString() } } },
+    },
+  });
+}
+
+// ── Stock Movements ─────────────────────────────────────────────
+
+function _renderStockMovements(data) {
+  const sm = data.stockMovements;
+  if (!sm.buckets.length && !sm.products.length) return _emptyCard('Stock Movements', 'full-width');
+  return `
+    <div class="card full-width">
+      <div class="card-header"><h3>Stock Movements</h3></div>
+      <canvas id="chart-movements" height="300"></canvas>
+      <details class="report-table-toggle">
+        <summary>View Table</summary>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Product</th><th>Received</th><th>Sold</th><th>Write-Off</th><th>Adjustment</th><th>Net</th></tr></thead>
+            <tbody>
+              ${sm.products.map(p => `<tr>
+                <td>${esc(p.name)}</td><td>${p.received}</td><td>${p.sold}</td>
+                <td>${p.writeOff}</td><td>${p.adjustment}</td>
+                <td class="${p.netChange >= 0 ? 'text-success' : 'text-danger'}">${p.netChange > 0 ? '+' : ''}${p.netChange}</td>
+              </tr>`).join('')}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </div>`;
+}
+
+function _buildStockMovementsChart(data) {
+  const buckets = data.stockMovements.buckets;
+  if (!buckets.length) return;
+  const ctx = document.getElementById('chart-movements');
+  if (!ctx) return;
+  _reportCharts.movements = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: buckets.map(b => b.bucket),
+      datasets: [
+        { label: 'Received', data: buckets.map(b => b.received), backgroundColor: _chartColors.green },
+        { label: 'Sold', data: buckets.map(b => b.sold), backgroundColor: _chartColors.amber },
+        { label: 'Write-Off', data: buckets.map(b => b.writeOff), backgroundColor: _chartColors.danger },
+        { label: 'Adjustment', data: buckets.map(b => b.adjustment), backgroundColor: _chartColors.blue },
+      ],
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { position: 'top' } },
+      scales: { x: { stacked: true }, y: { stacked: true } },
+    },
+  });
+}
+
+// ── Sales by Rep ────────────────────────────────────────────────
+
+function _renderSalesByRep(data) {
+  const reps = data.salesByRep;
+  if (!reps.length) return _emptyCard('Sales by Rep', 'full-width');
+  return `
+    <div class="card full-width">
+      <div class="card-header"><h3>Sales by Rep</h3></div>
+      <canvas id="chart-reps" height="250"></canvas>
+      <details class="report-table-toggle">
+        <summary>View Table</summary>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Rep</th><th>Orders</th><th>Revenue</th><th>Avg Order</th><th>Accounts</th></tr></thead>
+            <tbody>
+              ${reps.map(r => `<tr>
+                <td>${esc(r.name)}</td><td>${r.orderCount}</td><td>${fmtMoney(r.totalRevenue)}</td>
+                <td>${fmtMoney(r.avgOrder)}</td><td>${r.accountsServed}</td>
+              </tr>`).join('')}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </div>`;
+}
+
+function _buildSalesByRepChart(data) {
+  const reps = data.salesByRep;
+  if (!reps.length) return;
+  const ctx = document.getElementById('chart-reps');
+  if (!ctx) return;
+  _reportCharts.reps = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: reps.map(r => r.name),
+      datasets: [
+        { label: 'Revenue', data: reps.map(r => r.totalRevenue), backgroundColor: _chartColors.green, yAxisID: 'y' },
+        { label: 'Orders', data: reps.map(r => r.orderCount), backgroundColor: _chartColors.amber, yAxisID: 'y1' },
+      ],
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { position: 'top' } },
+      scales: {
+        y: { position: 'left', ticks: { callback: v => '$' + v.toLocaleString() } },
+        y1: { position: 'right', grid: { drawOnChartArea: false } },
+      },
+    },
+  });
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function _emptyCard(title, extraClass = '') {
+  return `<div class="card ${extraClass}">
+    <div class="card-header"><h3>${esc(title)}</h3></div>
+    <div class="empty-state">No data for this period</div>
+  </div>`;
+}
+
+// ── CSV Export ───────────────────────────────────────────────────
+
+function _reportsExportCsv() {
+  if (!_reportsData) return;
+  const d = _reportsData;
+  const lines = [];
+
+  // Sales Summary
+  lines.push('--- Sales Summary ---');
+  lines.push('Period,Orders,Revenue,Tax,Deposits');
+  for (const b of d.salesSummary.buckets) {
+    lines.push(`${b.bucket},${b.orderCount},${b.orderAmount.toFixed(2)},${b.taxAmount.toFixed(2)},${b.depositAmount.toFixed(2)}`);
+  }
+  lines.push('');
+
+  // Top Products
+  lines.push('--- Top Products ---');
+  lines.push('Product,Format,Qty Sold,Revenue,Avg Price,Orders');
+  for (const p of d.topProducts) {
+    lines.push(`"${p.productName}","${p.format}",${p.quantitySold},${p.revenue.toFixed(2)},${p.avgPrice.toFixed(2)},${p.orderCount}`);
+  }
+  lines.push('');
+
+  // Account Activity
+  lines.push('--- Account Activity ---');
+  lines.push('Account,Type,Orders,Total Spent,Avg Order,Last Order');
+  for (const a of d.accountActivity) {
+    lines.push(`"${a.name}","${a.type}",${a.orderCount},${a.totalSpent.toFixed(2)},${a.avgOrder.toFixed(2)},${a.lastOrderDate}`);
+  }
+  lines.push('');
+
+  // Stock Movements
+  lines.push('--- Stock Movements ---');
+  lines.push('Product,Received,Sold,Write-Off,Adjustment,Net');
+  for (const p of d.stockMovements.products) {
+    lines.push(`"${p.name}",${p.received},${p.sold},${p.writeOff},${p.adjustment},${p.netChange}`);
+  }
+  lines.push('');
+
+  // Sales by Rep
+  lines.push('--- Sales by Rep ---');
+  lines.push('Rep,Orders,Revenue,Avg Order,Accounts');
+  for (const r of d.salesByRep) {
+    lines.push(`"${r.name}",${r.orderCount},${r.totalRevenue.toFixed(2)},${r.avgOrder.toFixed(2)},${r.accountsServed}`);
+  }
+
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `reports_${_reportsStart}_${_reportsEnd}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/public/style.css
+++ b/public/style.css
@@ -538,6 +538,40 @@ body {
   font-size: 13px;
 }
 
+/* ── Reports Grid ──────────────────────────────────────── */
+
+.reports-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+}
+
+.reports-grid .card.full-width {
+  grid-column: 1 / -1;
+}
+
+.reports-grid canvas {
+  width: 100% !important;
+  max-height: 300px;
+}
+
+.report-table-toggle {
+  margin-top: 12px;
+}
+
+.report-table-toggle summary {
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  padding: 6px 0;
+  user-select: none;
+}
+
+.report-table-toggle summary:hover {
+  color: var(--text);
+}
+
 /* ── Filter Bar ─────────────────────────────────────────── */
 
 .filter-bar {
@@ -1282,6 +1316,7 @@ th input[type="checkbox"] {
   :root { --sidebar-width: 190px; }
   .content-area { padding: 18px 16px; }
   .dashboard-grid { grid-template-columns: 1fr; }
+  .reports-grid { grid-template-columns: 1fr; }
   .form-row { grid-template-columns: 1fr; }
 }
 
@@ -1425,8 +1460,9 @@ th input[type="checkbox"] {
     width: 100%;
   }
 
-  /* ── Dashboard grid: single column ── */
-  .dashboard-grid {
+  /* ── Dashboard / Reports grid: single column ── */
+  .dashboard-grid,
+  .reports-grid {
     grid-template-columns: 1fr;
   }
 

--- a/routes/reports.js
+++ b/routes/reports.js
@@ -1,0 +1,219 @@
+'use strict';
+
+const express = require('express');
+const { getAllRows } = require('../db');
+
+const router = express.Router();
+
+function bucketKey(dateStr, granularity) {
+  if (!dateStr) return '';
+  const d = dateStr.substring(0, 10);
+  if (granularity === 'day') return d;
+  if (granularity === 'month') return d.substring(0, 7);
+  // week: ISO week
+  const dt = new Date(d + 'T00:00:00');
+  const jan1 = new Date(dt.getFullYear(), 0, 1);
+  const dayOfYear = Math.floor((dt - jan1) / 86400000) + 1;
+  const weekNum = Math.ceil((dayOfYear + jan1.getDay()) / 7);
+  return `${dt.getFullYear()}-W${String(weekNum).padStart(2, '0')}`;
+}
+
+router.get('/', async (req, res) => {
+  try {
+    const { start, end, location } = req.query;
+    if (!start || !end) return res.status(400).json({ error: 'start and end query params required' });
+
+    let [orders, orderItems, stockMovements, accounts, inventory, staff, products] = await Promise.all([
+      getAllRows('ORDERS'),
+      getAllRows('ORDER_ITEMS'),
+      getAllRows('STOCK_MOVEMENTS'),
+      getAllRows('ACCOUNTS'),
+      getAllRows('INVENTORY'),
+      getAllRows('STAFF'),
+      getAllRows('PRODUCTS'),
+    ]);
+
+    // Location filter
+    if (location) {
+      orders = orders.filter(o => o.Location === location);
+      inventory = inventory.filter(i => i.Location === location);
+    }
+
+    // Determine granularity based on date range span
+    const startDate = new Date(start + 'T00:00:00');
+    const endDate = new Date(end + 'T00:00:00');
+    const daySpan = Math.round((endDate - startDate) / 86400000) + 1;
+    const granularity = daySpan <= 31 ? 'day' : daySpan <= 90 ? 'week' : 'month';
+
+    // Filter orders by date range (exclude Cancelled and Pre-Sale for sales)
+    const dateFilteredOrders = orders.filter(o => {
+      const d = (o.OrderDate || '').substring(0, 10);
+      return d >= start && d <= end;
+    });
+    const salesOrders = dateFilteredOrders.filter(o => o.Status !== 'Cancelled' && o.Status !== 'Pre-Sale');
+
+    // Build sets for quick lookups
+    const salesOrderIds = new Set(salesOrders.map(o => o.ID));
+    const dateOrderIds = new Set(dateFilteredOrders.map(o => o.ID));
+    const accountMap = Object.fromEntries(accounts.map(a => [a.ID, a]));
+    const staffMap = Object.fromEntries(staff.map(s => [s.ID, s]));
+    const inventoryMap = Object.fromEntries(inventory.map(i => [i.ID, i]));
+    const productMap = Object.fromEntries(products.map(p => [p.ID, p]));
+
+    // ── A. Sales Summary ──────────────────────────────────────────
+    const salesBuckets = {};
+    let totalOrders = 0, totalAmount = 0, totalTax = 0, totalDeposits = 0;
+
+    for (const o of salesOrders) {
+      const key = bucketKey(o.OrderDate, granularity);
+      if (!salesBuckets[key]) salesBuckets[key] = { bucket: key, orderCount: 0, orderAmount: 0, taxAmount: 0, depositAmount: 0 };
+      const b = salesBuckets[key];
+      const amt = parseFloat(o.OrderAmount || 0);
+      const tax = parseFloat(o.TaxAmount || 0);
+      const dep = parseFloat(o.DepositAmount || 0);
+      b.orderCount++;
+      b.orderAmount += amt;
+      b.taxAmount += tax;
+      b.depositAmount += dep;
+      totalOrders++;
+      totalAmount += amt;
+      totalTax += tax;
+      totalDeposits += dep;
+    }
+
+    const salesSummary = {
+      buckets: Object.values(salesBuckets).sort((a, b) => a.bucket.localeCompare(b.bucket)),
+      granularity,
+      totals: { orderCount: totalOrders, orderAmount: totalAmount, taxAmount: totalTax, depositAmount: totalDeposits },
+    };
+
+    // ── B. Top Products ───────────────────────────────────────────
+    const productAgg = {};
+    const salesItems = orderItems.filter(i => salesOrderIds.has(i.OrderID));
+
+    for (const item of salesItems) {
+      const key = `${item.ProductName || ''}|||${item.Format || ''}`;
+      if (!productAgg[key]) productAgg[key] = { productName: item.ProductName || '', format: item.Format || '', quantitySold: 0, revenue: 0, orderIds: new Set() };
+      const a = productAgg[key];
+      a.quantitySold += parseInt(item.Quantity || 0);
+      a.revenue += parseFloat(item.LineTotal || 0);
+      a.orderIds.add(item.OrderID);
+    }
+
+    const topProducts = Object.values(productAgg)
+      .map(p => ({
+        productName: p.productName,
+        format: p.format,
+        quantitySold: p.quantitySold,
+        revenue: p.revenue,
+        avgPrice: p.quantitySold > 0 ? p.revenue / p.quantitySold : 0,
+        orderCount: p.orderIds.size,
+      }))
+      .sort((a, b) => b.quantitySold - a.quantitySold);
+
+    // ── C. Account Activity ───────────────────────────────────────
+    const accountAgg = {};
+
+    for (const o of salesOrders) {
+      if (!o.AccountID) continue;
+      if (!accountAgg[o.AccountID]) {
+        const acct = accountMap[o.AccountID] || {};
+        accountAgg[o.AccountID] = { accountId: o.AccountID, name: o.AccountName || acct.Name || '', type: acct.Type || '', orderCount: 0, totalSpent: 0, lastOrderDate: '' };
+      }
+      const a = accountAgg[o.AccountID];
+      a.orderCount++;
+      a.totalSpent += parseFloat(o.OrderAmount || 0);
+      const d = (o.OrderDate || '').substring(0, 10);
+      if (d > a.lastOrderDate) a.lastOrderDate = d;
+    }
+
+    const accountActivity = Object.values(accountAgg)
+      .map(a => ({ ...a, avgOrder: a.orderCount > 0 ? a.totalSpent / a.orderCount : 0 }))
+      .sort((a, b) => b.totalSpent - a.totalSpent);
+
+    // ── D. Stock Movements ────────────────────────────────────────
+    // Filter movements by date and optionally by location (via inventoryMap)
+    const inventoryIds = location ? new Set(inventory.map(i => i.ID)) : null;
+    const filteredMovements = stockMovements.filter(m => {
+      const d = (m.Date || m.CreatedAt || '').substring(0, 10);
+      if (d < start || d > end) return false;
+      if (inventoryIds && !inventoryIds.has(m.InventoryID)) return false;
+      return true;
+    });
+
+    const movBuckets = {};
+    const movProducts = {};
+
+    for (const m of filteredMovements) {
+      const key = bucketKey(m.Date || m.CreatedAt, granularity);
+      if (!movBuckets[key]) movBuckets[key] = { bucket: key, received: 0, sold: 0, writeOff: 0, adjustment: 0 };
+      const b = movBuckets[key];
+      const qty = Math.abs(parseInt(m.Quantity || 0));
+      const type = (m.Type || '').toLowerCase();
+      if (type === 'received' || type === 'receive') b.received += qty;
+      else if (type === 'sale') b.sold += qty;
+      else if (type === 'write-off' || type === 'writeoff' || type === 'write_off') b.writeOff += qty;
+      else if (type === 'adjustment') b.adjustment += qty;
+
+      // Per-product aggregation
+      const pKey = m.InventoryName || m.InventoryID || '';
+      if (!movProducts[pKey]) movProducts[pKey] = { name: pKey, received: 0, sold: 0, writeOff: 0, adjustment: 0 };
+      const p = movProducts[pKey];
+      if (type === 'received' || type === 'receive') p.received += qty;
+      else if (type === 'sale') p.sold += qty;
+      else if (type === 'write-off' || type === 'writeoff' || type === 'write_off') p.writeOff += qty;
+      else if (type === 'adjustment') {
+        const raw = parseInt(m.Quantity || 0);
+        p.adjustment += raw;  // Keep sign for net calculation
+      }
+    }
+
+    const stockMovementsSummary = {
+      buckets: Object.values(movBuckets).sort((a, b) => a.bucket.localeCompare(b.bucket)),
+      products: Object.values(movProducts)
+        .map(p => ({ ...p, netChange: p.received - p.sold - p.writeOff + p.adjustment }))
+        .sort((a, b) => b.received - a.received),
+      granularity,
+    };
+
+    // ── E. Sales by Rep ───────────────────────────────────────────
+    const repAgg = {};
+
+    for (const o of salesOrders) {
+      const repId = o.StaffID || '_unassigned';
+      if (!repAgg[repId]) {
+        const s = staffMap[o.StaffID] || {};
+        repAgg[repId] = { staffId: repId, name: o.StaffName || s.Name || 'Unassigned', orderCount: 0, totalRevenue: 0, accountIds: new Set() };
+      }
+      const r = repAgg[repId];
+      r.orderCount++;
+      r.totalRevenue += parseFloat(o.OrderAmount || 0);
+      if (o.AccountID) r.accountIds.add(o.AccountID);
+    }
+
+    const salesByRep = Object.values(repAgg)
+      .map(r => ({
+        staffId: r.staffId,
+        name: r.name,
+        orderCount: r.orderCount,
+        totalRevenue: r.totalRevenue,
+        avgOrder: r.orderCount > 0 ? r.totalRevenue / r.orderCount : 0,
+        accountsServed: r.accountIds.size,
+      }))
+      .sort((a, b) => b.totalRevenue - a.totalRevenue);
+
+    res.json({
+      salesSummary,
+      topProducts,
+      accountActivity,
+      stockMovements: stockMovementsSummary,
+      salesByRep,
+      dateRange: { start, end, daySpan, granularity },
+    });
+  } catch (err) {
+    console.error(`[reports] ${err.message}`);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -36,6 +36,7 @@ const emailRoutes          = require('./routes/email');
 const orderItemsRoutes     = require('./routes/order-items');
 const notificationsRoutes  = require('./routes/notifications');
 const qboRoutes            = require('./routes/qbo');
+const reportsRoutes        = require('./routes/reports');
 
 const app  = express();
 const PORT = process.env.PORT || 3000;
@@ -117,6 +118,7 @@ app.use('/api/email',           requireAuth, emailRoutes);
 app.use('/api/order-items',     requireAuth, orderItemsRoutes);
 app.use('/api/notifications',  requireAuth, notificationsRoutes);
 app.use('/api/qbo',            requireAuth, qboRoutes.apiRouter);
+app.use('/api/reports',        requireAuth, reportsRoutes);
 
 // Status endpoint (public – used by the frontend before auth).
 app.get('/api/status', (req, res) => {


### PR DESCRIPTION
## Summary
- Adds a new **Reports** view with 5 sections: Sales Summary, Top Products, Account Activity, Stock Movements, and Sales by Rep
- Each section includes a Chart.js visualization and a collapsible data table
- Date range presets (This Month, Last Month, Last 7/30 Days, This/Last Year) plus custom date range picker
- Location filtering via the existing sidebar location switcher
- CSV export of all report data
- Responsive 2-column grid that collapses to single column on mobile

Closes #198

## Test plan
- [x] Navigate to Reports — default "This Month" loads with charts and data
- [x] Change date preset — data refreshes, charts re-render without duplicates
- [x] Select "Custom Range" — date inputs appear, filtering works correctly
- [x] Switch location — reports filter to that location's data
- [x] Click "View Table" — expands collapsible data table under each chart
- [x] Click "Export CSV" — downloads CSV file with all report sections
- [x] Verify empty state — sections with no data show "No data for this period"
- [x] Test on mobile — grid collapses to single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)