### PR TITLE
Add Receive button to Stock Levels page (#296)

### DIFF
--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -298,7 +298,13 @@ function openAdjustInventory(id) {
 }
 
 function openReceiveInventory() {
-  const items = (state.inventory || []).slice().sort((a, b) => {
+  const seen = new Set();
+  const items = (state.inventory || []).filter(i => {
+    const key = `${i.ProductID}|||${i.Format || ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  }).sort((a, b) => {
     const la = a.Format ? `${a.Name} — ${a.Format}` : a.Name;
     const lb = b.Format ? `${b.Name} — ${b.Format}` : b.Name;
     return la.localeCompare(lb);


### PR DESCRIPTION
## Summary
- Adds a green "Receive" button to each row's action menu on the Stock Levels page
- Opens a streamlined modal with quantity, date, and notes fields (with @mentions support)
- Submits a `received` stock movement via the existing `/api/stock-movements` endpoint — no backend changes needed

## Test plan
- [x] Verify "Receive" button appears in actions for each inventory row
- [x] Click Receive, enter a quantity, and submit — confirm stock total updates
- [x] Check History to confirm a "Received" movement was recorded
- [x] Verify the existing "Adjust" button still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)