### PR TITLE
Enable @mentions in stock movement notes

### DIFF
--- a/public/js/core.js
+++ b/public/js/core.js
@@ -348,7 +348,7 @@ const modal = {
     document.getElementById('modal-cancel-btn').style.display = '';
     document.getElementById('modal-cancel-btn').textContent = 'Cancel';
     modal._onSubmit = null;
-    if (typeof destroyMentions === 'function') destroyMentions('f-notes');
+    if (typeof destroyAllMentions === 'function') destroyAllMentions();
     if (modal._trapFocus) {
       document.getElementById('modal-overlay').removeEventListener('keydown', modal._trapFocus);
       modal._trapFocus = null;

--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -287,6 +287,7 @@ function openAdjustInventory(id) {
     toast(`Stock adjusted — new total: ${result.newUnits} units`);
     loadInventory();
   });
+  setTimeout(() => initMentions('f-adj-notes'), 0);
 }
 
 async function openInventoryHistory(id) {

--- a/public/js/mentions.js
+++ b/public/js/mentions.js
@@ -172,3 +172,7 @@ function destroyMentions(inputId) {
   if (inst.dropdown.parentNode) inst.dropdown.parentNode.removeChild(inst.dropdown);
   delete _mentionInstances[inputId];
 }
+
+function destroyAllMentions() {
+  for (const id of Object.keys(_mentionInstances)) destroyMentions(id);
+}

--- a/routes/stock-movements.js
+++ b/routes/stock-movements.js
@@ -3,6 +3,7 @@
 const express = require('express');
 const { v4: uuidv4 } = require('uuid');
 const { getAllRows, addRow, updateRow } = require('../db');
+const { processMentions } = require('../lib/notifications');
 
 const router = express.Router();
 
@@ -172,6 +173,14 @@ router.post('/', async (req, res) => {
       Units:       String(newUnits),
       LastUpdated: movDate,
     });
+
+    const baseUrl = `${req.protocol}://${req.get('host')}`;
+    processMentions({
+      newText: notes || '', oldText: '',
+      entityType: 'stock movement', entityName: movement.InventoryName,
+      entityId: movement.ID, accountId: '',
+      user: req.user, mentionerName: req.user?.name || '', baseUrl,
+    }).catch(err => console.error('[notifications]', err));
 
     res.json({ movement, newUnits });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Add `initMentions('f-adj-notes')` to the adjust-stock modal so the @mention autocomplete works
- Import `processMentions` in the stock-movements route and call it after saving, so mentioned staff get notified
- Fix `modal.close()` to call `destroyAllMentions()` instead of only `destroyMentions('f-notes')`, cleaning up all active mention instances regardless of field ID

Fixes #253

## Test plan
- [x] Open Adjust Stock modal — type `@` in Notes field, staff autocomplete should appear
- [x] Complete an adjustment with an @mention — mentioned staff should receive a notification
- [x] Verify other @mention fields (todos, outreach, orders) still work correctly
- [x] Verify modal close properly cleans up mention dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)