### PR TITLE
Prevent duplicate staff members by email (#268)

### DIFF
--- a/public/js/staff.js
+++ b/public/js/staff.js
@@ -135,11 +135,13 @@ function openAddStaff() {
   modal.open('Add Staff Member', staffForm(), async () => {
     const name = val('f-name');
     if (!name) { toast('Name is required', 'error'); return; }
-    await api.post('/api/staff', {
-      Name: name, Role: val('f-role'), Email: val('f-email'),
-      Phone: val('f-phone'), Notes: val('f-notes'),
-      Locations: _getCheckedLocations(),
-    });
+    try {
+      await api.post('/api/staff', {
+        Name: name, Role: val('f-role'), Email: val('f-email'),
+        Phone: val('f-phone'), Notes: val('f-notes'),
+        Locations: _getCheckedLocations(),
+      });
+    } catch (err) { toast(err.message, 'error'); return; }
     modal.close();
     toast('Staff member added');
     loadStaff();
@@ -152,11 +154,13 @@ function openEditStaff(id) {
   modal.open('Edit Staff Member', staffForm(member), async () => {
     const name = val('f-name');
     if (!name) { toast('Name is required', 'error'); return; }
-    await api.put(`/api/staff/${id}`, {
-      Name: name, Role: val('f-role'), Email: val('f-email'),
-      Phone: val('f-phone'), Active: val('f-active'), Notes: val('f-notes'),
-      Locations: _getCheckedLocations(),
-    });
+    try {
+      await api.put(`/api/staff/${id}`, {
+        Name: name, Role: val('f-role'), Email: val('f-email'),
+        Phone: val('f-phone'), Active: val('f-active'), Notes: val('f-notes'),
+        Locations: _getCheckedLocations(),
+      });
+    } catch (err) { toast(err.message, 'error'); return; }
     modal.close();
     toast('Staff member updated');
     loadStaff();

--- a/routes/staff.js
+++ b/routes/staff.js
@@ -21,6 +21,12 @@ router.post('/', async (req, res) => {
     const { Name, Email, Phone, Role, Notes, Locations } = req.body;
     if (!Name) return res.status(400).json({ error: 'Name is required' });
 
+    if (Email && Email.trim()) {
+      const existing = await getAllRows('STAFF');
+      const dupe = existing.find(s => s.Email && s.Email.toLowerCase() === Email.trim().toLowerCase());
+      if (dupe) return res.status(409).json({ error: 'A staff member with this email already exists' });
+    }
+
     const member = {
       ID: uuidv4(),
       Name: Name.trim(),
@@ -46,6 +52,13 @@ router.put('/:id', async (req, res) => {
     const updates = { ...req.body };
     delete updates.ID;
     delete updates.CreatedAt;
+
+    if (updates.Email && updates.Email.trim()) {
+      const existing = await getAllRows('STAFF');
+      const dupe = existing.find(s => s.ID !== req.params.id && s.Email && s.Email.toLowerCase() === updates.Email.trim().toLowerCase());
+      if (dupe) return res.status(409).json({ error: 'A staff member with this email already exists' });
+    }
+
     const updated = await updateRow('STAFF', req.params.id, updates);
     res.json(updated);
   } catch (err) {


### PR DESCRIPTION
## Summary
- Adds duplicate email validation on the `POST /api/staff` and `PUT /api/staff/:id` endpoints
- Returns a 409 with a clear error message if a staff member with the same email already exists
- Frontend add/edit handlers now catch API errors and display them as toast notifications

Closes #268

## Test plan
- [x] Try creating a staff member with an email that already exists — should show error toast
- [x] Try editing a staff member's email to match another existing member — should show error toast
- [x] Creating/editing with a unique email still works as before
- [x] Creating staff with no email (blank) still works without conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)