### PR TITLE
Fix mobile portrait layout and sidebar backdrop

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1206,7 +1206,18 @@ tr.row-completed button {
 }
 
 .sidebar-backdrop {
-  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 99;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+.sidebar-backdrop.open {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 /* ── Bulk Actions Bar ──────────────────────────────────── */
@@ -1341,7 +1352,12 @@ th input[type="checkbox"] {
 
 @media (max-width: 640px) {
   /* ── Prevent content from widening the viewport ── */
-  html {
+  html, body {
+    overflow-x: hidden;
+  }
+
+  .layout {
+    max-width: 100vw;
     overflow-x: hidden;
   }
 
@@ -1358,18 +1374,6 @@ th input[type="checkbox"] {
 
   .sidebar.open {
     transform: translateX(0);
-  }
-
-  /* ── Backdrop overlay when sidebar is open ── */
-  .sidebar-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.4);
-    z-index: 99;
-  }
-
-  .sidebar-backdrop.open {
-    display: block;
   }
 
   /* ── Main content: remove sidebar offset ── */


### PR DESCRIPTION
## Summary
Follows up on #250 (merged) with additional fixes for mobile portrait issues:

- **Sidebar backdrop**: Moved backdrop styles out of the media query and switched from `display: none/block` to `opacity`/`pointer-events` toggling. The previous approach broke when the user pinch-zoomed, causing the backdrop to not appear when opening the sidebar.
- **Stronger overflow prevention**: Added `overflow-x: hidden` to both `html` and `body`, plus `max-width: 100vw` and `overflow-x: hidden` on `.layout` to more reliably prevent content from widening the viewport on iOS Safari.

Fixes #249

## Test plan
- [ ] Open dashboard on mobile portrait — content should fit without needing to zoom out
- [ ] Open sidebar via hamburger — dark backdrop should appear behind the sidebar
- [ ] Tap backdrop to close sidebar — sidebar and backdrop should both dismiss
- [ ] Pinch-zoom out, then open sidebar — backdrop should still appear
- [ ] Verify desktop layout is unaffected (sidebar always visible, no backdrop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)