### PR TITLE
Fix order amount not saving when editing a pending order (#314)

### DIFF
--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -407,11 +407,16 @@ async function initOrderCredit(accountId, orderId) {
   section.style.display = '';
   // If editing, the saved OrderAmount was already reduced by the credit.
   // Restore the pre-credit amount so the save logic doesn't double-deduct.
+  // But skip this if line items are present — recalcOrderAmount() already
+  // calculated the pre-credit total from line item prices.
   if (existingApplied > 0) {
-    const amountEl = document.getElementById('f-amount');
-    if (amountEl) {
-      const currentAmt = parseFloat(amountEl.value) || 0;
-      amountEl.value = (currentAmt + existingApplied).toFixed(2);
+    const hasLineItems = document.querySelectorAll('#order-line-items .order-line-item').length > 0;
+    if (!hasLineItems) {
+      const amountEl = document.getElementById('f-amount');
+      if (amountEl) {
+        const currentAmt = parseFloat(amountEl.value) || 0;
+        amountEl.value = (currentAmt + existingApplied).toFixed(2);
+      }
     }
   }
   const info = document.getElementById('order-credit-info');
@@ -605,7 +610,7 @@ function _buildTierDropdown(prices, selectedTier) {
   </select>`;
 }
 
-function addOrderLineItem(inventoryId, qty, priceTier) {
+function addOrderLineItem(inventoryId, qty, priceTier, savedUnitPrice) {
   const wrap = document.getElementById('order-line-items');
   if (!wrap) return;
 
@@ -620,6 +625,10 @@ function addOrderLineItem(inventoryId, qty, priceTier) {
   } else if (prices.length === 1) {
     selectedPrice = parseFloat(prices[0].price || 0);
     selectedTierLabel = prices[0].label || '';
+  }
+  // Override with saved unit price from order item (preserves original price during edit)
+  if (savedUnitPrice !== undefined && parseFloat(savedUnitPrice) > 0) {
+    selectedPrice = parseFloat(savedUnitPrice);
   }
   const lineQty = qty || 1;
   const lineTotal = selectedPrice * lineQty;
@@ -775,7 +784,7 @@ async function refreshOrderProductsFromItems(orderItems, readOnly = false) {
   wrap.innerHTML = orderProductsHtml();
   for (const item of orderItems) {
     if (item.InventoryID) {
-      addOrderLineItem(item.InventoryID, parseInt(item.Quantity || 0), item.PriceTier || undefined);
+      addOrderLineItem(item.InventoryID, parseInt(item.Quantity || 0), item.PriceTier || undefined, item.UnitPrice);
     }
   }
 }
@@ -1321,7 +1330,7 @@ async function openEditOrder(id) {
       taxEl.style.background = '#f5f5f5';
     }
   }
-  if (!isPaid) initOrderCredit(order.AccountID, id);
+  if (!isPaid) await initOrderCredit(order.AccountID, id);
 }
 
 async function deleteOrder(id) {


### PR DESCRIPTION
## Summary
- **Preserve saved unit prices on edit**: When editing an order with existing line items, `addOrderLineItem` now uses the saved `UnitPrice` from the order item instead of re-looking up prices from current inventory. Previously, if inventory prices changed after order creation, the amount would silently recalculate to a different value on save.
- **Fix credit double-counting**: For orders with previously applied credit, `recalcOrderAmount()` already sets the amount to the pre-credit line item total. `initOrderCredit` was then adding the credit back again (assuming the amount was still credit-reduced), inflating the saved amount by the credit amount on every edit.
- **Await credit initialization**: `initOrderCredit` was not awaited, so fast saves could occur before credit state was initialized, losing credit application entirely.

## Test plan
- [ ] Edit a pending order with line items — amount should match the original, not recalculate from current inventory prices
- [ ] Edit a pending order that has account credit applied — amount should remain correct after save (not increase by the credit amount)
- [ ] Save an order quickly after opening edit — credit should still be applied correctly

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)