### PR TITLE
Fix QBO invoice number not saved on order after sync

### DIFF
--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -79,12 +79,13 @@ async function promptQboSync(orderId, reloadFn) {
   document.getElementById('qbo-prompt-create').onclick = async () => {
     modal.close();
     toast('Creating QuickBooks invoice...');
+    let syncedOrder;
     try {
-      const updated = await api.post(`/api/qbo/sync/${orderId}`);
-      if (updated.QboSyncStatus === 'synced') {
+      syncedOrder = await api.post(`/api/qbo/sync/${orderId}`);
+      if (syncedOrder.QboSyncStatus === 'synced') {
         toast('Invoice created in QuickBooks');
       } else {
-        toast('QBO sync failed: ' + (updated.QboSyncError || updated.error || 'unknown error — check Settings'), 'error');
+        toast('QBO sync failed: ' + (syncedOrder.QboSyncError || syncedOrder.error || 'unknown error — check Settings'), 'error');
       }
     } catch (err) {
       toast('QBO sync error: ' + err.message, 'error');
@@ -93,6 +94,11 @@ async function promptQboSync(orderId, reloadFn) {
     // Refresh cache and reopen the order so the user sees the QBO result
     if (state.view === 'account-profile') {
       _ordersCache = await api.get(`/api/orders?accountId=${encodeURIComponent(state.accountProfileId)}`);
+    }
+    // Patch cached order with sync response to ensure InvoiceNumber is current
+    if (syncedOrder && syncedOrder.ID) {
+      const idx = _ordersCache.findIndex(o => o.ID === syncedOrder.ID);
+      if (idx >= 0) _ordersCache[idx] = { ..._ordersCache[idx], ...syncedOrder };
     }
     openEditOrder(orderId);
   };

--- a/qbo-service.js
+++ b/qbo-service.js
@@ -550,10 +550,11 @@ async function createInvoice(order, lineItems, account) {
     }
   }
 
+  const docNumber = order.InvoiceNumber || await getNextInvoiceNumber();
   const invoiceBody = {
     CustomerRef:  { value: customerId },
     Line:         lines,
-    DocNumber:    order.InvoiceNumber || await getNextInvoiceNumber(),
+    DocNumber:    docNumber,
     TxnDate:      order.OrderDate ? order.OrderDate.split('T')[0] : undefined,
     DueDate:      order.DeliveryDate ? order.DeliveryDate.split('T')[0] : undefined,
     BillEmail:     billEmail ? { Address: billEmail } : undefined,
@@ -586,7 +587,10 @@ async function createInvoice(order, lineItems, account) {
   Object.keys(invoiceBody).forEach(k => invoiceBody[k] === undefined && delete invoiceBody[k]);
 
   const result = await qboApiRequest('POST', 'invoice', invoiceBody);
-  return result.Invoice;
+  const invoice = result.Invoice;
+  // Ensure DocNumber is always set — QBO may not echo it back in some configurations
+  if (invoice && !invoice.DocNumber) invoice.DocNumber = docNumber;
+  return invoice;
 }
 
 // ── Top-level sync function ──────────────────────────────────────
@@ -638,11 +642,8 @@ async function syncOrderToQbo(orderId) {
       QboInvoiceId:  qboInvoiceId,
       QboSyncStatus: 'synced',
       QboSyncError:  '',
+      InvoiceNumber: invoice.DocNumber,
     };
-    // Store the QBO invoice number on the order
-    if (invoice.DocNumber) {
-      updates.InvoiceNumber = invoice.DocNumber;
-    }
     await updateRow('ORDERS', orderId, updates);
 
     // Verify the update persisted


### PR DESCRIPTION
## Summary
- **Backend**: `createInvoice()` computed the DocNumber but if QBO didn't echo it back in the response, the conditional `if (invoice.DocNumber)` guard skipped saving it. Now the sent DocNumber is captured as a fallback and the save is unconditional.
- **Frontend**: The sync API response (containing the updated order with InvoiceNumber) was never merged into `_ordersCache`. The code relied solely on a full reload. Now the cached order is patched with the sync response before reopening the edit modal.

## Test plan
- [x] Create a new order without entering an invoice number
- [x] Click "Create Invoice" on the QBO prompt
- [x] Verify the reopened order modal shows the QBO-assigned invoice number
- [x] Verify the invoice number persists in the orders table after closing the modal
- [x] Retry QBO sync on an existing order — verify invoice number is updated

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)