### PR TITLE
Reopen order modal after QBO sync to show result

### DIFF
--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -89,13 +89,22 @@ async function promptQboSync(orderId, reloadFn) {
     } catch (err) {
       toast('QBO sync error: ' + err.message, 'error');
     }
-    reloadFn();
+    await reloadFn();
+    // Refresh cache and reopen the order so the user sees the QBO result
+    if (state.view === 'account-profile') {
+      _ordersCache = await api.get(`/api/orders?accountId=${encodeURIComponent(state.accountProfileId)}`);
+    }
+    openEditOrder(orderId);
   };
   document.getElementById('qbo-prompt-skip').onclick = async () => {
     modal.close();
     await api.put(`/api/orders/${orderId}`, { QboSyncStatus: 'skipped' }).catch(() => {});
     toast('QuickBooks sync skipped');
-    reloadFn();
+    await reloadFn();
+    if (state.view === 'account-profile') {
+      _ordersCache = await api.get(`/api/orders?accountId=${encodeURIComponent(state.accountProfileId)}`);
+    }
+    openEditOrder(orderId);
   };
 }
 


### PR DESCRIPTION
## Summary
- After creating or skipping a QBO invoice, reopen the Edit Order modal so the user immediately sees the updated QBO status (synced badge, "View in QuickBooks" / "Download Invoice" links, or failure message with retry button)
- Previously the modal closed and only the list reloaded, requiring the user to click the order again to see the result

## Test plan
- [ ] Create an order and sync to QBO — verify the Edit Order modal reopens showing the synced status
- [ ] Click "Skip" on the QBO prompt — verify the modal reopens showing "Sync Disabled"
- [ ] Test from the account profile view — verify modal reopens correctly there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)