### PR TITLE
Add Delivered toggle to mobile actions menu

### DIFF
--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -1052,7 +1052,10 @@ function renderOrders() {
                   ${isPreSale ? `<button class="btn btn-ghost btn-sm" onclick="openEditPreSale('${esc(s.ID)}')">Edit</button><button class="btn btn-ghost btn-sm text-success" onclick="convertPreSale('${esc(s.ID)}')">Convert</button><button class="btn btn-ghost btn-sm text-danger" onclick="cancelPreSale('${esc(s.ID)}')">Cancel</button>`
                   : `${s.Status === 'Pending' ? `<button class="btn btn-ghost btn-sm text-success" onclick="markOrderPaid('${esc(s.ID)}')">Paid</button>` : ''}
                   <button class="btn btn-ghost btn-sm" onclick="openEditOrder('${esc(s.ID)}')">${s.Status === 'Paid' ? 'View' : 'Edit'}</button>
-                  <button class="btn btn-ghost btn-sm text-danger" onclick="deleteOrder('${esc(s.ID)}')">Del</button>`}
+                  <button class="btn btn-ghost btn-sm text-danger" onclick="deleteOrder('${esc(s.ID)}')">Del</button>
+                  ${s.Delivered === 'true'
+                    ? `<button class="btn btn-ghost btn-sm mobile-only" disabled>&#10003; Delivered</button>`
+                    : `<button class="btn btn-ghost btn-sm mobile-only" onclick="toggleDelivered('${esc(s.ID)}')">Mark Delivered</button>`}`}
                   </div>
                 </td>
               </tr>`;

--- a/public/style.css
+++ b/public/style.css
@@ -989,6 +989,7 @@ textarea.form-control { resize: vertical; min-height: 72px; }
 .text-warning { color: #e65100; }
 .text-success { color: var(--green-dark); }
 .fw-600       { font-weight: 600; }
+.mobile-only  { display: none; }
 .mb-0         { margin-bottom: 0; }
 
 .confirm-body {
@@ -1593,6 +1594,7 @@ th input[type="checkbox"] {
   }
 
   .mobile-actions-menu.open { display: block; }
+  .mobile-actions-menu .mobile-only { display: block; }
 
   .mobile-actions-menu .btn {
     display: block;


### PR DESCRIPTION
## Summary
- The "Delivered" checkbox column is hidden on mobile (`mobile-hide` at <640px), leaving no way to mark orders as delivered
- Adds a "Mark Delivered" button inside the existing three-dots action menu, visible only on mobile via a new `mobile-only` CSS class
- Shows a disabled "✓ Delivered" state if the order is already delivered

## Test plan
- [ ] Resize browser to <640px — verify "Mark Delivered" appears in the three-dots menu for non-delivered orders
- [ ] Click "Mark Delivered" — verify the delivery confirmation modal opens and works
- [ ] Verify already-delivered orders show disabled "✓ Delivered" in the menu
- [ ] At desktop width — verify the menu item is hidden and the checkbox column still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)