### PR TITLE
Fix QBO connection lost on transient refresh failures

### DIFF
--- a/qbo-service.js
+++ b/qbo-service.js
@@ -101,38 +101,51 @@ async function getValidToken(forceRefresh = false) {
 }
 
 async function _doRefresh(tokens) {
-  try {
-    const oauthClient = getOAuthClient();
-    oauthClient.setToken({
-      access_token:  tokens.accessToken,
-      refresh_token: tokens.refreshToken,
-      token_type:    'bearer',
-      expires_in:    0,
-    });
-    const authResponse = await oauthClient.refresh();
-    const refreshed = authResponse.getJson();
+  // Retry once on transient failures (network glitches, 5xx, etc.)
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const oauthClient = getOAuthClient();
+      oauthClient.setToken({
+        access_token:  tokens.accessToken,
+        refresh_token: tokens.refreshToken,
+        token_type:    'bearer',
+        expires_in:    0,
+      });
+      const authResponse = await oauthClient.refresh();
+      const refreshed = authResponse.getJson();
 
-    const newTokens = {
-      accessToken:  refreshed.access_token,
-      refreshToken: refreshed.refresh_token,
-      realmId:      tokens.realmId,
-      expiresAt:    Date.now() + (refreshed.expires_in || 3600) * 1000,
-    };
-    await storeTokens(newTokens);
-    return newTokens;
-  } catch (err) {
-    const msg = err.message || String(err);
-    console.error('[qbo] Token refresh failed:', msg);
+      const newTokens = {
+        accessToken:  refreshed.access_token,
+        refreshToken: refreshed.refresh_token,
+        realmId:      tokens.realmId,
+        expiresAt:    Date.now() + (refreshed.expires_in || 3600) * 1000,
+      };
+      await storeTokens(newTokens);
+      return newTokens;
+    } catch (err) {
+      const msg = err.message || String(err);
+      const errDetail = msg + ' ' + String(err.authResponse || '') + ' ' + String(err.body || '');
 
-    // If the refresh token is permanently invalid, clear stored tokens so
-    // the UI shows "disconnected" and the user can reconnect.
-    const isInvalidGrant = /invalid_grant|token.*expired|unauthorized/i.test(msg + ' ' + String(err.authResponse || '') + ' ' + String(err.body || ''));
-    if (isInvalidGrant) {
-      console.error('[qbo] Refresh token appears expired — clearing stored tokens');
-      await clearTokens();
+      // Only clear tokens on definitively permanent failures (invalid_grant
+      // means the refresh token has been revoked or expired after 100 days).
+      // Do NOT clear on transient errors like network timeouts or 5xx.
+      const isInvalidGrant = /invalid_grant/i.test(errDetail);
+      if (isInvalidGrant) {
+        console.error('[qbo] Refresh token is invalid (invalid_grant) — clearing stored tokens');
+        await clearTokens();
+        throw new Error('QuickBooks refresh token expired — please reconnect in Settings.');
+      }
+
+      // On first attempt, log and retry after a brief pause
+      if (attempt === 0) {
+        console.warn(`[qbo] Token refresh attempt failed (will retry): ${msg}`);
+        await new Promise(r => setTimeout(r, 1000));
+        continue;
+      }
+
+      console.error('[qbo] Token refresh failed after retry:', msg);
+      throw new Error(`QuickBooks token refresh failed — try again shortly. (${msg})`);
     }
-
-    throw new Error(`QuickBooks token refresh failed — try reconnecting in Settings. (${msg})`);
   }
 }
 


### PR DESCRIPTION
## Summary
- The token refresh error handler used a broad regex (`/invalid_grant|token.*expired|unauthorized/i`) that could match transient errors like network timeouts or 5xx responses. When matched, it cleared all stored tokens, permanently disconnecting QBO until manual reconnection in Settings.
- Narrowed the token-clearing check to only match `invalid_grant`, which is the specific OAuth error for truly revoked/expired refresh tokens (after 100 days of inactivity or manual revocation)
- Added a retry with 1-second pause for transient refresh failures — if the first attempt fails for a non-permanent reason, it tries once more before giving up
- Transient failures no longer clear tokens, so the next API request will simply attempt another refresh

## Test plan
- [ ] Verify normal QBO sync still works (token refresh on expired access token)
- [ ] Verify connection survives transient network issues during token refresh
- [ ] If refresh token is genuinely expired (invalid_grant), verify tokens are cleared and user is prompted to reconnect

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)