### PR TITLE
Fix keg deposit qty/rate on QBO invoices (#302)

### DIFF
--- a/qbo-service.js
+++ b/qbo-service.js
@@ -692,21 +692,65 @@ async function createInvoice(order, lineItems, account) {
     return line;
   });
 
-  // Add deposit as a separate line if present (non-taxable)
+  // Add deposit lines per keg format if present (non-taxable)
   const depositAmount = parseFloat(order.DepositAmount || 0);
   if (depositAmount > 0) {
-    lines.push({
-      DetailType:          'SalesItemLineDetail',
-      Amount:              depositAmount,
-      Description:         'Keg Deposits',
-      SalesItemLineDetail: {
-        ItemRef:   { value: productItemId },
-        UnitPrice: depositAmount,
-        Qty:       1,
-        TaxCodeRef: { value: 'NON' },
-      },
-      LineNum: lines.length + 1,
-    });
+    // Look up per-format keg deposit rates from settings
+    const settingsRows = await getAllRows('SETTINGS');
+    const depRow = settingsRows.find(r => r.Key === 'kegDeposits');
+    let kegDeposits = {};
+    if (depRow) {
+      try { kegDeposits = JSON.parse(depRow.Value); } catch (e) { /* ignore */ }
+    }
+
+    // Count kegs per format from line items
+    const kegsByFormat = {};
+    for (const li of lineItems) {
+      const fmt = li.Format || '';
+      if (fmt.toLowerCase().includes('keg')) {
+        const qty = parseFloat(li.Quantity || 0);
+        if (qty > 0) {
+          kegsByFormat[fmt] = (kegsByFormat[fmt] || 0) + qty;
+        }
+      }
+    }
+
+    // Build one deposit line per keg format with a matching rate
+    let depositLinesAdded = false;
+    for (const [fmt, qty] of Object.entries(kegsByFormat)) {
+      const rate = parseFloat(kegDeposits[fmt]) || 0;
+      if (rate > 0) {
+        lines.push({
+          DetailType:          'SalesItemLineDetail',
+          Amount:              parseFloat((rate * qty).toFixed(2)),
+          Description:         `Keg Deposit — ${fmt}`,
+          SalesItemLineDetail: {
+            ItemRef:   { value: productItemId },
+            UnitPrice: rate,
+            Qty:       qty,
+            TaxCodeRef: { value: 'NON' },
+          },
+          LineNum: lines.length + 1,
+        });
+        depositLinesAdded = true;
+      }
+    }
+
+    // Fallback: if no per-format rates matched, use single line with total
+    if (!depositLinesAdded) {
+      lines.push({
+        DetailType:          'SalesItemLineDetail',
+        Amount:              depositAmount,
+        Description:         'Keg Deposits',
+        SalesItemLineDetail: {
+          ItemRef:   { value: productItemId },
+          UnitPrice: depositAmount,
+          Qty:       1,
+          TaxCodeRef: { value: 'NON' },
+        },
+        LineNum: lines.length + 1,
+      });
+    }
   }
 
   // Determine bill email: prefer BillingEmail, fall back to account Email


### PR DESCRIPTION
## Summary
- QBO invoice deposit lines now show correct per-keg quantity and rate instead of QTY=1 with total as the rate
- Reads keg deposit rates from Settings and groups line items by keg format to create separate deposit lines (e.g. `Keg Deposit — 1/2 Keg` with Qty=2, Rate=$30)
- Falls back to previous single-line behavior if no deposit rates are configured in settings

## Test plan
- [ ] Create an order with multiple keg formats (e.g. 2x 1/2 Keg, 1x 1/6 Keg) and sync to QBO — verify separate deposit lines with correct qty and rate
- [ ] Create an order with no kegs — verify no deposit line appears
- [ ] Create an order with kegs but no deposit settings configured — verify fallback to single line with total amount

🤖 Generated with [Claude Code](https://claude.com/claude-code)