### PR TITLE
Add Draft order status

### DIFF
--- a/public/js/core.js
+++ b/public/js/core.js
@@ -249,7 +249,7 @@ function typeBadge(type) {
 }
 
 function orderStatusBadge(status) {
-  const map = { 'Pre-Sale': 'badge-pre-sale', Pending: 'badge-pending', Paid: 'badge-paid', Cancelled: 'badge-cancelled' };
+  const map = { 'Pre-Sale': 'badge-pre-sale', Draft: 'badge-draft', Pending: 'badge-pending', Paid: 'badge-paid', Cancelled: 'badge-cancelled' };
   return `<span class="badge ${map[status] || 'badge-pending'}">${esc(status || 'Pending')}</span>`;
 }
 

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ORDER_STATUSES = ['Pending', 'Paid', 'Cancelled', 'Pre-Sale'];
+const ORDER_STATUSES = ['Draft', 'Pending', 'Paid', 'Cancelled', 'Pre-Sale'];
 
 let _qboAppUrl = '';
 let _orderCreditBalance = 0;
@@ -1091,7 +1091,7 @@ function renderOrders() {
                 <td class="mobile-hide">${s.TaxAmount && parseFloat(s.TaxAmount) > 0 ? fmtMoney(s.TaxAmount) : '—'}</td>
                 <td class="fw-600">${isPreSale && !parseFloat(s.OrderAmount) ? '<span class="text-muted">—</span>' : fmtMoney(total)}</td>
                 <td>${orderStatusBadge(s.Status)}${s.PaymentMethod ? `<br><span class="text-muted text-sm">${esc(s.PaymentMethod)}${s.PaymentReference ? ' · ' + esc(s.PaymentReference) : ''}</span>` : ''}</td>
-                <td class="mobile-hide text-center">${isPreSale ? '—'
+                <td class="mobile-hide text-center">${isPreSale || s.Status === 'Draft' ? '—'
                   : s.Delivered === 'true'
                   ? `<input type="checkbox" checked disabled title="${s.DeliveryDate ? formatDate(s.DeliveryDate) : 'Delivered'}" />`
                   : `<input type="checkbox" onchange="toggleDelivered('${esc(s.ID)}')" />`}</td>
@@ -1099,7 +1099,7 @@ function renderOrders() {
                   <button class="btn btn-ghost btn-sm mobile-actions-toggle" onclick="toggleMobileActions(event)">&#8230;</button>
                   <div class="mobile-actions-menu">
                   ${isPreSale ? `<button class="btn btn-ghost btn-sm" onclick="openEditPreSale('${esc(s.ID)}')">Edit</button><button class="btn btn-ghost btn-sm text-success" onclick="convertPreSale('${esc(s.ID)}')">Convert</button><button class="btn btn-ghost btn-sm text-danger" onclick="cancelPreSale('${esc(s.ID)}')">Cancel</button>`
-                  : `${s.Status === 'Pending' ? `<button class="btn btn-ghost btn-sm text-success" onclick="markOrderPaid('${esc(s.ID)}')">Paid</button>` : ''}
+                  : `${s.Status === 'Pending' || s.Status === 'Draft' ? `<button class="btn btn-ghost btn-sm text-success" onclick="markOrderPaid('${esc(s.ID)}')">Paid</button>` : ''}
                   <button class="btn btn-ghost btn-sm" onclick="openEditOrder('${esc(s.ID)}')">${s.Status === 'Paid' ? 'View' : 'Edit'}</button>
                   <button class="btn btn-ghost btn-sm text-danger" onclick="deleteOrder('${esc(s.ID)}')">Del</button>
                   ${s.Delivered === 'true'
@@ -1187,7 +1187,11 @@ async function openAddOrder(presetAccountId = '') {
     const reloadFn = state.view === 'account-profile'
       ? () => loadAccountProfile(state.accountProfileId)
       : () => loadOrders();
-    promptQboSync(order.ID, reloadFn);
+    if (newStatus !== 'Draft') {
+      promptQboSync(order.ID, reloadFn);
+    } else {
+      reloadFn();
+    }
   });
   setTimeout(() => initMentions('f-notes'), 0);
   await refreshOrderProducts();
@@ -1288,7 +1292,16 @@ async function openEditOrder(id) {
           toast('Payment saved but QBO sync failed: ' + (err.message || 'unknown error'), 'error');
         }
       }
-      loadOrders();
+      // Prompt QBO sync when transitioning from Draft to Pending or Paid
+      const leavingDraft = order.Status === 'Draft' && newStatus !== 'Draft';
+      if (leavingDraft && !order.QboInvoiceId) {
+        const reloadFn = state.view === 'account-profile'
+          ? () => loadAccountProfile(state.accountProfileId)
+          : () => loadOrders();
+        promptQboSync(id, reloadFn);
+      } else {
+        loadOrders();
+      }
     });
   }
   setTimeout(() => initMentions('f-notes'), 0);

