### PR TITLE
Add Enter key to trigger modal save action

### DIFF
--- a/public/js/core.js
+++ b/public/js/core.js
@@ -323,6 +323,19 @@ const modal = {
     };
     document.getElementById('modal-overlay').addEventListener('keydown', modal._trapFocus);
 
+    // Enter key triggers save
+    if (modal._enterSubmit) document.getElementById('modal-overlay').removeEventListener('keydown', modal._enterSubmit);
+    modal._enterSubmit = function(e) {
+      if (e.key !== 'Enter') return;
+      if (e.target.tagName === 'TEXTAREA') return;
+      if (!modal._onSubmit) return;
+      const btn = document.getElementById('modal-submit-btn');
+      if (btn.disabled) return;
+      e.preventDefault();
+      btn.click();
+    };
+    document.getElementById('modal-overlay').addEventListener('keydown', modal._enterSubmit);
+
     // Focus first input
     const first = document.querySelector('#modal-body input:not([type="hidden"]), #modal-body select, #modal-body textarea');
     if (first) first.focus();
@@ -339,6 +352,10 @@ const modal = {
     if (modal._trapFocus) {
       document.getElementById('modal-overlay').removeEventListener('keydown', modal._trapFocus);
       modal._trapFocus = null;
+    }
+    if (modal._enterSubmit) {
+      document.getElementById('modal-overlay').removeEventListener('keydown', modal._enterSubmit);
+      modal._enterSubmit = null;
     }
   },
 


### PR DESCRIPTION
## Summary
- Pressing Enter while focused on a form input now triggers the modal submit button, matching standard form UX
- Skips textareas (Enter inserts newlines), disabled buttons (prevents double-submit), and read-only modals
- Listener is cleaned up on `modal.close()`

Closes #238

## Test plan
- [x] Open a create/edit modal → press Enter on an input → saves
- [x] Focus a textarea field (Notes) → press Enter → inserts newline, does not save
- [x] @mentions dropdown → press Enter → selects mention, does not save
- [x] Confirm dialog → Enter triggers confirm
- [x] Rapid Enter presses → no double-submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)