### PR TITLE
Skip consent re-prompt on Google login

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -72,7 +72,7 @@ const basePath = process.env.BASE_PATH || '';
 router.get('/google', requireOAuthConfig, passport.authenticate('google', {
   scope: ['profile', 'email', 'https://www.googleapis.com/auth/gmail.send'],
   accessType: 'offline',
-  prompt: 'consent',
+  prompt: 'select_account',
 }));
 
 // Google redirects here after the user grants (or denies) access.


### PR DESCRIPTION
## Summary
- Changes Google OAuth `prompt` from `consent` to `select_account`
- Users no longer have to re-grant email permissions on every login — Google remembers the granted scopes from the initial authorization
- Users still see the account picker so they can choose which Google account to sign in with

## Test plan
- [ ] First-time user: still sees full consent screen with email permission request
- [ ] Returning user: sees only account picker, no permission re-grant
- [ ] Email sending still works after login (refresh token from initial consent is preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)