### PR TITLE
Allow staff with personal Google accounts to log in

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -3,7 +3,7 @@
 const express  = require('express');
 const passport = require('passport');
 const { Strategy: GoogleStrategy } = require('passport-google-oauth20');
-const { getRow, addRow, updateRow } = require('../db');
+const { getRow, addRow, updateRow, getAllRows } = require('../db');
 
 const router = express.Router();
 
@@ -19,19 +19,31 @@ if (oauthConfigured) {
       clientID:     process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
       callbackURL:  process.env.GOOGLE_CALLBACK_URL || '/auth/google/callback',
-      // hd restricts the Google sign-in picker to the workspace domain.
-      // Only works with a single domain; when multiple are configured we
-      // omit it and rely on server-side verification below.
-      hd: ALLOWED_DOMAINS.length === 1 ? ALLOWED_DOMAINS[0] : undefined,
+      // Omit hd so the Google picker shows all accounts, including personal
+      // ones that may belong to whitelisted staff members.
     },
     function verify(accessToken, refreshToken, profile, done) {
       // Enforce Google Workspace domain restriction.
       if (ALLOWED_DOMAINS.length > 0) {
         const hostedDomain = ((profile._json && profile._json.hd) || '').toLowerCase();
         if (!ALLOWED_DOMAINS.includes(hostedDomain)) {
-          return done(null, false, {
-            message: `Access restricted to @${ALLOWED_DOMAINS.join(', @')} accounts.`,
-          });
+          // Check if the email belongs to a staff member (staff Email field
+          // supports comma-separated values).
+          const userEmail = ((profile.emails && profile.emails[0] && profile.emails[0].value) || '').toLowerCase();
+          const staffRows = getAllRows('STAFF');
+          const staffEmails = new Set();
+          for (const s of staffRows) {
+            if (s.Email) {
+              for (const e of s.Email.split(',')) {
+                staffEmails.add(e.trim().toLowerCase());
+              }
+            }
+          }
+          if (!userEmail || !staffEmails.has(userEmail)) {
+            return done(null, false, {
+              message: `Access restricted to @${ALLOWED_DOMAINS.join(', @')} accounts.`,
+            });
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- When `GOOGLE_ALLOWED_DOMAIN` is configured, staff members with personal Google accounts (e.g. gmail.com) were blocked because personal accounts lack the `hd` (hosted domain) claim
- Now if a user's email matches any staff member's Email field (supports comma-separated values), login is allowed regardless of domain
- Removes the `hd` parameter from the Google OAuth config so the account picker shows all Google accounts, not just workspace ones

## Test plan
- [x] Set `GOOGLE_ALLOWED_DOMAIN=yourcompany.com` in `.env`
- [x] Add a staff member with a personal email (e.g. `john@gmail.com`)
- [x] Log in with `john@gmail.com` — should succeed
- [x] Log in with a random non-staff, non-domain email — should be rejected
- [x] Log in with a `@yourcompany.com` account — should still work as before

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)