### PR TITLE
Add "Create Invoice" button for skipped/pending QBO orders

### DIFF
--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -209,8 +209,8 @@ function orderForm(order = {}, presetAccountId = '', readOnly = false) {
       ${order.QboSyncStatus === 'synced' ? `<span class="badge badge-success">Synced</span>${qboInvoiceUrl(order) ? `<a href="${qboInvoiceUrl(order)}" target="_blank" rel="noopener" class="btn btn-ghost btn-sm">View in QuickBooks</a>` : `<span class="text-sm text-muted">Invoice ID: ${esc(order.QboInvoiceId)}</span>`}` : ''}
       ${order.QboSyncStatus === 'failed' ? `<span class="badge badge-danger">Sync Failed</span>${order.QboSyncError ? `<span class="text-sm text-danger">${esc(order.QboSyncError)}</span>` : ''}<button class="btn btn-ghost btn-sm" onclick="retryQboSync('${esc(order.ID)}')">Retry</button>` : ''}
       ${order.QboSyncStatus === 'disabled' ? '<span class="badge badge-neutral">Not Connected</span>' : ''}
-      ${order.QboSyncStatus === 'skipped' ? '<span class="badge badge-neutral">Sync Disabled</span>' : ''}
-      ${!order.QboSyncStatus ? '<span class="badge badge-neutral">Pending</span>' : ''}
+      ${order.QboSyncStatus === 'skipped' ? `<span class="badge badge-neutral">Sync Disabled</span><button class="btn btn-ghost btn-sm" onclick="retryQboSync('${esc(order.ID)}')">Create Invoice</button>` : ''}
+      ${!order.QboSyncStatus ? `<span class="badge badge-neutral">Pending</span><button class="btn btn-ghost btn-sm" onclick="retryQboSync('${esc(order.ID)}')">Create Invoice</button>` : ''}
     </div>` : ''}`;
 }
 


### PR DESCRIPTION
## Summary
- Adds a "Create Invoice" button next to the status badge for orders with `skipped` or empty (pending) QBO sync status
- Reuses the existing `retryQboSync()` function — no backend changes needed

Closes #271

## Test plan
- [ ] Create an order and skip QBO sync
- [ ] Edit that order — verify the QBO section shows a "Create Invoice" button
- [ ] Click it — verify the invoice is created in QBO and status updates to "Synced"

🤖 Generated with [Claude Code](https://claude.com/claude-code)