### PR TITLE
Fix unknown error on QBO invoice sync (#304)

### DIFF
--- a/qbo-service.js
+++ b/qbo-service.js
@@ -793,7 +793,7 @@ async function syncOrderToQbo(orderId) {
 
     // Skip if already synced or explicitly opted out
     if (order.QboSyncStatus === 'synced' && order.QboInvoiceId) return;
-    if (order.QboSyncStatus === 'skipped') return;
+    // If explicitly called on a skipped order, allow it to proceed
 
     const account = getRow('ACCOUNTS', order.AccountID);
     if (!account) {
@@ -889,7 +889,7 @@ async function syncOrderToQbo(orderId) {
   } catch (err) {
     console.error(`[qbo] Sync failed for order ${orderId}:`, err.message);
     try {
-      await updateRow('ORDERS', orderId, { QboSyncStatus: 'failed', QboSyncError: err.message });
+      await updateRow('ORDERS', orderId, { QboSyncStatus: 'failed', QboSyncError: err.message || String(err) || 'An unexpected error occurred' });
     } catch { /* ignore update error */ }
   }
 }

--- a/routes/qbo.js
+++ b/routes/qbo.js
@@ -171,7 +171,11 @@ apiRouter.post('/sync/:orderId', async (req, res) => {
     await syncOrderToQbo(req.params.orderId);
     const { getRow } = require('../db');
     const order = getRow('ORDERS', req.params.orderId);
-    res.json(order || { error: 'Order not found' });
+    if (!order) return res.json({ error: 'Order not found' });
+    if (order.QboSyncStatus !== 'synced' && !order.QboSyncError) {
+      order.QboSyncError = 'QBO sync failed — check Settings for connection issues';
+    }
+    res.json(order);
   } catch (err) {
     console.error('[qbo]', err.message);
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- **Remove 'skipped' early return** in `syncOrderToQbo` so clicking "Create Invoice" on a skipped order actually syncs instead of silently returning with no error
- **Harden catch block** to always store a non-empty `QboSyncError` (falls back to `String(err)` or a default message)
- **Add fallback error in route response** so the frontend always has an error message to display when sync fails

## Test plan
- [ ] Disconnect QBO, then retry sync on an order — should show the actual error, not "unknown error"
- [ ] Skip QBO sync on order creation, then click "Create Invoice" — should now sync instead of showing "unknown error"
- [ ] Normal sync flow (connected QBO) remains unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)