### PR TITLE
Add variation notes to product formats

### DIFF
--- a/db.js
+++ b/db.js
@@ -31,7 +31,7 @@ const TABLES = {
 // On startup, any missing columns are automatically added (migration-safe).
 const HEADERS = {
   PRODUCTS:  ['ID', 'Name', 'Style', 'ABV', 'Format', 'PricePerUnit', 'Notes', 'CreatedAt'],
-  INVENTORY: ['ID', 'Name', 'Location', 'Style', 'ABV', 'Format', 'Units', 'PricePerUnit', 'LowStockThreshold', 'Notes', 'LastUpdated', 'ProductID', 'ProductName'],
+  INVENTORY: ['ID', 'Name', 'Location', 'Style', 'ABV', 'Format', 'VariationNote', 'Units', 'PricePerUnit', 'LowStockThreshold', 'Notes', 'LastUpdated', 'ProductID', 'ProductName'],
   ACCOUNTS:  ['ID', 'Name', 'Type', 'Tags', 'ContactName', 'Email', 'AdditionalEmails', 'Phone', 'PreferredMethod', 'BillingContactName', 'BillingEmail', 'BillingPhone', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'ChargeDeposits', 'Taxable', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'QboCustomerId', 'CreatedAt'],
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
   REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
@@ -42,7 +42,7 @@ const HEADERS = {
   KEG_TRACKING:    ['ID', 'AccountID', 'AccountName', 'OrderID', 'InventoryID', 'ProductName', 'Format', 'Quantity', 'DepositPerUnit', 'DepositTotal', 'DepositRefunded', 'DeliveredDate', 'ReturnedDate', 'ReturnedQuantity', 'Notes', 'CreatedAt'],
   TAP_HANDLES:     ['ID', 'AccountID', 'AccountName', 'Quantity', 'DeployedDate', 'CollectedDate', 'CollectedQuantity', 'Notes', 'CreatedAt'],
   EMAIL_LOG:       ['ID', 'SenderName', 'SenderEmail', 'Recipients', 'Subject', 'Body', 'Type', 'AccountIDs', 'Status', 'Error', 'CreatedAt'],
-  ORDER_ITEMS:     ['ID', 'OrderID', 'InventoryID', 'ProductName', 'Format', 'Quantity', 'UnitPrice', 'LineTotal', 'CreatedAt'],
+  ORDER_ITEMS:     ['ID', 'OrderID', 'InventoryID', 'ProductName', 'Format', 'VariationNote', 'Quantity', 'UnitPrice', 'LineTotal', 'CreatedAt'],
   NOTIFICATIONS:   ['ID', 'Type', 'Channel', 'RecipientStaffID', 'RecipientName', 'RecipientEmail', 'SenderName', 'SenderEmail', 'EntityType', 'EntityID', 'EntityName', 'Message', 'Status', 'Error', 'CreatedAt'],
   ACCOUNT_CREDITS: ['ID', 'AccountID', 'AccountName', 'Type', 'Amount', 'OrderID', 'Reason', 'Notes', 'CreatedAt'],
 };

--- a/public/js/core.js
+++ b/public/js/core.js
@@ -122,6 +122,12 @@ function _paginationReadHash() {
 
 // ── Utilities ────────────────────────────────────────────────────
 
+function fmtLabel(item) {
+  const fmt = item.Format || item.format || '';
+  const note = item.VariationNote || item.variationNote || '';
+  return [fmt, note].filter(Boolean).join(' ');
+}
+
 function esc(str) {
   return String(str || '')
     .replace(/&/g, '&amp;')

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -59,7 +59,7 @@ async function loadDashboard() {
     : dash.lowStockItems.map(i => `
         <li class="clickable" onclick="navigate('inventory')">
           <span class="dash-label">${esc(i.Name)}</span>
-          <span class="dash-meta">${esc(i.Units)} left (${esc(i.Format || 'units')})</span>
+          <span class="dash-meta">${esc(i.Units)} left (${esc(fmtLabel(i) || 'units')})</span>
           <span class="badge badge-low-stock">Low</span>
         </li>`).join('');
 

--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -103,7 +103,7 @@ function renderInventory() {
                 <td class="fw-600">${esc(item.Name)}</td>
                 <td>${esc(item.Style)}</td>
                 <td>${item.ABV ? esc(item.ABV) + '%' : '—'}</td>
-                <td>${esc(item.Format) || '—'}</td>
+                <td>${esc(fmtLabel(item)) || '—'}</td>
                 <td>${esc(item.Units)}</td>
                 <td>${item.PricePerUnit ? '$' + esc(item.PricePerUnit) : '—'}</td>
                 <td><span class="badge ${low ? 'badge-low-stock' : 'badge-ok-stock'}">${out ? 'Out' : low ? 'Low' : 'OK'}</span></td>
@@ -133,22 +133,23 @@ async function openAddInventory() {
     api.get('/api/products'),
   ]);
 
-  // Build set of existing combos at this location: "ProductID|||Format"
+  // Build set of existing combos at this location: "ProductID|||Format|||VariationNote"
   const existingCombos = new Set(
-    locationInventory.map(i => `${i.ProductID}|||${i.Format || ''}`).filter(k => k.startsWith(''))
+    locationInventory.map(i => `${i.ProductID}|||${i.Format || ''}|||${i.VariationNote || ''}`)
   );
 
   // Build all globally known combos from inventory (deduplicated)
-  const globalCombos = new Map(); // key → { productId, productName, format, pricePerUnit }
+  const globalCombos = new Map(); // key → { productId, productName, format, variationNote, pricePerUnit }
   for (const inv of allInventory) {
     if (!inv.ProductID) continue;
-    const key = `${inv.ProductID}|||${inv.Format || ''}`;
+    const key = `${inv.ProductID}|||${inv.Format || ''}|||${inv.VariationNote || ''}`;
     if (!globalCombos.has(key)) {
       const product = allProducts.find(p => p.ID === inv.ProductID);
       globalCombos.set(key, {
         productId: inv.ProductID,
         productName: inv.ProductName || (product ? product.Name : '') || inv.Name || '',
         format: inv.Format || '',
+        variationNote: inv.VariationNote || '',
         pricePerUnit: inv.PricePerUnit || '',
       });
     }
@@ -169,8 +170,10 @@ async function openAddInventory() {
 
   // Sort alphabetically by display label
   available.sort((a, b) => {
-    const la = a.format ? `${a.productName} (${a.format})` : a.productName;
-    const lb = b.format ? `${b.productName} (${b.format})` : b.productName;
+    const fmtA = [a.format, a.variationNote].filter(Boolean).join(' ');
+    const fmtB = [b.format, b.variationNote].filter(Boolean).join(' ');
+    const la = fmtA ? `${a.productName} (${fmtA})` : a.productName;
+    const lb = fmtB ? `${b.productName} (${fmtB})` : b.productName;
     return la.localeCompare(lb);
   });
 
@@ -183,7 +186,8 @@ async function openAddInventory() {
       <select class="form-control" id="f-product-combo">
         <option value="">-- Select Product --</option>
         ${available.map(c => {
-          const label = c.format ? `${c.productName} (${c.format})` : c.productName;
+          const fmtDisplay = [c.format, c.variationNote].filter(Boolean).join(' ');
+          const label = fmtDisplay ? `${c.productName} (${fmtDisplay})` : c.productName;
           return `<option value="${esc(c.key)}">${esc(label)}</option>`;
         }).join('')}
       </select>
@@ -200,6 +204,7 @@ async function openAddInventory() {
       ProductID: combo.productId,
       Location: state.location,
       Format: combo.format,
+      VariationNote: combo.variationNote,
       PricePerUnit: combo.pricePerUnit,
       LowStockThreshold: val('f-threshold'),
     });
@@ -212,7 +217,7 @@ async function openAddInventory() {
 function openEditInventory(id) {
   const item = state.inventory.find(i => i.ID === id);
   if (!item) return;
-  const label = item.Format ? `${item.Name} — ${item.Format}` : item.Name;
+  const label = fmtLabel(item) ? `${item.Name} — ${fmtLabel(item)}` : item.Name;
   modal.open('Edit Stock Threshold', `
     <p class="text-muted text-sm" style="margin-bottom:16px">
       <strong>${esc(label)}</strong> at ${esc(state.location)}
@@ -246,7 +251,7 @@ async function deleteInventory(id, name) {
 function openAdjustInventory(id) {
   const item = state.inventory.find(i => i.ID === id);
   if (!item) return;
-  const label = item.Format ? `${item.Name} — ${item.Format}` : item.Name;
+  const label = fmtLabel(item) ? `${item.Name} — ${fmtLabel(item)}` : item.Name;
   modal.open('Adjust Stock', `
     <p class="text-muted text-sm" style="margin-bottom:16px">
       <strong>${esc(label)}</strong> &mdash; current stock: <strong>${esc(item.Units)} units</strong>

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -462,7 +462,8 @@ function parseRequestedProducts(productsStr, inventoryItems) {
     const rest = part.slice(qtyMatch[0].length).trim();
     // Match against inventory by reconstructing "Name (Format)" as collectOrderProducts does
     const item = inventoryItems.find(i => {
-      const label = i.Format ? `${i.Name} (${i.Format})` : i.Name;
+      const fl = fmtLabel(i);
+      const label = fl ? `${i.Name} (${fl})` : i.Name;
       return rest === label || rest === i.Name;
     });
     if (item) quantities[item.ID] = qty;
@@ -486,7 +487,7 @@ function productPickerHtml(items, quantities = {}, readOnly = false) {
       const qty = quantities[item.ID] || 0;
       return `<tr>
         <td class="fw-600">${esc(item.Name)}</td>
-        <td class="text-sm">${esc(item.Format) || '—'}</td>
+        <td class="text-sm">${esc(fmtLabel(item)) || '—'}</td>
         <td class="text-sm">${price ? '$' + price.toFixed(2) : '—'}</td>
         <td class="text-sm">${qty}</td>
       </tr>`;
@@ -523,7 +524,8 @@ function _buildProductOptions(selectedId) {
   if (inStock.length) {
     html += '<optgroup label="In Stock">';
     for (const item of inStock) {
-      const label = item.Format ? `${item.Name} (${item.Format})` : item.Name;
+      const fl = fmtLabel(item);
+      const label = fl ? `${item.Name} (${fl})` : item.Name;
       const sel = item.ID === selectedId ? ' selected' : '';
       html += `<option value="${esc(item.ID)}"${sel}>${esc(label)} [${item.Units}]</option>`;
     }
@@ -532,7 +534,8 @@ function _buildProductOptions(selectedId) {
   if (outOfStock.length) {
     html += '<optgroup label="Out of Stock">';
     for (const item of outOfStock) {
-      const label = item.Format ? `${item.Name} (${item.Format})` : item.Name;
+      const fl = fmtLabel(item);
+      const label = fl ? `${item.Name} (${fl})` : item.Name;
       const sel = item.ID === selectedId ? ' selected' : '';
       html += `<option value="${esc(item.ID)}"${sel}>${esc(label)}</option>`;
     }
@@ -657,7 +660,7 @@ function orderItemsReadOnlyHtml(orderItems) {
     const isNeg = total < 0;
     return `<tr>
       <td class="fw-600">${esc(item.ProductName || '—')}</td>
-      <td class="text-sm">${esc(item.Format) || '—'}</td>
+      <td class="text-sm">${esc(fmtLabel(item)) || '—'}</td>
       <td class="text-sm">${qty}</td>
       <td class="text-sm"${isNeg ? ' style="color:#2e7d32"' : ''}>${price ? '$' + price.toFixed(2) : '—'}</td>
       <td class="text-sm"${isNeg ? ' style="color:#2e7d32"' : ''}>${total ? '$' + total.toFixed(2) : '—'}</td>
@@ -750,7 +753,8 @@ function collectOrderProducts() {
     if (qty > 0) {
       const item = _orderFormInventory.find(i => i.ID === inventoryId);
       if (!item) continue;
-      const label = item.Format ? `${item.Name} (${item.Format})` : item.Name;
+      const fl = fmtLabel(item);
+      const label = fl ? `${item.Name} (${fl})` : item.Name;
       selected.push(`${qty}x ${label}`);
     }
   }
@@ -768,6 +772,7 @@ function collectOrderItems() {
         InventoryID: item.ID,
         ProductName: item.Name,
         Format: item.Format || '',
+        VariationNote: item.VariationNote || '',
         Quantity: qty,
         UnitPrice: price.toFixed(2),
         LineTotal: (qty * price).toFixed(2),
@@ -1359,7 +1364,7 @@ async function openDeliveryConfirmModal(orderId, order, onComplete) {
     const hidden = group === 'other';
     return `<tr data-stock="${group}"${hidden ? ' style="display:none"' : ''}>
             <td class="fw-600">${esc(item.Name)}</td>
-            <td class="text-sm">${esc(item.Format) || '—'}</td>
+            <td class="text-sm">${esc(fmtLabel(item)) || '—'}</td>
             <td class="text-sm">${esc(item.Units)}</td>
             <td><input class="form-control" type="number" min="0" max="${stock}" value="${prefill}"
                  id="deliv-qty-${item.ID}" style="width:80px" /></td>
@@ -1404,7 +1409,7 @@ async function openDeliveryConfirmModal(orderId, order, onComplete) {
             const depPerUnit = parseFloat(k.DepositPerUnit) || 0;
             return `<tr>
               <td class="fw-600">${esc(k.ProductName)}</td>
-              <td class="text-sm">${esc(k.Format) || '—'}</td>
+              <td class="text-sm">${esc(fmtLabel(k)) || '—'}</td>
               <td class="text-sm">${outstanding}</td>
               <td class="text-sm">${depPerUnit > 0 ? '$' + depPerUnit.toFixed(2) + '/keg' : '—'}</td>
               <td><input class="form-control" type="number" min="0" max="${outstanding}" value="0"

--- a/public/js/products.js
+++ b/public/js/products.js
@@ -3,7 +3,7 @@
 // ── Products View (location-independent catalog) ─────────────────
 
 let _productsCache = [];
-let _productFormats = {}; // { productId: [{format, pricePerUnit}] }
+let _productFormats = {}; // { productId: [{format, variationNote, pricePerUnit}] }
 let _prodSort = { col: 'Name', dir: 'asc' };
 let _variationCounter = 0;
 
@@ -31,7 +31,7 @@ function productForm(product = {}) {
     <hr class="form-divider" />
     <div class="form-section-title">Format Variations</div>
     <div id="variations-wrap"></div>
-    <button type="button" class="btn btn-ghost btn-sm" onclick="addVariationRow('', '')" style="margin-top:4px">+ Add Format</button>
+    <button type="button" class="btn btn-ghost btn-sm" onclick="addVariationRow('', '', '')" style="margin-top:4px">+ Add Format</button>
     <hr class="form-divider" />
     <div class="form-group">
       <label>Notes</label>
@@ -39,7 +39,7 @@ function productForm(product = {}) {
     </div>`;
 }
 
-function addVariationRow(format, price) {
+function addVariationRow(format, price, note) {
   const wrap = document.getElementById('variations-wrap');
   if (!wrap) return;
   const id = _variationCounter++;
@@ -54,6 +54,10 @@ function addVariationRow(format, price) {
         <option value="">-- Select --</option>
         ${FORMATS.map(f => `<option value="${f}" ${format === f ? 'selected' : ''}>${f}</option>`).join('')}
       </select>
+    </div>
+    <div class="form-group" style="flex:1;margin-bottom:0">
+      <label>Note</label>
+      <input class="form-control" id="var-note-${id}" value="${esc(note || '')}" placeholder="e.g. Wholesale, Fruited" />
     </div>
     <div class="form-group" style="flex:1;margin-bottom:0">
       <label>Price ($)</label>
@@ -78,9 +82,10 @@ function collectVariations() {
   const variations = [];
   rows.forEach(row => {
     const select = row.querySelector('select');
-    const input = row.querySelector('input[type="number"]');
-    if (select && input) {
-      variations.push({ format: select.value, pricePerUnit: input.value });
+    const noteInput = row.querySelector('input[type="text"], input:not([type])');
+    const priceInput = row.querySelector('input[type="number"]');
+    if (select && priceInput) {
+      variations.push({ format: select.value, variationNote: noteInput ? noteInput.value.trim() : '', pricePerUnit: priceInput.value });
     }
   });
   return variations;
@@ -101,10 +106,11 @@ async function loadProducts(preservePage = false) {
     if (!inv.ProductID) continue;
     if (!_productFormats[inv.ProductID]) _productFormats[inv.ProductID] = [];
     const fmt = inv.Format || '';
+    const note = inv.VariationNote || '';
     const price = inv.PricePerUnit || '';
-    // Deduplicate by format
-    if (!_productFormats[inv.ProductID].some(v => v.format === fmt)) {
-      _productFormats[inv.ProductID].push({ format: fmt, pricePerUnit: price });
+    // Deduplicate by format + variationNote
+    if (!_productFormats[inv.ProductID].some(v => v.format === fmt && v.variationNote === note)) {
+      _productFormats[inv.ProductID].push({ format: fmt, variationNote: note, pricePerUnit: price });
     }
   }
 
@@ -126,7 +132,7 @@ function formatBadges(productId) {
   const vars = _productFormats[productId] || [];
   if (vars.length === 0) return '<span class="text-muted">—</span>';
   return vars.map(v => {
-    const fmt = v.format || 'No format';
+    const fmt = fmtLabel(v) || 'No format';
     const price = v.pricePerUnit ? `$${parseFloat(v.pricePerUnit).toFixed(2)}` : '';
     const label = price ? `${fmt} — ${price}` : fmt;
     return `<span class="badge badge-neutral" style="margin:2px 4px 2px 0">${esc(label)}</span>`;
@@ -236,7 +242,7 @@ function openAddProduct() {
     loadProducts();
   });
   // Add one blank variation row after modal opens
-  setTimeout(() => addVariationRow('', ''), 0);
+  setTimeout(() => addVariationRow('', '', ''), 0);
 }
 
 async function openEditProduct(id) {
@@ -264,35 +270,37 @@ async function openEditProduct(id) {
 
     // Diff variations: add new ones, remove deleted ones
     const newVars = collectVariations();
-    const oldFormats = new Set(existingVars.map(v => v.format));
-    const newFormats = new Set(newVars.map(v => v.format));
+    const varKey = v => `${v.format}|||${v.variationNote || ''}`;
+    const oldKeys = new Set(existingVars.map(varKey));
+    const newKeys = new Set(newVars.map(varKey));
 
     // Add new variations
     for (const v of newVars) {
-      if (!oldFormats.has(v.format)) {
+      if (!oldKeys.has(varKey(v))) {
         try {
           await api.post(`/api/products/${id}/variations`, v);
         } catch (err) {
-          toast(`Could not add format "${v.format}": ${err.message}`, 'error');
+          toast(`Could not add format "${fmtLabel(v)}": ${err.message}`, 'error');
         }
       }
     }
 
     // Remove deleted variations
     for (const v of existingVars) {
-      if (!newFormats.has(v.format)) {
+      if (!newKeys.has(varKey(v))) {
         try {
-          await api.del(`/api/products/${id}/variations/${encodeURIComponent(v.format)}`);
+          const noteParam = v.variationNote ? `?note=${encodeURIComponent(v.variationNote)}` : '';
+          await api.del(`/api/products/${id}/variations/${encodeURIComponent(v.format)}${noteParam}`);
         } catch (err) {
-          toast(`Could not remove format "${v.format}": ${err.message}`, 'error');
+          toast(`Could not remove format "${fmtLabel(v)}": ${err.message}`, 'error');
         }
       }
     }
 
     // Update price changes on existing variations (update inventory rows directly)
     for (const v of newVars) {
-      if (oldFormats.has(v.format)) {
-        const old = existingVars.find(ev => ev.format === v.format);
+      if (oldKeys.has(varKey(v))) {
+        const old = existingVars.find(ev => varKey(ev) === varKey(v));
         if (old && old.pricePerUnit !== v.pricePerUnit) {
           // Update price on all inventory rows for this product+format
           for (const loc of old.locations) {
@@ -312,10 +320,10 @@ async function openEditProduct(id) {
   // Populate variation rows after modal opens
   setTimeout(() => {
     if (existingVars.length === 0) {
-      addVariationRow('', '');
+      addVariationRow('', '', '');
     } else {
       for (const v of existingVars) {
-        addVariationRow(v.format, v.pricePerUnit);
+        addVariationRow(v.format, v.pricePerUnit, v.variationNote);
       }
     }
   }, 0);

--- a/routes/inventory.js
+++ b/routes/inventory.js
@@ -20,6 +20,7 @@ async function enrichInventory(items) {
       Style: product.Style || inv.Style || '',
       ABV: product.ABV || inv.ABV || '',
       Format: inv.Format || product.Format || '',
+      VariationNote: inv.VariationNote || '',
       PricePerUnit: inv.PricePerUnit || product.PricePerUnit || '',
     };
   });
@@ -71,9 +72,10 @@ router.post('/', async (req, res) => {
     const product = products.find(p => p.ID === ProductID);
     if (!product) return res.status(404).json({ error: 'Product not found' });
 
-    // Check if already exists at this location (Format-aware)
+    // Check if already exists at this location (Format+VariationNote-aware)
+    const { VariationNote } = req.body;
     const inventory = await getAllRows('INVENTORY');
-    const existing = inventory.find(i => i.ProductID === ProductID && i.Location === Location && (i.Format || '') === (Format || ''));
+    const existing = inventory.find(i => i.ProductID === ProductID && i.Location === Location && (i.Format || '') === (Format || '') && (i.VariationNote || '') === (VariationNote || ''));
     if (existing) return res.status(400).json({ error: 'Product already exists at this location' });
 
     const item = {

--- a/routes/order-items.js
+++ b/routes/order-items.js
@@ -39,7 +39,7 @@ router.get('/counts', async (req, res) => {
 // POST /api/order-items — create a single item
 router.post('/', async (req, res) => {
   try {
-    const { OrderID, InventoryID, ProductName, Format, Quantity, UnitPrice, LineTotal } = req.body;
+    const { OrderID, InventoryID, ProductName, Format, VariationNote, Quantity, UnitPrice, LineTotal } = req.body;
     if (!OrderID) return res.status(400).json({ error: 'OrderID is required' });
 
     const item = {
@@ -48,6 +48,7 @@ router.post('/', async (req, res) => {
       InventoryID: InventoryID || '',
       ProductName: ProductName || '',
       Format: Format || '',
+      VariationNote: VariationNote || '',
       Quantity: Quantity || '0',
       UnitPrice: UnitPrice || '0',
       LineTotal: LineTotal || '0',
@@ -78,6 +79,7 @@ router.post('/bulk', async (req, res) => {
         InventoryID: raw.InventoryID || '',
         ProductName: raw.ProductName || '',
         Format: raw.Format || '',
+        VariationNote: raw.VariationNote || '',
         Quantity: String(raw.Quantity || '0'),
         UnitPrice: String(raw.UnitPrice || '0'),
         LineTotal: String(raw.LineTotal || '0'),

--- a/routes/products.js
+++ b/routes/products.js
@@ -59,6 +59,7 @@ router.post('/', async (req, res) => {
           ProductID: product.ID,
           ProductName: product.Name,
           Format: v.format || '',
+          VariationNote: v.variationNote || '',
           PricePerUnit: v.pricePerUnit || '',
           Location: loc,
           Units: '0',
@@ -116,14 +117,16 @@ router.get('/:id/variations', async (req, res) => {
     const inventory = await getAllRows('INVENTORY');
     const related = inventory.filter(i => i.ProductID === req.params.id);
 
-    // Deduplicate by Format
+    // Deduplicate by Format + VariationNote
     const formatMap = new Map();
     for (const inv of related) {
       const fmt = inv.Format || '';
-      if (!formatMap.has(fmt)) {
-        formatMap.set(fmt, { format: fmt, pricePerUnit: inv.PricePerUnit || '', locations: [] });
+      const note = inv.VariationNote || '';
+      const key = `${fmt}|||${note}`;
+      if (!formatMap.has(key)) {
+        formatMap.set(key, { format: fmt, variationNote: note, pricePerUnit: inv.PricePerUnit || '', locations: [] });
       }
-      formatMap.get(fmt).locations.push({ location: inv.Location, inventoryId: inv.ID, units: inv.Units || '0' });
+      formatMap.get(key).locations.push({ location: inv.Location, inventoryId: inv.ID, units: inv.Units || '0' });
     }
 
     res.json([...formatMap.values()]);
@@ -136,15 +139,15 @@ router.get('/:id/variations', async (req, res) => {
 // POST /api/products/:id/variations — add a new format variation
 router.post('/:id/variations', async (req, res) => {
   try {
-    const { format, pricePerUnit } = req.body;
+    const { format, pricePerUnit, variationNote } = req.body;
     const products = await getAllRows('PRODUCTS');
     const product = products.find(p => p.ID === req.params.id);
     if (!product) return res.status(404).json({ error: 'Product not found' });
 
-    // Check for duplicate format
+    // Check for duplicate format + variationNote
     const inventory = await getAllRows('INVENTORY');
-    const existing = inventory.find(i => i.ProductID === req.params.id && (i.Format || '') === (format || ''));
-    if (existing) return res.status(400).json({ error: 'This format already exists for this product' });
+    const existing = inventory.find(i => i.ProductID === req.params.id && (i.Format || '') === (format || '') && (i.VariationNote || '') === (variationNote || ''));
+    if (existing) return res.status(400).json({ error: 'This format variation already exists for this product' });
 
     // Read locations
     const settings = await getAllRows('SETTINGS');
@@ -162,6 +165,7 @@ router.post('/:id/variations', async (req, res) => {
         ProductID: req.params.id,
         ProductName: product.Name,
         Format: format || '',
+        VariationNote: variationNote || '',
         PricePerUnit: pricePerUnit || '',
         Location: loc,
         Units: '0',
@@ -172,7 +176,7 @@ router.post('/:id/variations', async (req, res) => {
       inventoryRows.push(inv);
     }
 
-    res.status(201).json({ format: format || '', pricePerUnit: pricePerUnit || '', inventoryRows });
+    res.status(201).json({ format: format || '', variationNote: variationNote || '', pricePerUnit: pricePerUnit || '', inventoryRows });
   } catch (err) {
     console.error(`[products] ${err.message}`);
     res.status(500).json({ error: 'Internal server error' });
@@ -183,8 +187,9 @@ router.post('/:id/variations', async (req, res) => {
 router.delete('/:id/variations/:format', async (req, res) => {
   try {
     const format = decodeURIComponent(req.params.format);
+    const note = req.query.note != null ? decodeURIComponent(req.query.note) : '';
     const inventory = await getAllRows('INVENTORY');
-    const related = inventory.filter(i => i.ProductID === req.params.id && (i.Format || '') === format);
+    const related = inventory.filter(i => i.ProductID === req.params.id && (i.Format || '') === format && (i.VariationNote || '') === note);
 
     if (related.length === 0) return res.status(404).json({ error: 'Variation not found' });
 

--- a/routes/reports.js
+++ b/routes/reports.js
@@ -92,8 +92,10 @@ router.get('/', async (req, res) => {
     const salesItems = orderItems.filter(i => salesOrderIds.has(i.OrderID));
 
     for (const item of salesItems) {
-      const key = `${item.ProductName || ''}|||${item.Format || ''}`;
-      if (!productAgg[key]) productAgg[key] = { productName: item.ProductName || '', format: item.Format || '', quantitySold: 0, revenue: 0, orderIds: new Set() };
+      const note = item.VariationNote || '';
+      const displayFormat = [item.Format || '', note].filter(Boolean).join(' ');
+      const key = `${item.ProductName || ''}|||${displayFormat}`;
+      if (!productAgg[key]) productAgg[key] = { productName: item.ProductName || '', format: displayFormat, quantitySold: 0, revenue: 0, orderIds: new Set() };
       const a = productAgg[key];
       a.quantitySold += parseInt(item.Quantity || 0);
       a.revenue += parseFloat(item.LineTotal || 0);

--- a/routes/stock-movements.js
+++ b/routes/stock-movements.js
@@ -50,11 +50,13 @@ router.post('/bulk', async (req, res) => {
       const product = productMap[inv.ProductID] || {};
       const invName = inv.ProductName || product.Name || inv.Name || '';
       const invFormat = inv.Format || product.Format || '';
+      const invNote = inv.VariationNote || '';
+      const displayFormat = [invFormat, invNote].filter(Boolean).join(' ');
 
       const movement = {
         ID:            uuidv4(),
         InventoryID:   item.inventoryId,
-        InventoryName: [invName, invFormat].filter(Boolean).join(' — '),
+        InventoryName: [invName, displayFormat].filter(Boolean).join(' — '),
         OrderID:       orderId,
         Type:          'sale',
         Quantity:      String(-qty),
@@ -148,6 +150,8 @@ router.post('/', async (req, res) => {
     const product = productMap[inv.ProductID] || {};
     const invName = inv.ProductName || product.Name || inv.Name || '';
     const invFormat = inv.Format || product.Format || '';
+    const invNote = inv.VariationNote || '';
+    const displayFormat = [invFormat, invNote].filter(Boolean).join(' ');
 
     // received = add stock; write-off and adjustment = remove stock
     const delta     = type === 'received' ? qty : -qty;
@@ -157,7 +161,7 @@ router.post('/', async (req, res) => {
     const movement = {
       ID:            uuidv4(),
       InventoryID:   inventoryId,
-      InventoryName: [invName, invFormat].filter(Boolean).join(' — '),
+      InventoryName: [invName, displayFormat].filter(Boolean).join(' — '),
       OrderID:       '',
       Type:          type,
       Quantity:      String(delta),


### PR DESCRIPTION
## Summary
- Adds an optional `VariationNote` text field to product format variations, allowing the same format to exist multiple times with different qualifiers (e.g. "1/6 Keg" vs "1/6 Keg Wholesale" at different prices)
- New `fmtLabel()` helper combines Format + VariationNote for display throughout the app
- Uniqueness key for inventory rows is now ProductID + Location + Format + VariationNote

## Changes
- **db.js**: Added `VariationNote` column to INVENTORY and ORDER_ITEMS HEADERS (auto-migrated)
- **routes/products.js**: Variation CRUD uses Format+VariationNote for dedup, creation, and deletion (`?note=` query param)
- **routes/inventory.js**: Enrichment passes through VariationNote; uniqueness check includes it
- **routes/stock-movements.js**: InventoryName display includes variation note; keg detection stays on base Format
- **routes/order-items.js**: Stores VariationNote on single and bulk creation
- **routes/reports.js**: Aggregation key includes VariationNote so variations report separately
- **public/js/core.js**: `fmtLabel(item)` utility
- **public/js/products.js**: Variation form has Note input; badges, diff logic, and dedup all use compound keys
- **public/js/orders.js**: Product picker labels, read-only tables, delivery confirmation all use `fmtLabel()`
- **public/js/inventory.js**: Table, modals, and "Add to Location" dialog use `fmtLabel()` and include VariationNote in combo keys
- **public/js/dashboard.js**: Low-stock display uses `fmtLabel()`

## Test plan
- [ ] Add product with two "1/6 Keg" variations: one blank note, one "Wholesale" — both created
- [ ] Product list badges show "1/6 Keg — $80" and "1/6 Keg Wholesale — $55"
- [ ] Edit product — notes populated, can be changed
- [ ] Delete a variation with a note — only that variation removed
- [ ] Orders: product picker shows "Beer Name (1/6 Keg Wholesale)"
- [ ] Inventory table shows variation note alongside format
- [ ] Keg deposit tracking still works (uses base Format, not note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)