### PR TITLE
Style email queue action links

### DIFF
--- a/public/js/inbound-emails.js
+++ b/public/js/inbound-emails.js
@@ -32,22 +32,22 @@ function renderInboundEmailQueue(emails, total) {
 
     // Build compact action links
     const links = [];
-    links.push(`<a href="#" onclick="viewInboundEmailDetail('${esc(e.ID)}');return false">Details</a>`);
+    links.push(`<a href="#" class="action-link" onclick="viewInboundEmailDetail('${esc(e.ID)}');return false">Details</a>`);
     if (e.Status === 'pending' || e.Status === 'error') {
-      links.push(`<a href="#" onclick="retryInboundEmail('${esc(e.ID)}');return false">Parse</a>`);
+      links.push(`<a href="#" class="action-link" onclick="retryInboundEmail('${esc(e.ID)}');return false">Parse</a>`);
     }
     if (e.Status === 'parsed' && e._accountMatched === false) {
-      links.push(`<a href="#" onclick="createAccountAndOrder('${esc(e.ID)}');return false">New Account + Order</a>`);
+      links.push(`<a href="#" class="action-link" onclick="createAccountAndOrder('${esc(e.ID)}');return false">New Account + Order</a>`);
     } else if (e.Status === 'parsed' || (e.Status === 'order_created' && e._orderMissing)) {
-      links.push(`<a href="#" onclick="resetAndCreateOrder('${esc(e.ID)}');return false">Create Order</a>`);
+      links.push(`<a href="#" class="action-link" onclick="resetAndCreateOrder('${esc(e.ID)}');return false">Create Order</a>`);
     }
     if (e.Status === 'order_created' && e.OrderID && !e._orderMissing) {
-      links.push(`<a href="#" onclick="viewEmailOrder('${esc(e.OrderID)}');return false">View Order</a>`);
+      links.push(`<a href="#" class="action-link" onclick="viewEmailOrder('${esc(e.OrderID)}');return false">View Order</a>`);
     }
     if ((e.Status !== 'order_created' && e.Status !== 'skipped') || (e.Status === 'order_created' && e._orderMissing)) {
-      links.push(`<a href="#" onclick="skipInboundEmail('${esc(e.ID)}');return false">Skip</a>`);
+      links.push(`<a href="#" class="action-link" onclick="skipInboundEmail('${esc(e.ID)}');return false">Skip</a>`);
     }
-    links.push(`<a href="#" class="text-danger" onclick="deleteInboundEmail('${esc(e.ID)}');return false">Delete</a>`);
+    links.push(`<a href="#" class="action-link text-danger" onclick="deleteInboundEmail('${esc(e.ID)}');return false">Delete</a>`);
 
     const badges = statusBadge(e.Status)
       + (e._orderMissing ? ' <span class="badge badge-danger">Order missing</span>' : '')

--- a/public/style.css
+++ b/public/style.css
@@ -1006,6 +1006,10 @@ textarea.form-control { resize: vertical; min-height: 72px; }
 .text-sm      { font-size: 12px; }
 .hidden       { display: none !important; }
 .text-danger  { color: #c62828; }
+.action-link  { color: var(--text-secondary); text-decoration: none; font-weight: 500; }
+.action-link:hover { color: var(--accent); }
+.action-link.text-danger { color: #c62828; }
+.action-link.text-danger:hover { color: #b71c1c; }
 .text-warning { color: #e65100; }
 .text-success { color: var(--green-dark); }
 .fw-600       { font-weight: 600; }


### PR DESCRIPTION
## Summary
- Add `.action-link` CSS class for inline action links in the email queue
- Links now use the app's green text color (`--text-secondary`) instead of default browser blue
- No underline, medium font weight, accent color on hover
- Delete link retains red color with darker hover state

## Test plan
- [ ] Open email queue modal — action links (Details, Create Order, Skip, Delete) should match app styling
- [ ] Hover over links — should turn accent orange
- [ ] Delete link should be red, darker on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)