### PR TITLE
Fix QBO token refresh reliability with direct HTTP

### DIFF
--- a/qbo-service.js
+++ b/qbo-service.js
@@ -101,50 +101,89 @@ async function getValidToken(forceRefresh = false) {
 }
 
 async function _doRefresh(tokens) {
-  // Retry once on transient failures (network glitches, 5xx, etc.)
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
-      const oauthClient = getOAuthClient();
-      oauthClient.setToken({
-        access_token:  tokens.accessToken,
-        refresh_token: tokens.refreshToken,
-        token_type:    'bearer',
-        expires_in:    0,
-      });
-      const authResponse = await oauthClient.refresh();
-      const refreshed = authResponse.getJson();
+  const TOKEN_ENDPOINT = 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer';
+  const credentials = Buffer.from(`${QBO_CLIENT_ID}:${QBO_CLIENT_SECRET}`).toString('base64');
+  const tail = (s) => s ? s.slice(-4) : '????';
 
+  for (let attempt = 0; attempt < 2; attempt++) {
+    // On retry, re-read tokens from DB — another concurrent request may have
+    // already refreshed successfully, giving us a new valid refresh token.
+    let currentTokens = tokens;
+    if (attempt > 0) {
+      const stored = await getStoredTokens();
+      if (stored && stored.refreshToken) {
+        // If the stored tokens are already valid (not expired), just use them
+        if (stored.expiresAt && Date.now() < stored.expiresAt - 60 * 1000) {
+          console.log(`[qbo-refresh] Attempt ${attempt}: stored tokens are already valid (expires ${new Date(stored.expiresAt).toISOString()}), using them`);
+          return stored;
+        }
+        currentTokens = stored;
+        console.log(`[qbo-refresh] Attempt ${attempt}: re-read tokens from DB (refresh …${tail(currentTokens.refreshToken)})`);
+      }
+    }
+
+    console.log(`[qbo-refresh] Attempt ${attempt}: refreshing with token …${tail(currentTokens.refreshToken)}`);
+
+    try {
+      const resp = await fetch(TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Basic ${credentials}`,
+          'Content-Type':  'application/x-www-form-urlencoded',
+          'Accept':        'application/json',
+        },
+        body: `grant_type=refresh_token&refresh_token=${encodeURIComponent(currentTokens.refreshToken)}`,
+      });
+
+      const body = await resp.text();
+      console.log(`[qbo-refresh] Attempt ${attempt}: Intuit responded ${resp.status}`);
+
+      if (!resp.ok) {
+        const isInvalidGrant = /invalid_grant/i.test(body);
+        if (isInvalidGrant) {
+          // On first attempt, don't clear yet — check if DB has newer tokens
+          if (attempt === 0) {
+            console.warn(`[qbo-refresh] Got invalid_grant on attempt 0, will retry with fresh DB tokens`);
+            await new Promise(r => setTimeout(r, 500));
+            continue;
+          }
+          console.error(`[qbo-refresh] Refresh token is invalid (invalid_grant) — clearing stored tokens`);
+          await clearTokens();
+          throw new Error('QuickBooks refresh token expired — please reconnect in Settings.');
+        }
+
+        // Transient error (5xx, network issue, etc.)
+        if (attempt === 0) {
+          console.warn(`[qbo-refresh] Transient error ${resp.status}, will retry: ${body.slice(0, 200)}`);
+          await new Promise(r => setTimeout(r, 1000));
+          continue;
+        }
+
+        throw new Error(`QuickBooks token refresh failed (${resp.status}) — try again shortly.`);
+      }
+
+      const refreshed = JSON.parse(body);
       const newTokens = {
         accessToken:  refreshed.access_token,
         refreshToken: refreshed.refresh_token,
-        realmId:      tokens.realmId,
+        realmId:      currentTokens.realmId,
         expiresAt:    Date.now() + (refreshed.expires_in || 3600) * 1000,
       };
       await storeTokens(newTokens);
+      console.log(`[qbo-refresh] Success — new access token stored, refresh …${tail(newTokens.refreshToken)}, expires ${new Date(newTokens.expiresAt).toISOString()}`);
       return newTokens;
     } catch (err) {
-      const msg = err.message || String(err);
-      const errDetail = msg + ' ' + String(err.authResponse || '') + ' ' + String(err.body || '');
+      // Re-throw our own errors (from the block above)
+      if (err.message.includes('QuickBooks')) throw err;
 
-      // Only clear tokens on definitively permanent failures (invalid_grant
-      // means the refresh token has been revoked or expired after 100 days).
-      // Do NOT clear on transient errors like network timeouts or 5xx.
-      const isInvalidGrant = /invalid_grant/i.test(errDetail);
-      if (isInvalidGrant) {
-        console.error('[qbo] Refresh token is invalid (invalid_grant) — clearing stored tokens');
-        await clearTokens();
-        throw new Error('QuickBooks refresh token expired — please reconnect in Settings.');
-      }
-
-      // On first attempt, log and retry after a brief pause
+      // Network-level failures (DNS, TLS, timeout, etc.)
       if (attempt === 0) {
-        console.warn(`[qbo] Token refresh attempt failed (will retry): ${msg}`);
+        console.warn(`[qbo-refresh] Network error on attempt 0 (will retry): ${err.message}`);
         await new Promise(r => setTimeout(r, 1000));
         continue;
       }
-
-      console.error('[qbo] Token refresh failed after retry:', msg);
-      throw new Error(`QuickBooks token refresh failed — try again shortly. (${msg})`);
+      console.error(`[qbo-refresh] Token refresh failed after retry:`, err.message);
+      throw new Error(`QuickBooks token refresh failed — try again shortly. (${err.message})`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replaces intuit-oauth library's `refresh()` with a direct `fetch` to Intuit's token endpoint, eliminating hidden retry logic and opaque state mutation that caused stale refresh tokens
- Re-reads tokens from DB before retry so concurrent requests that already refreshed successfully aren't ignored
- Short-circuits retry if stored tokens are already valid (another request beat us to it)
- Defers `invalid_grant` token clearing to the second attempt, allowing recovery when Intuit rotated the refresh token and another request saved it
- Adds detailed `[qbo-refresh]` logging (token suffix, HTTP status, expiry) for debugging

Fixes #282

## Test plan
- [ ] Connect QBO in Settings, sync an order — verify invoice created
- [ ] Manually set stored `expiresAt` to a past timestamp, trigger a QBO operation — verify `[qbo-refresh]` logs show successful refresh
- [ ] Check server logs for `[qbo-refresh]` entries showing attempt number, Intuit response status, and token suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)