### PR TITLE
Fix QBO token refresh race condition and connection loss

### DIFF
--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -42,7 +42,7 @@ async function retryQboSync(orderId) {
     if (updated.QboSyncStatus === 'synced') {
       toast('Synced to QuickBooks');
     } else {
-      toast('QBO sync failed: ' + (updated.QboSyncError || 'unknown error'), 'error');
+      toast('QBO sync failed: ' + (updated.QboSyncError || updated.error || 'unknown error — check Settings'), 'error');
     }
     await loadOrders(true);
   } catch (err) {
@@ -84,7 +84,7 @@ async function promptQboSync(orderId, reloadFn) {
       if (updated.QboSyncStatus === 'synced') {
         toast('Invoice created in QuickBooks');
       } else {
-        toast('QBO sync failed: ' + (updated.QboSyncError || 'unknown error'), 'error');
+        toast('QBO sync failed: ' + (updated.QboSyncError || updated.error || 'unknown error — check Settings'), 'error');
       }
     } catch (err) {
       toast('QBO sync error: ' + err.message, 'error');

--- a/qbo-service.js
+++ b/qbo-service.js
@@ -72,6 +72,10 @@ async function clearTokens() {
 
 // ── Token refresh ────────────────────────────────────────────────
 
+// Deduplication: prevent concurrent refresh calls from racing and
+// invalidating each other's refresh tokens.
+let _refreshPromise = null;
+
 async function getValidToken(forceRefresh = false) {
   const tokens = await getStoredTokens();
   if (!tokens || !tokens.accessToken || !tokens.refreshToken) return null;
@@ -83,7 +87,20 @@ async function getValidToken(forceRefresh = false) {
     return tokens;
   }
 
-  // Refresh the token
+  // If a refresh is already in progress, wait for it instead of starting another
+  if (_refreshPromise) {
+    return _refreshPromise;
+  }
+
+  _refreshPromise = _doRefresh(tokens);
+  try {
+    return await _refreshPromise;
+  } finally {
+    _refreshPromise = null;
+  }
+}
+
+async function _doRefresh(tokens) {
   try {
     const oauthClient = getOAuthClient();
     oauthClient.setToken({
@@ -104,8 +121,18 @@ async function getValidToken(forceRefresh = false) {
     await storeTokens(newTokens);
     return newTokens;
   } catch (err) {
-    console.error('[qbo] Token refresh failed:', err.message);
-    throw new Error(`QuickBooks token refresh failed — try reconnecting in Settings. (${err.message})`);
+    const msg = err.message || String(err);
+    console.error('[qbo] Token refresh failed:', msg);
+
+    // If the refresh token is permanently invalid, clear stored tokens so
+    // the UI shows "disconnected" and the user can reconnect.
+    const isInvalidGrant = /invalid_grant|token.*expired|unauthorized/i.test(msg + ' ' + String(err.authResponse || '') + ' ' + String(err.body || ''));
+    if (isInvalidGrant) {
+      console.error('[qbo] Refresh token appears expired — clearing stored tokens');
+      await clearTokens();
+    }
+
+    throw new Error(`QuickBooks token refresh failed — try reconnecting in Settings. (${msg})`);
   }
 }
 
@@ -571,9 +598,12 @@ async function syncOrderToQbo(orderId) {
       return;
     }
 
-    const tokens = await getStoredTokens();
-    if (!tokens || !tokens.accessToken) {
-      await updateRow('ORDERS', orderId, { QboSyncStatus: 'disabled' });
+    const tokens = await getValidToken();
+    if (!tokens) {
+      await updateRow('ORDERS', orderId, {
+        QboSyncStatus: 'failed',
+        QboSyncError:  'Not connected to QuickBooks — reconnect in Settings',
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary
- Fix race condition where concurrent requests with an expired token all try to refresh simultaneously — the first succeeds but the second invalidates the new credentials, causing QBO to appear "disconnected"
- Auto-clear stored tokens when the refresh token is permanently expired so the Settings page shows "Disconnected" and prompts reconnection instead of silently failing
- Use `getValidToken()` in `syncOrderToQbo` so invalid tokens produce a descriptive "Not connected" error instead of the generic "unknown error"

## Test plan
- [ ] Sync an order to QBO — verify it still works normally
- [ ] Load Settings with QBO connected — verify tax codes load
- [ ] If QBO connection drops, verify Settings shows "Disconnected" with a reconnect option (instead of appearing connected but broken)
- [ ] Verify sync failures show descriptive error messages in the toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)