### PR TITLE
Add staff send-from email chooser

### DIFF
--- a/email-service.js
+++ b/email-service.js
@@ -63,7 +63,7 @@ function buildRawMessage({ from, to, cc, bcc, replyTo, subject, body }) {
  * @param {string} opts.body         - Plain-text body
  * @returns {Promise<object>}        - Gmail API response
  */
-async function sendEmail({ user, to, cc, bcc, replyTo, subject, body }) {
+async function sendEmail({ user, to, cc, bcc, replyTo, subject, body, fromEmail }) {
   if (!isEmailConfigured()) {
     throw new Error('Email is not configured. Google OAuth credentials are missing.');
   }
@@ -86,7 +86,7 @@ async function sendEmail({ user, to, cc, bcc, replyTo, subject, body }) {
   const bccAddress = bcc && bcc.length > 0 ? bcc.join(', ') : undefined;
 
   const raw = buildRawMessage({
-    from:    user.email,
+    from:    fromEmail || user.email,
     to:      toAddress,
     cc:      ccAddress,
     bcc:     bccAddress,

--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -1336,6 +1336,16 @@ function updateBulkEmailBar() {
   }
 }
 
+function fromEmailHtml() {
+  if (state.userEmails && state.userEmails.length > 1) {
+    const opts = state.userEmails.map(e =>
+      `<option value="${esc(e)}"${e === state.userEmail ? ' selected' : ''}>${esc(e)}</option>`
+    ).join('');
+    return `<select class="form-control" id="f-email-from">${opts}</select>`;
+  }
+  return `<input class="form-control" id="f-email-from" value="${esc(state.userEmail || '')}" readonly style="background:#f5f5f5;cursor:default" />`;
+}
+
 function openEmailCompose(accountId) {
   const acct = state.accounts.find(a => a.ID === accountId);
   if (!acct) return;
@@ -1362,7 +1372,7 @@ function openEmailCompose(accountId) {
     </div>
     <div class="form-group">
       <label>From</label>
-      <input class="form-control" value="${esc(state.userEmail || '')}" readonly style="background:#f5f5f5;cursor:default" />
+      ${fromEmailHtml()}
     </div>
     <div class="form-group">
       <label>Subject <span class="required">*</span></label>
@@ -1375,8 +1385,9 @@ function openEmailCompose(accountId) {
     </div>`;
 
   modal.open('Send Email', formHtml, async () => {
-    const subject = val('f-email-subject');
-    const body    = val('f-email-body');
+    const subject   = val('f-email-subject');
+    const body      = val('f-email-body');
+    const fromEmail = val('f-email-from');
     if (!subject) { toast('Subject is required', 'error'); return; }
     if (!body)    { toast('Message is required', 'error'); return; }
 
@@ -1386,6 +1397,7 @@ function openEmailCompose(accountId) {
         cc:          ccEmails.length > 0 ? ccEmails : undefined,
         subject,
         body,
+        fromEmail,
         accountId:   acct.ID,
         accountName: acct.Name,
       });
@@ -1443,7 +1455,7 @@ function openBulkEmail() {
     </div>
     <div class="form-group">
       <label>From</label>
-      <input class="form-control" value="${esc(state.userEmail || '')}" readonly style="background:#f5f5f5;cursor:default" />
+      ${fromEmailHtml()}
     </div>
     <div class="form-group">
       <label>Subject <span class="required">*</span></label>
@@ -1456,8 +1468,9 @@ function openBulkEmail() {
     </div>`;
 
   modal.open('Send Bulk Email', formHtml, async () => {
-    const subject = val('f-email-subject');
-    const body    = val('f-email-body');
+    const subject   = val('f-email-subject');
+    const body      = val('f-email-body');
+    const fromEmail = val('f-email-from');
     if (!subject) { toast('Subject is required', 'error'); return; }
     if (!body)    { toast('Message is required', 'error'); return; }
 
@@ -1469,7 +1482,7 @@ function openBulkEmail() {
     }));
 
     try {
-      const result = await api.post('/api/email/bulk', { recipients, subject, body });
+      const result = await api.post('/api/email/bulk', { recipients, subject, body, fromEmail });
       modal.close();
       toast(`Email sent to ${result.sent} address${result.sent !== 1 ? 'es' : ''}`);
       document.querySelectorAll('.acct-select:checked').forEach(cb => { cb.checked = false; });

--- a/public/js/init.js
+++ b/public/js/init.js
@@ -147,8 +147,9 @@ async function init() {
   try {
     const { user } = await api.get('/auth/me');
     if (user) {
-      state.userEmail = user.email || '';
-      state.userName  = user.name  || '';
+      state.userEmail  = user.email || '';
+      state.userName   = user.name  || '';
+      state.userEmails = user.staffEmails || [user.email];
       const panel = document.getElementById('sidebar-user');
       if (panel) {
         document.getElementById('sidebar-user-name').textContent  = user.name  || '';

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -133,7 +133,24 @@ router.get('/google/callback',
 router.get('/me', (req, res) => {
   if (req.isAuthenticated && req.isAuthenticated()) {
     const { id, name, email, photo } = req.user;
-    return res.json({ user: { id, name, email, photo } });
+
+    // Look up the STAFF row whose comma-separated Email field contains
+    // the authenticated user's email so we can expose all their addresses.
+    let staffEmails = [email];
+    const userLower = (email || '').toLowerCase();
+    if (userLower) {
+      const staffRows = getAllRows('STAFF');
+      for (const s of staffRows) {
+        if (!s.Email) continue;
+        const parsed = s.Email.split(',').map(e => e.trim()).filter(Boolean);
+        if (parsed.some(e => e.toLowerCase() === userLower)) {
+          staffEmails = parsed;
+          break;
+        }
+      }
+    }
+
+    return res.json({ user: { id, name, email, photo, staffEmails } });
   }
   res.status(401).json({ user: null });
 });

--- a/routes/email.js
+++ b/routes/email.js
@@ -20,6 +20,28 @@ function getReplyToAddress(user) {
 }
 
 /**
+ * Validate that a requested fromEmail belongs to the user's STAFF record.
+ * Falls back to the OAuth email if missing or invalid.
+ */
+function validateFromEmail(oauthEmail, fromEmail) {
+  if (!fromEmail) return oauthEmail;
+  const requested = fromEmail.trim().toLowerCase();
+  if (requested === oauthEmail.toLowerCase()) return fromEmail.trim();
+
+  const staffRows = getAllRows('STAFF');
+  const oauthLower = oauthEmail.toLowerCase();
+  for (const s of staffRows) {
+    if (!s.Email) continue;
+    const emails = s.Email.split(',').map(e => e.trim()).filter(Boolean);
+    if (emails.some(e => e.toLowerCase() === oauthLower) &&
+        emails.some(e => e.toLowerCase() === requested)) {
+      return fromEmail.trim();
+    }
+  }
+  return oauthEmail;
+}
+
+/**
  * Create an Outreach log entry for an emailed account and update LastContacted.
  */
 async function logOutreach(accountId, accountName, subject) {
@@ -56,21 +78,23 @@ router.post('/send', async (req, res) => {
       return res.status(503).json({ error: 'Email is not configured. Google OAuth credentials are missing.' });
     }
 
-    const { to, cc, subject, body, accountId, accountName } = req.body;
+    const { to, cc, subject, body, accountId, accountName, fromEmail } = req.body;
 
     if (!to)      return res.status(400).json({ error: 'Recipient email is required' });
     if (!subject) return res.status(400).json({ error: 'Subject is required' });
     if (!body)    return res.status(400).json({ error: 'Message body is required' });
 
+    // Validate fromEmail belongs to this user's staff record
+    const validatedFrom = validateFromEmail(req.user.email, fromEmail);
     const senderName  = req.user.name  || 'Brewery Team';
-    const senderEmail = req.user.email || '';
+    const senderEmail = validatedFrom;
     const ccEmails = Array.isArray(cc) ? cc.filter(Boolean) : [];
 
     let status = 'sent';
     let error  = '';
 
     try {
-      await sendEmail({ user: req.user, to, cc: ccEmails.length > 0 ? ccEmails : undefined, replyTo: getReplyToAddress(req.user), subject, body });
+      await sendEmail({ user: req.user, to, cc: ccEmails.length > 0 ? ccEmails : undefined, replyTo: getReplyToAddress(req.user), subject, body, fromEmail: validatedFrom });
     } catch (err) {
       status = 'failed';
       error  = err.message;
@@ -116,7 +140,7 @@ router.post('/bulk', async (req, res) => {
       return res.status(503).json({ error: 'Email is not configured. Google OAuth credentials are missing.' });
     }
 
-    const { recipients, subject, body } = req.body;
+    const { recipients, subject, body, fromEmail } = req.body;
     // recipients: [{ email, additionalEmails, accountId, accountName }, ...]
 
     if (!recipients || !Array.isArray(recipients) || recipients.length === 0) {
@@ -124,6 +148,9 @@ router.post('/bulk', async (req, res) => {
     }
     if (!subject) return res.status(400).json({ error: 'Subject is required' });
     if (!body)    return res.status(400).json({ error: 'Message body is required' });
+
+    // Validate fromEmail belongs to this user's staff record
+    const validatedFrom = validateFromEmail(req.user.email, fromEmail);
 
     const bccEmails = [];
     for (const r of recipients) {
@@ -139,13 +166,13 @@ router.post('/bulk', async (req, res) => {
     }
 
     const senderName  = req.user.name  || 'Brewery Team';
-    const senderEmail = req.user.email || '';
+    const senderEmail = validatedFrom;
 
     let status = 'sent';
     let error  = '';
 
     try {
-      await sendEmail({ user: req.user, bcc: bccEmails, replyTo: getReplyToAddress(req.user), subject, body });
+      await sendEmail({ user: req.user, bcc: bccEmails, replyTo: getReplyToAddress(req.user), subject, body, fromEmail: validatedFrom });
     } catch (err) {
       status = 'failed';
       error  = err.message;


### PR DESCRIPTION
## Summary
- Staff with multiple comma-separated emails in their STAFF record now see a **dropdown** in email compose modals to choose which address to send from
- Staff with a single email see the existing readonly input (no change)
- Server-side validation ensures the chosen `fromEmail` belongs to the same STAFF record as the OAuth email, falling back gracefully if invalid

## Changes
- **`routes/auth.js`** — `GET /auth/me` returns `staffEmails` array from matching STAFF row
- **`public/js/init.js`** — Stores `state.userEmails` from the auth response
- **`public/js/accounts.js`** — `fromEmailHtml()` helper renders dropdown or readonly input; both `openEmailCompose()` and `openBulkEmail()` pass selected `fromEmail` to API
- **`routes/email.js`** — `validateFromEmail()` helper validates address belongs to user's STAFF record; used in both `/send` and `/bulk`
- **`email-service.js`** — Accepts optional `fromEmail` param, uses it in MIME `From:` header

## Test plan
- [ ] Staff with multiple emails → "From" shows dropdown with all addresses
- [ ] Staff with single email → readonly input (unchanged behavior)
- [ ] Select alternate email, send → email log `SenderEmail` and MIME header use chosen address
- [ ] Same behavior for bulk email
- [ ] Invalid `fromEmail` in API request → falls back to OAuth email

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)