--- a/public/style.css
+++ b/public/style.css
@@ -715,6 +715,7 @@ tbody td {
 .badge-ok-stock  { background: var(--success-bg); color: var(--success-text); }
 
 /* Order status badges */
+.badge-draft     { background: #f5f5f5; color: #616161; }
 .badge-pre-sale  { background: #f3e5f5; color: #7b1fa2; }
 .badge-pending   { background: #e3f2fd; color: #1565c0; }
 .badge-paid      { background: var(--success-bg); color: var(--success-text); }

--- a/routes/api-webhooks.js
+++ b/routes/api-webhooks.js
@@ -205,7 +205,7 @@ async function handleOrderCreate(data) {
   const rawDate = orderDate || today;
   const fullDate = rawDate.includes('T') ? rawDate : rawDate + 'T' + now.split('T')[1];
 
-  const VALID_STATUSES = new Set(['Pending', 'Paid', 'Cancelled', 'Pre-Sale']);
+  const VALID_STATUSES = new Set(['Draft', 'Pending', 'Paid', 'Cancelled', 'Pre-Sale']);
   let orderStatus = status || 'Pending';
   orderStatus = orderStatus.charAt(0).toUpperCase() + orderStatus.slice(1);
   if (!VALID_STATUSES.has(orderStatus)) orderStatus = 'Pending';

--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -76,9 +76,9 @@ router.get('/', async (req, res) => {
       .slice(0, 8);
 
     const currentMonth = today.substring(0, 7); // 'YYYY-MM'
-    const monthlyOrders = orders.filter(s => (s.OrderDate || '').startsWith(currentMonth) && s.Status !== 'Pre-Sale');
+    const monthlyOrders = orders.filter(s => (s.OrderDate || '').startsWith(currentMonth) && s.Status !== 'Pre-Sale' && s.Status !== 'Draft');
     const monthlyOrdersTotal = monthlyOrders.reduce((sum, s) => sum + parseFloat(s.OrderAmount || 0), 0);
-    const pendingDeliveries = orders.filter(s => s.Delivered !== 'true' && s.Status !== 'Cancelled' && s.Status !== 'Pre-Sale').length;
+    const pendingDeliveries = orders.filter(s => s.Delivered !== 'true' && s.Status !== 'Cancelled' && s.Status !== 'Pre-Sale' && s.Status !== 'Draft').length;
 
     res.json({
       totalProducts: inventory.length,

--- a/routes/gallonage.js
+++ b/routes/gallonage.js
@@ -34,7 +34,7 @@ router.get('/', async (req, res) => {
     // Date range + exclude Cancelled/Pre-Sale
     const salesOrders = orders.filter(o => {
       const d = (o.OrderDate || '').substring(0, 10);
-      return d >= start && d <= end && o.Status !== 'Cancelled' && o.Status !== 'Pre-Sale';
+      return d >= start && d <= end && o.Status !== 'Cancelled' && o.Status !== 'Pre-Sale' && o.Status !== 'Draft';
     });
 
     // Build account lookup

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -70,7 +70,7 @@ router.post('/', async (req, res) => {
       DepositAmount: DepositAmount || '0',
       Notes:     Notes     || '',
       RequestedProducts: RequestedProducts || '',
-      Status:    Status    || 'Pending',
+      Status:    Status    || 'Draft',
       Delivered: Delivered || 'false',
       CreatedAt: new Date().toISOString(),
     };

--- a/routes/reports.js
+++ b/routes/reports.js
@@ -50,7 +50,7 @@ router.get('/', async (req, res) => {
       const d = (o.OrderDate || '').substring(0, 10);
       return d >= start && d <= end;
     });
-    const salesOrders = dateFilteredOrders.filter(o => o.Status !== 'Cancelled' && o.Status !== 'Pre-Sale');
+    const salesOrders = dateFilteredOrders.filter(o => o.Status !== 'Cancelled' && o.Status !== 'Pre-Sale' && o.Status !== 'Draft');
 
     // Build sets for quick lookups
     const salesOrderIds = new Set(salesOrders.map(o => o.ID));


### PR DESCRIPTION
## Summary
- Adds a **Draft** status as the default for new orders, giving admins a preparation stage before finalizing
- QBO sync prompt only appears when transitioning from Draft to Pending/Paid, not when first saving a draft
- Draft orders are excluded from dashboard stats, gallonage calculations, and sales reports
- Draft orders show a gray badge, hide the delivery checkbox, and display a "Paid" quick-action button

## Test plan
- [x] Create a new order → defaults to Draft, no QBO prompt
- [x] Edit a Draft order, change to Pending → QBO prompt appears
- [x] Verify Draft orders are excluded from dashboard stats, gallonage, and reports
- [x] Verify Draft orders show gray badge, "Paid" button, "Edit" button, and no delivery checkbox
- [x] Verify Pre-sale conversion still prompts QBO sync
- [x] Verify webhook API accepts Draft as valid status

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)