### PR TITLE
Add inventory recount movement type

### DIFF
--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -255,14 +255,20 @@ function openAdjustInventory(id) {
     </p>
     <div class="form-group">
       <label>Movement Type <span class="required">*</span></label>
-      <select class="form-control" id="f-adj-type">
+      <select class="form-control" id="f-adj-type" onchange="
+        var lbl = document.getElementById('f-adj-qty-label');
+        var inp = document.getElementById('f-adj-qty');
+        if (this.value === 'recount') { lbl.textContent = 'New Count'; inp.min = '0'; inp.placeholder = 'e.g. 8'; }
+        else { lbl.textContent = 'Quantity'; inp.min = '1'; inp.placeholder = 'e.g. 10'; }
+      ">
         <option value="received">Received (add stock)</option>
         <option value="write-off">Write-off (remove stock)</option>
         <option value="adjustment">Adjustment (remove stock)</option>
+        <option value="recount">Recount (set new total)</option>
       </select>
     </div>
     <div class="form-group">
-      <label>Quantity <span class="required">*</span></label>
+      <label id="f-adj-qty-label">Quantity <span class="required">*</span></label>
       <input class="form-control" id="f-adj-qty" type="number" min="1" placeholder="e.g. 10" />
     </div>
     <div class="form-group">
@@ -275,7 +281,7 @@ function openAdjustInventory(id) {
     </div>`, async () => {
     const type = val('f-adj-type');
     const qty  = parseInt(val('f-adj-qty'));
-    if (!qty || qty <= 0) { toast('Enter a valid quantity', 'error'); return; }
+    if (type === 'recount' ? (isNaN(qty) || qty < 0) : (!qty || qty <= 0)) { toast('Enter a valid quantity', 'error'); return; }
     const result = await api.post('/api/stock-movements', {
       inventoryId: id,
       type,
@@ -294,7 +300,7 @@ async function openInventoryHistory(id) {
   const item = state.inventory.find(i => i.ID === id);
   if (!item) return;
   const movements = await api.get(`/api/stock-movements?inventoryId=${encodeURIComponent(id)}`);
-  const typeLabel = { sale: 'Sale', received: 'Received', 'write-off': 'Write-off', adjustment: 'Adjustment' };
+  const typeLabel = { sale: 'Sale', received: 'Received', 'write-off': 'Write-off', adjustment: 'Adjustment', recount: 'Recount' };
   const rows = movements.length === 0
     ? `<tr><td colspan="5" class="empty-state">No stock movements recorded yet.</td></tr>`
     : movements.map(m => {

--- a/routes/stock-movements.js
+++ b/routes/stock-movements.js
@@ -134,11 +134,12 @@ router.post('/', async (req, res) => {
     const { inventoryId, type, quantity, notes, date } = req.body;
     if (!inventoryId) return res.status(400).json({ error: 'inventoryId is required' });
 
-    const VALID_TYPES = ['received', 'write-off', 'adjustment'];
+    const VALID_TYPES = ['received', 'write-off', 'adjustment', 'recount'];
     if (!VALID_TYPES.includes(type)) return res.status(400).json({ error: `type must be one of: ${VALID_TYPES.join(', ')}` });
 
     const qty = parseInt(quantity);
-    if (!qty || qty <= 0) return res.status(400).json({ error: 'quantity must be a positive integer' });
+    if (type === 'recount' ? (isNaN(qty) || qty < 0) : (!qty || qty <= 0))
+      return res.status(400).json({ error: 'quantity must be a positive integer' });
 
     const inventory = await getAllRows('INVENTORY');
     const inv = inventory.find(i => i.ID === inventoryId);
@@ -150,8 +151,9 @@ router.post('/', async (req, res) => {
     const invName = inv.ProductName || product.Name || inv.Name || '';
     const invFormat = inv.Format || product.Format || '';
 
-    // received = add stock; write-off and adjustment = remove stock
-    const delta     = type === 'received' ? qty : -qty;
+    // received = add stock; write-off and adjustment = remove stock; recount = set absolute
+    const currentUnits = parseInt(inv.Units || '0');
+    const delta     = type === 'recount' ? (qty - currentUnits) : (type === 'received' ? qty : -qty);
     const movDate   = date || new Date().toISOString().split('T')[0];
     const createdAt = new Date().toISOString();
 
@@ -168,11 +170,14 @@ router.post('/', async (req, res) => {
     };
     await addRow('STOCK_MOVEMENTS', movement);
 
-    const newUnits = Math.max(0, parseInt(inv.Units || '0') + delta);
-    await updateRow('INVENTORY', inventoryId, {
-      Units:       String(newUnits),
-      LastUpdated: movDate,
-    });
+    // For recount with no change, still record movement but skip inventory update
+    const newUnits = delta === 0 ? currentUnits : Math.max(0, currentUnits + delta);
+    if (delta !== 0) {
+      await updateRow('INVENTORY', inventoryId, {
+        Units:       String(newUnits),
+        LastUpdated: movDate,
+      });
+    }
 
     const baseUrl = `${req.protocol}://${req.get('host')}`;
     processMentions({


### PR DESCRIPTION
## Summary
- Adds a "Recount (set new total)" option to the stock adjustment modal, so admins can enter the correct count instead of calculating a delta
- System automatically computes the difference (positive, negative, or zero) and records the movement
- A recount resulting in no change still records the movement to confirm the count was verified
- History view displays "Recount" badge for recount movements

## Test plan
- [x] Open Stock Levels, click Adjust on an item with e.g. 10 units
- [x] Select "Recount", enter 8 → movement with qty -2, new total 8
- [ ] Select "Recount", enter 12 → movement with qty +2, new total 12
- [ ] Select "Recount", enter 10 → movement with qty 0, total stays 10
- [ ] Select "Recount", enter 0 → movement with qty -10, total becomes 0
- [ ] Check History view shows "Recount" badge correctly
- [ ] Verify other movement types (received, write-off, adjustment) still work unchanged

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)