### PR TITLE
Sort account dropdown by location in Log Order modal

### DIFF
--- a/public/js/core.js
+++ b/public/js/core.js
@@ -426,12 +426,22 @@ document.addEventListener('click', () => {
   document.querySelectorAll('.mobile-actions-menu.open').forEach(m => m.classList.remove('open'));
 });
 
-function accountOptions(selectedId = '') {
-  return state.accounts
+function accountOptions(selectedId = '', location = '') {
+  const active = state.accounts
     .filter(a => a.Status !== 'Inactive')
-    .sort((a, b) => a.Name.localeCompare(b.Name))
-    .map(a => `<option value="${esc(a.ID)}" ${a.ID === selectedId ? 'selected' : ''}>${esc(a.Name)}</option>`)
-    .join('');
+    .sort((a, b) => a.Name.localeCompare(b.Name));
+  if (!location) {
+    return active
+      .map(a => `<option value="${esc(a.ID)}" ${a.ID === selectedId ? 'selected' : ''}>${esc(a.Name)}</option>`)
+      .join('');
+  }
+  const serviced = active.filter(a => a.ServicedBy === location || !a.ServicedBy);
+  const other = active.filter(a => a.ServicedBy && a.ServicedBy !== location);
+  const optHtml = list => list.map(a => `<option value="${esc(a.ID)}" ${a.ID === selectedId ? 'selected' : ''}>${esc(a.Name)}</option>`).join('');
+  let html = '';
+  if (serviced.length) html += `<optgroup label="Serviced by ${esc(location)}">${optHtml(serviced)}</optgroup>`;
+  if (other.length) html += `<optgroup label="Other accounts">${optHtml(other)}</optgroup>`;
+  return html;
 }
 
 function staffOptions(selectedId = '') {

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -123,13 +123,13 @@ function orderForm(order = {}, presetAccountId = '', readOnly = false) {
         <label>Account <span class="required">*</span></label>
         <select class="form-control" id="f-account" ${presetAccountId || readOnly ? 'disabled' : ''} onchange="initOrderDepositCheckbox(); initOrderTaxCheckbox()">
           <option value="">-- Select Account --</option>
-          ${accountOptions(selAcctId)}
+          ${accountOptions(selAcctId, order.Location || state.location)}
         </select>
         ${presetAccountId ? `<input type="hidden" id="f-account-hidden" value="${esc(presetAccountId)}" />` : ''}
       </div>
       <div class="form-group">
         <label>Location <span class="required">*</span></label>
-        <select class="form-control" id="f-location"${dis}${readOnly ? '' : ' onchange="refreshOrderProducts()"'}>
+        <select class="form-control" id="f-location"${dis}${readOnly ? '' : ' onchange="refreshOrderAccounts(); refreshOrderProducts()"'}>
           ${LOCATIONS.map(l => `<option value="${l}" ${(order.Location || state.location) === l ? 'selected' : ''}>${l}</option>`).join('')}
         </select>
       </div>
@@ -723,6 +723,14 @@ function getOrderLineItems() {
     }
   });
   return items;
+}
+
+function refreshOrderAccounts() {
+  const location = val('f-location');
+  const sel = document.getElementById('f-account');
+  if (!sel) return;
+  const current = sel.value;
+  sel.innerHTML = '<option value="">-- Select Account --</option>' + accountOptions(current, location);
 }
 
 async function refreshOrderProducts(existingProducts = '', readOnly = false) {


### PR DESCRIPTION
## Summary
- Groups accounts in the Log Order dropdown by location using `<optgroup>` labels: "Serviced by {location}" (matching + unassigned accounts) at the top, "Other accounts" below
- Dropdown re-groups dynamically when the location is changed
- Existing callers of `accountOptions()` without a location parameter are unaffected

## Test plan
- [x] Open Log Order modal — verify serviced accounts appear in top group, others below
- [x] Change location dropdown — verify account dropdown re-groups accordingly
- [x] Open an existing order in read-only view — verify display is unaffected
- [x] Verify pre-sale form account dropdown still works (no location grouping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)