### PR TITLE
Download QBO invoice PDF and attach to order

### DIFF
--- a/db.js
+++ b/db.js
@@ -37,7 +37,7 @@ const HEADERS = {
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
   REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
   STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt', 'Locations'],
-  ORDERS:          ['ID', 'AccountID', 'AccountName', 'Location', 'StaffID', 'StaffName', 'OrderDate', 'DeliveryDate', 'InvoiceNumber', 'OrderAmount', 'TaxAmount', 'DepositAmount', 'Notes', 'RequestedProducts', 'Status', 'Delivered', 'QboInvoiceId', 'QboSyncStatus', 'QboSyncError', 'CreatedAt'],
+  ORDERS:          ['ID', 'AccountID', 'AccountName', 'Location', 'StaffID', 'StaffName', 'OrderDate', 'DeliveryDate', 'InvoiceNumber', 'OrderAmount', 'TaxAmount', 'DepositAmount', 'Notes', 'RequestedProducts', 'Status', 'Delivered', 'QboInvoiceId', 'QboSyncStatus', 'QboSyncError', 'InvoicePdf', 'CreatedAt'],
   STOCK_MOVEMENTS: ['ID', 'InventoryID', 'InventoryName', 'OrderID', 'Type', 'Quantity', 'Notes', 'Date', 'CreatedAt'],
   SETTINGS:        ['ID', 'Key', 'Value', 'UpdatedAt'],
   KEG_TRACKING:    ['ID', 'AccountID', 'AccountName', 'OrderID', 'InventoryID', 'ProductName', 'Format', 'Quantity', 'DepositPerUnit', 'DepositTotal', 'DepositRefunded', 'DeliveredDate', 'ReturnedDate', 'ReturnedQuantity', 'Notes', 'CreatedAt'],

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -206,7 +206,7 @@ function orderForm(order = {}, presetAccountId = '', readOnly = false) {
     <hr class="form-divider" />
     <div class="form-section-title">QuickBooks</div>
     <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
-      ${order.QboSyncStatus === 'synced' ? `<span class="badge badge-success">Synced</span>${qboInvoiceUrl(order) ? `<a href="${qboInvoiceUrl(order)}" target="_blank" rel="noopener" class="btn btn-ghost btn-sm">View in QuickBooks</a>` : `<span class="text-sm text-muted">Invoice ID: ${esc(order.QboInvoiceId)}</span>`}` : ''}
+      ${order.QboSyncStatus === 'synced' ? `<span class="badge badge-success">Synced</span>${qboInvoiceUrl(order) ? `<a href="${qboInvoiceUrl(order)}" target="_blank" rel="noopener" class="btn btn-ghost btn-sm">View in QuickBooks</a>` : `<span class="text-sm text-muted">Invoice ID: ${esc(order.QboInvoiceId)}</span>`}${order.InvoicePdf ? `<a href="/api/qbo/invoice-pdf/${esc(order.ID)}" target="_blank" class="btn btn-ghost btn-sm">Download Invoice</a>` : ''}` : ''}
       ${order.QboSyncStatus === 'failed' ? `<span class="badge badge-danger">Sync Failed</span>${order.QboSyncError ? `<span class="text-sm text-danger">${esc(order.QboSyncError)}</span>` : ''}<button class="btn btn-ghost btn-sm" onclick="retryQboSync('${esc(order.ID)}')">Retry</button>` : ''}
       ${order.QboSyncStatus === 'disabled' ? '<span class="badge badge-neutral">Not Connected</span>' : ''}
       ${order.QboSyncStatus === 'skipped' ? '<span class="badge badge-neutral">Sync Disabled</span>' : ''}

--- a/qbo-service.js
+++ b/qbo-service.js
@@ -2,6 +2,8 @@
 
 const OAuthClient = require('intuit-oauth');
 const { v4: uuidv4 } = require('uuid');
+const fs = require('fs');
+const path = require('path');
 const { getAllRows, getRow, addRow, updateRow } = require('./db');
 require('dotenv').config();
 
@@ -357,6 +359,36 @@ async function getInvoice(invoiceId) {
   return result.Invoice;
 }
 
+async function downloadInvoicePdf(invoiceId) {
+  let tokens = await getValidToken();
+  if (!tokens) throw new Error('Not connected to QuickBooks');
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const url = `${BASE_URL}/v3/company/${tokens.realmId}/invoice/${invoiceId}/pdf`;
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${tokens.accessToken}`,
+        'Accept':        'application/pdf',
+      },
+    });
+
+    if (resp.status === 401 && attempt === 0) {
+      console.log(`[qbo] Got 401 on PDF download for invoice ${invoiceId}, force-refreshing token and retrying…`);
+      tokens = await getValidToken(true);
+      if (!tokens) throw new Error('Not connected to QuickBooks');
+      continue;
+    }
+
+    if (!resp.ok) {
+      throw new Error(`QBO API GET invoice/${invoiceId}/pdf returned ${resp.status}`);
+    }
+
+    const arrayBuffer = await resp.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  }
+}
+
 async function voidInvoice(invoiceId) {
   const invoice = await getInvoice(invoiceId);
   if (!invoice) throw new Error(`Invoice ${invoiceId} not found in QBO`);
@@ -636,6 +668,19 @@ async function syncOrderToQbo(orderId) {
     } catch (linkErr) {
       console.error(`[qbo] Failed to append invoice link for order ${orderId}:`, linkErr.message);
     }
+
+    // Download and save invoice PDF locally
+    try {
+      const pdfBuffer = await downloadInvoicePdf(qboInvoiceId);
+      const pdfDir = path.join(__dirname, 'data', 'invoices');
+      fs.mkdirSync(pdfDir, { recursive: true });
+      const pdfFilename = `${orderId}.pdf`;
+      fs.writeFileSync(path.join(pdfDir, pdfFilename), pdfBuffer);
+      await updateRow('ORDERS', orderId, { InvoicePdf: pdfFilename });
+      console.log(`[qbo] Invoice PDF saved for order ${orderId}`);
+    } catch (pdfErr) {
+      console.error(`[qbo] Failed to download invoice PDF for order ${orderId}:`, pdfErr.message);
+    }
   } catch (err) {
     console.error(`[qbo] Sync failed for order ${orderId}:`, err.message);
     try {
@@ -656,6 +701,7 @@ module.exports = {
   clearTaxInfoCache,
   getPayment,
   getInvoice,
+  downloadInvoicePdf,
   voidInvoice,
   processQboPaymentWebhook,
   QBO_APP_URL,

--- a/routes/qbo.js
+++ b/routes/qbo.js
@@ -117,6 +117,27 @@ apiRouter.post('/tax-code', async (req, res) => {
   }
 });
 
+// GET /api/qbo/invoice-pdf/:orderId — serve saved invoice PDF
+apiRouter.get('/invoice-pdf/:orderId', (req, res) => {
+  try {
+    const { getRow } = require('../db');
+    const path = require('path');
+    const fs = require('fs');
+    const order = getRow('ORDERS', req.params.orderId);
+    if (!order || !order.InvoicePdf) {
+      return res.status(404).json({ error: 'Invoice PDF not found' });
+    }
+    const pdfPath = path.join(__dirname, '..', 'data', 'invoices', order.InvoicePdf);
+    if (!fs.existsSync(pdfPath)) {
+      return res.status(404).json({ error: 'Invoice PDF file missing' });
+    }
+    res.sendFile(pdfPath, { headers: { 'Content-Type': 'application/pdf' } });
+  } catch (err) {
+    console.error('[qbo]', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 // POST /api/qbo/sync/:orderId — manual retry
 apiRouter.post('/sync/:orderId', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- After creating a QBO invoice, downloads the PDF via the QBO API and saves it locally to `data/invoices/{orderId}.pdf`
- Adds a "Download Invoice" button next to "View in QuickBooks" in the order form so staff can view invoices without logging into QuickBooks
- PDF download failure is non-blocking — the invoice sync still succeeds even if the PDF can't be fetched

## Test plan
- [ ] Create an order and sync to QBO
- [ ] Verify `data/invoices/` contains the saved PDF file
- [ ] Edit the order — verify "Download Invoice" link appears next to "View in QuickBooks"
- [ ] Click the link — verify the PDF opens/downloads in the browser
- [ ] Verify that if PDF download fails, the QBO sync still completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)