### PR TITLE
Fix Invalid Credentials error for staff email sending

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -3,6 +3,7 @@
 const express  = require('express');
 const passport = require('passport');
 const { Strategy: GoogleStrategy } = require('passport-google-oauth20');
+const { getRow, addRow, updateRow } = require('../db');
 
 const router = express.Router();
 
@@ -34,6 +35,24 @@ if (oauthConfigured) {
         }
       }
 
+      // Google only returns a refreshToken on the initial consent.
+      // Persist it so subsequent logins (which skip consent) can reuse it.
+      const settingsKey = `google_refresh_token:${profile.id}`;
+      let effectiveRefreshToken = refreshToken || '';
+      if (effectiveRefreshToken) {
+        // Save new refresh token
+        const existing = getRow('SETTINGS', settingsKey);
+        if (existing) {
+          updateRow('SETTINGS', settingsKey, { Value: effectiveRefreshToken, UpdatedAt: new Date().toISOString() });
+        } else {
+          addRow('SETTINGS', { ID: settingsKey, Key: settingsKey, Value: effectiveRefreshToken, UpdatedAt: new Date().toISOString() });
+        }
+      } else {
+        // Load previously saved refresh token
+        const saved = getRow('SETTINGS', settingsKey);
+        if (saved && saved.Value) effectiveRefreshToken = saved.Value;
+      }
+
       // Store only the fields we actually need in the session.
       const user = {
         id:           profile.id,
@@ -41,7 +60,7 @@ if (oauthConfigured) {
         email:        (profile.emails && profile.emails[0] && profile.emails[0].value) || '',
         photo:        (profile.photos && profile.photos[0] && profile.photos[0].value) || '',
         accessToken:  accessToken  || '',
-        refreshToken: refreshToken || '',
+        refreshToken: effectiveRefreshToken,
       };
 
       return done(null, user);


### PR DESCRIPTION
## Summary
- Google only returns a refresh token on the **initial** OAuth consent grant. Subsequent logins with `prompt: 'select_account'` skip the consent screen and return no refresh token.
- When the short-lived access token expires (~1 hour) and there's no refresh token to renew it, the Gmail API returns "Invalid Credentials"
- Fix: persist refresh tokens in the Settings table (keyed by Google user ID) so they survive across logins, session expiration, and server restarts

## Immediate workaround for Alex
Until this is deployed, have Alex go to [Google Account → Third-party apps](https://myaccount.google.com/permissions), revoke this app, then log in again. This forces fresh consent which returns a new refresh token.

## Test plan
- [x] Log in → verify refresh token is saved to Settings table
- [x] Log out and back in → verify saved refresh token is loaded (Google won't return a new one)
- [x] Send email after login → succeeds
- [x] Wait >1 hour (or manually expire token) → send email → still succeeds via auto-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)