### PR TITLE
Auto-send QBO invoices via email after creation

### DIFF
--- a/qbo-service.js
+++ b/qbo-service.js
@@ -434,6 +434,17 @@ async function syncOrderToQbo(orderId) {
     await updateRow('ORDERS', orderId, updates);
 
     console.log(`[qbo] Order ${orderId} synced → QBO Invoice ${invoice.Id}`);
+
+    // Send the invoice via email
+    const billEmail = account.BillingEmail || account.Email;
+    if (billEmail) {
+      try {
+        await qboApiRequest('POST', `invoice/${invoice.Id}/send?sendTo=${encodeURIComponent(billEmail)}`);
+        console.log(`[qbo] Invoice ${invoice.Id} sent to ${billEmail}`);
+      } catch (sendErr) {
+        console.error(`[qbo] Invoice ${invoice.Id} created but send failed:`, sendErr.message);
+      }
+    }
   } catch (err) {
     console.error(`[qbo] Sync failed for order ${orderId}:`, err.message);
     try {


### PR DESCRIPTION
## Summary
- After creating an invoice in QBO, automatically sends it to the customer's billing email (or primary email) via the QBO send API
- Send failure is logged but doesn't fail the sync — the invoice is still created successfully

## Test plan
- [x] Create an order for an account with a BillingEmail set
- [x] Verify the invoice is created in QBO and the customer receives the email
- [x] Create an order for an account with no email — verify sync succeeds without attempting to send

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)