### PR TITLE
Add staff location assignment

### DIFF
--- a/db.js
+++ b/db.js
@@ -36,7 +36,7 @@ const HEADERS = {
   ACCOUNTS:  ['ID', 'Name', 'Type', 'Tags', 'ContactName', 'Email', 'AdditionalEmails', 'Phone', 'PreferredMethod', 'BillingContactName', 'BillingEmail', 'BillingPhone', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'ChargeDeposits', 'Taxable', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'QboCustomerId', 'CreatedAt'],
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
   REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
-  STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt'],
+  STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt', 'Locations'],
   ORDERS:          ['ID', 'AccountID', 'AccountName', 'Location', 'StaffID', 'StaffName', 'OrderDate', 'DeliveryDate', 'InvoiceNumber', 'OrderAmount', 'TaxAmount', 'DepositAmount', 'Notes', 'RequestedProducts', 'Status', 'Delivered', 'QboInvoiceId', 'QboSyncStatus', 'QboSyncError', 'CreatedAt'],
   STOCK_MOVEMENTS: ['ID', 'InventoryID', 'InventoryName', 'OrderID', 'Type', 'Quantity', 'Notes', 'Date', 'CreatedAt'],
   SETTINGS:        ['ID', 'Key', 'Value', 'UpdatedAt'],

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -14,9 +14,21 @@ async function loadDashboard() {
   state.staff = staff;
   state.dashTodos = [...(dash.overdueReminders || []), ...(dash.upcomingReminders || [])];
 
+  // Build set of staff IDs assigned to the current location (for filtering)
+  const locationStaffIds = new Set();
+  if (state.location && LOCATIONS.length > 1) {
+    for (const s of staff) {
+      try {
+        const locs = JSON.parse(s.Locations || '[]');
+        if (Array.isArray(locs) && locs.includes(state.location)) locationStaffIds.add(s.ID);
+      } catch { /* ignore */ }
+    }
+  }
+  const _staffAtLocation = (id) => !state.location || LOCATIONS.length <= 1 || !id || locationStaffIds.has(id);
+
   // Pending deliveries: undelivered orders with a delivery date
   const pendingDeliveries = (allOrders || [])
-    .filter(o => o.Delivered !== 'true' && o.DeliveryDate)
+    .filter(o => o.Delivered !== 'true' && o.DeliveryDate && _staffAtLocation(o.StaffID))
     .map(o => ({
       _type: 'delivery',
       ID: o.ID,

--- a/public/js/staff.js
+++ b/public/js/staff.js
@@ -34,6 +34,15 @@ function staffForm(member = {}) {
         <option value="false" ${member.Active === 'false' ? 'selected' : ''}>Inactive</option>
       </select>
     </div>
+    ${LOCATIONS.length > 1 ? `<div class="form-group">
+      <label>Locations</label>
+      <div class="checkbox-group" id="f-locations">
+        ${LOCATIONS.map(loc => {
+          const checked = (() => { try { return JSON.parse(member.Locations || '[]').includes(loc); } catch { return false; } })();
+          return `<label class="checkbox-label"><input type="checkbox" value="${esc(loc)}" ${checked ? 'checked' : ''} /> ${esc(loc)}</label>`;
+        }).join('')}
+      </div>
+    </div>` : ''}
     <div class="form-group">
       <label>Notes</label>
       <textarea class="form-control" id="f-notes" rows="2">${esc(member.Notes)}</textarea>
@@ -86,17 +95,18 @@ function renderStaff() {
         <thead>
           <tr>
             <th>Name</th><th class="mobile-hide">Role</th><th>Email</th><th class="mobile-hide">Phone</th>
-            <th class="mobile-hide">Accounts</th><th class="mobile-hide">Status</th><th class="mobile-hide">Notes</th><th>Actions</th>
+            <th class="mobile-hide">Accounts</th>${LOCATIONS.length > 1 ? '<th class="mobile-hide">Locations</th>' : ''}<th class="mobile-hide">Status</th><th class="mobile-hide">Notes</th><th>Actions</th>
           </tr>
         </thead>
         <tbody>
-          ${pg.total === 0 ? `<tr><td colspan="8" class="empty-state">No staff found. Add your first team member!</td></tr>` :
+          ${pg.total === 0 ? `<tr><td colspan="${LOCATIONS.length > 1 ? 9 : 8}" class="empty-state">No staff found. Add your first team member!</td></tr>` :
             pg.rows.map(s => `<tr>
               <td class="fw-600"><span class="td-link" onclick="openEditStaff('${esc(s.ID)}')">${esc(s.Name)}</span></td>
               <td class="mobile-hide">${esc(s.Role) || '—'}</td>
               <td class="text-sm">${esc(s.Email) || '—'}</td>
               <td class="mobile-hide text-sm">${s.Phone ? esc(formatPhone(s.Phone)) : '—'}</td>
               <td class="mobile-hide"><span class="badge badge-prospect">${acctCounts[s.ID] || 0} account${(acctCounts[s.ID] || 0) !== 1 ? 's' : ''}</span></td>
+              ${LOCATIONS.length > 1 ? `<td class="mobile-hide">${(() => { try { return JSON.parse(s.Locations || '[]').map(l => `<span class="badge">${esc(l)}</span>`).join(' '); } catch { return ''; } })() || '—'}</td>` : ''}
               <td class="mobile-hide"><span class="badge ${s.Active !== 'false' ? 'badge-staff-active' : 'badge-staff-inactive'}">${s.Active !== 'false' ? 'Active' : 'Inactive'}</span></td>
               <td class="mobile-hide text-sm text-muted">${esc(s.Notes).substring(0, 50)}${s.Notes && s.Notes.length > 50 ? '…' : ''}</td>
               <td class="td-actions">
@@ -115,6 +125,12 @@ function renderStaff() {
   if (_focused === 'staff-search') refocusSearch('staff-search');
 }
 
+function _getCheckedLocations() {
+  const el = document.getElementById('f-locations');
+  if (!el) return '[]';
+  return JSON.stringify([...el.querySelectorAll('input:checked')].map(cb => cb.value));
+}
+
 function openAddStaff() {
   modal.open('Add Staff Member', staffForm(), async () => {
     const name = val('f-name');
@@ -122,6 +138,7 @@ function openAddStaff() {
     await api.post('/api/staff', {
       Name: name, Role: val('f-role'), Email: val('f-email'),
       Phone: val('f-phone'), Notes: val('f-notes'),
+      Locations: _getCheckedLocations(),
     });
     modal.close();
     toast('Staff member added');
@@ -138,6 +155,7 @@ function openEditStaff(id) {
     await api.put(`/api/staff/${id}`, {
       Name: name, Role: val('f-role'), Email: val('f-email'),
       Phone: val('f-phone'), Active: val('f-active'), Notes: val('f-notes'),
+      Locations: _getCheckedLocations(),
     });
     modal.close();
     toast('Staff member updated');

--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -8,17 +8,30 @@ const router = express.Router();
 router.get('/', async (req, res) => {
   try {
     const { location } = req.query;
-    let [inventory, accounts, outreach, reminders, orders, products] = await Promise.all([
+    let [inventory, accounts, outreach, reminders, orders, products, staff] = await Promise.all([
       getAllRows('INVENTORY'),
       getAllRows('ACCOUNTS'),
       getAllRows('OUTREACH'),
       getAllRows('REMINDERS'),
       getAllRows('ORDERS'),
       getAllRows('PRODUCTS'),
+      getAllRows('STAFF'),
     ]);
     if (location) {
       inventory = inventory.filter(i => i.Location === location);
       orders    = orders.filter(o => o.Location === location);
+
+      // Build set of staff IDs assigned to this location
+      const locationStaffIds = new Set();
+      for (const s of staff) {
+        try {
+          const locs = JSON.parse(s.Locations || '[]');
+          if (Array.isArray(locs) && locs.includes(location)) locationStaffIds.add(s.ID);
+        } catch { /* ignore bad JSON */ }
+      }
+
+      // Filter reminders: keep if unassigned or assigned to staff at this location
+      reminders = reminders.filter(r => !r.StaffID || locationStaffIds.has(r.StaffID));
     }
 
     // Enrich inventory with product data for display

--- a/routes/staff.js
+++ b/routes/staff.js
@@ -18,7 +18,7 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
   try {
-    const { Name, Email, Phone, Role, Notes } = req.body;
+    const { Name, Email, Phone, Role, Notes, Locations } = req.body;
     if (!Name) return res.status(400).json({ error: 'Name is required' });
 
     const member = {
@@ -29,6 +29,7 @@ router.post('/', async (req, res) => {
       Role: Role || '',
       Active: 'true',
       Notes: Notes || '',
+      Locations: Locations || '[]',
       CreatedAt: new Date().toISOString(),
     };
 


### PR DESCRIPTION
## Summary
- Staff members can now be assigned to one or more locations via checkboxes in the staff form (only shown when multiple locations are configured)
- Dashboard todos (overdue, upcoming, "My Todos") are filtered server-side to only show reminders for staff assigned to the currently selected location
- Pending deliveries are filtered client-side by the same logic
- Unassigned items (no StaffID) continue to appear at all locations
- Staff directory table shows assigned locations as badges

## Test plan
- [x] Add/edit a staff member and assign locations via checkboxes
- [x] Switch between locations on the dashboard and confirm todos only show for staff assigned to the selected location
- [x] Confirm unassigned todos (no StaffID) still appear at all locations
- [x] Confirm the staff directory table shows location badges
- [x] Verify single-location setups are unaffected (checkboxes and column hidden)

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)