### PR TITLE
Fix dotenv to load .env relative to app directory, not cwd

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const session        = require('express-session');
 const passport       = require('passport');
 const helmet         = require('helmet');
 const rateLimit      = require('express-rate-limit');
-require('dotenv').config();
+require('dotenv').config({ path: path.join(__dirname, '.env') });
 
 // ── Startup guards ───────────────────────────────────────────────────────
 if (!process.env.SESSION_SECRET) {


### PR DESCRIPTION
pm2 may run the process with a different working directory than the app root, causing dotenv to miss the .env file. Use __dirname to ensure it always finds the correct .env.