### PR TITLE
Show all in-stock products regardless of allocation (#319)

### DIFF
--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -32,9 +32,9 @@ function renderInventory() {
   const stockFilter = _invStockFilter;
 
   let filtered = items;
-  if (stockFilter === 'in-stock') filtered = filtered.filter(i => parseInt(i.Available || i.Units || '0') > 0);
-  else if (stockFilter === 'low') filtered = filtered.filter(i => { const a = parseInt(i.Available || i.Units || '0'); return a > 0 && a <= parseInt(i.LowStockThreshold || '5'); });
-  else if (stockFilter === 'out') filtered = filtered.filter(i => parseInt(i.Available || i.Units || '0') <= 0);
+  if (stockFilter === 'in-stock') filtered = filtered.filter(i => parseInt(i.Units || '0') > 0);
+  else if (stockFilter === 'low') filtered = filtered.filter(i => { const u = parseInt(i.Units || '0'); return u > 0 && u <= parseInt(i.LowStockThreshold || '5'); });
+  else if (stockFilter === 'out') filtered = filtered.filter(i => parseInt(i.Units || '0') <= 0);
 
   if (search) filtered = filtered.filter(i =>
     (i.Name || '').toLowerCase().includes(search.toLowerCase()) || (i.Style || '').toLowerCase().includes(search.toLowerCase())


### PR DESCRIPTION
## Summary
- In-Stock filter now shows all products with physical stock (Units > 0), even if some units are allocated to pending orders
- Low Stock and Out of Stock filters also use total Units for consistency
- Previously these filters used Available (Units minus Allocated), which hid products that were fully allocated but still physically in stock

Closes #319

## Test plan
- [ ] Add inventory for a product, create an order allocating all units
- [ ] Verify the product still appears under "In-Stock Only" filter
- [ ] Verify "Out of Stock" only shows products with 0 total units
- [ ] Verify "Low Stock" threshold is based on total units

🤖 Generated with [Claude Code](https://claude.com/claude-code)