### PR TITLE
Fix table overflow on initial page load

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -308,6 +308,7 @@ body {
   margin-left: var(--sidebar-width);
   flex: 1;
   min-width: 0;
+  overflow: hidden;
 }
 
 .content-area {


### PR DESCRIPTION
## Summary
- Adds `overflow: hidden` to `.main-content` so wide tables (e.g. Staff Directory) no longer push beyond the viewport
- The existing `overflow-x: auto` on `.table-wrap` now properly handles horizontal scrolling when needed

Closes #273

## Test plan
- [ ] Load Staff Directory page — table should stay within viewport bounds
- [ ] Resize browser to narrow width — table should get a horizontal scrollbar inside `.table-wrap`
- [ ] Verify other pages with tables (Accounts, Inventory, Orders) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)