### PR TITLE
Fix QBO duplicate name error by searching email first (#284)

### DIFF
--- a/qbo-service.js
+++ b/qbo-service.js
@@ -216,16 +216,7 @@ async function findOrCreateCustomer(account) {
     return qboId;
   };
 
-  // Search QBO by display name
-  const displayName = (account.Name || '').replace(/'/g, "\\'");
-  const query = `SELECT * FROM Customer WHERE DisplayName = '${displayName}'`;
-  const result = await qboApiRequest('GET', `query?query=${encodeURIComponent(query)}`);
-
-  if (result.QueryResponse?.Customer?.length > 0) {
-    return cacheAndReturn(result.QueryResponse.Customer[0]);
-  }
-
-  // Search QBO by email address
+  // Search QBO by email first — more reliable than name matching
   const email = account.BillingEmail || account.Email;
   if (email) {
     const emailEsc = email.replace(/'/g, "\\'");
@@ -234,6 +225,15 @@ async function findOrCreateCustomer(account) {
     if (emailResult.QueryResponse?.Customer?.length > 0) {
       return cacheAndReturn(emailResult.QueryResponse.Customer[0]);
     }
+  }
+
+  // Fall back to display name search
+  const displayName = (account.Name || '').replace(/'/g, "\\'");
+  const query = `SELECT * FROM Customer WHERE DisplayName = '${displayName}'`;
+  const result = await qboApiRequest('GET', `query?query=${encodeURIComponent(query)}`);
+
+  if (result.QueryResponse?.Customer?.length > 0) {
+    return cacheAndReturn(result.QueryResponse.Customer[0]);
   }
 
   // Create new customer in QBO


### PR DESCRIPTION
## Summary
- Reorders `findOrCreateCustomer` to search QBO customers by email address before display name
- Email is a more reliable identifier — display name lookups can miss due to casing, whitespace, or special character differences, causing QBO to reject the create with error 6240 ("Duplicate Name Exists Error")
- The display name search and 6240 error catch remain as fallbacks

Fixes #284

## Test plan
- [ ] Sync an invoice for an account that already exists in QBO — verify it finds the customer by email without hitting the duplicate name error
- [ ] Sync an invoice for a new account — verify customer is created normally
- [ ] Sync an invoice for an account with no email — verify it falls back to display name lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)