### PR TITLE
Make beer style options configurable

### DIFF
--- a/public/js/core.js
+++ b/public/js/core.js
@@ -5,7 +5,8 @@ let LOCATIONS = [];      // Populated from settings on init
 let ACCOUNT_TAGS = [];   // Populated from settings on init
 
 const FORMATS = ['1/6 Keg', '1/4 Keg', '1/2 Keg', '12oz Can (case/24)', '16oz Can (case/24)', '22oz Bottle (case/12)', '750ml Bottle (case/12)', 'Other'];
-const STYLES  = ['IPA', 'Double IPA', 'Pale Ale', 'Lager', 'Pilsner', 'Wheat', 'Hefeweizen', 'Stout', 'Porter', 'Sour', 'Saison', 'Amber', 'Brown Ale', 'Barleywine', 'Scottish', 'English Mild', 'Kölsch', 'Golden Ale', 'Other'];
+const DEFAULT_STYLES = ['IPA', 'Double IPA', 'Pale Ale', 'Lager', 'Pilsner', 'Wheat', 'Hefeweizen', 'Stout', 'Porter', 'Sour', 'Saison', 'Amber', 'Brown Ale', 'Barleywine', 'Scottish', 'English Mild', 'Kölsch', 'Golden Ale', 'Other'];
+let STYLES = [...DEFAULT_STYLES]; // Populated from settings on init
 const PAYMENT_METHODS = ['Check', 'Cash', 'ACH', 'Credit Card', 'Other'];
 
 const state = {

--- a/public/js/init.js
+++ b/public/js/init.js
@@ -131,6 +131,9 @@ function applySettings(settings) {
   if (Array.isArray(settings.accountTags) && settings.accountTags.length > 0) {
     ACCOUNT_TAGS = settings.accountTags;
   }
+  if (Array.isArray(settings.styles) && settings.styles.length > 0) {
+    STYLES = settings.styles;
+  }
   if (settings.companyName) {
     const el = document.getElementById('brand-title');
     if (el) el.textContent = settings.companyName;

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -27,6 +27,7 @@ function renderSettings() {
   const companyName = s.companyName || '';
   const locations = Array.isArray(s.locations) ? s.locations : [...LOCATIONS];
   const accountTags = Array.isArray(s.accountTags) ? s.accountTags : [];
+  const styles = Array.isArray(s.styles) ? s.styles : [...STYLES];
   const kegDeposits = getKegDeposits();
   const kegFormats = ['1/6 Keg', '1/4 Keg', '1/2 Keg'];
 
@@ -93,6 +94,31 @@ function renderSettings() {
                     <div class="settings-location-actions">
                       <button class="btn btn-ghost btn-sm" onclick="openRenameAccountTag(${i}, '${esc(t)}')">Rename</button>
                       <button class="btn btn-ghost btn-sm text-danger" onclick="removeAccountTag(${i}, '${esc(t)}')">Remove</button>
+                    </div>
+                  </li>`).join('')}
+              </ul>`
+          }
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <h3>Beer Styles</h3>
+          <button class="btn btn-ghost btn-sm" onclick="openAddStyle()">+ Add Style</button>
+        </div>
+        <div style="padding:0 18px 18px">
+          <p class="text-sm text-muted" style="margin-bottom:12px">
+            Manage beer style options. These appear in the product form style dropdown.
+          </p>
+          ${styles.length === 0
+            ? '<p class="empty-state">No styles configured.</p>'
+            : `<ul class="settings-location-list">
+                ${styles.map((st, i) => `
+                  <li class="settings-location-item">
+                    <span class="settings-location-name">${esc(st)}</span>
+                    <div class="settings-location-actions">
+                      <button class="btn btn-ghost btn-sm" onclick="openRenameStyle(${i}, '${esc(st)}')">Rename</button>
+                      <button class="btn btn-ghost btn-sm text-danger" onclick="removeStyle(${i}, '${esc(st)}')">Remove</button>
                     </div>
                   </li>`).join('')}
               </ul>`
@@ -372,6 +398,65 @@ function removeAccountTag(index, name) {
     applySettings(updated);
     modal.close();
     toast('Tag removed');
+    renderSettings();
+  });
+}
+
+// ── Beer Styles ──────────────────────────────────────────────────
+
+function openAddStyle() {
+  modal.open('Add Beer Style', `
+    <div class="form-group">
+      <label>Style Name <span class="required">*</span></label>
+      <input class="form-control" id="f-style-name" placeholder="e.g. Hazy IPA, Witbier" />
+    </div>
+  `, async () => {
+    const name = val('f-style-name');
+    if (!name) { toast('Style name is required', 'error'); return; }
+    const current = Array.isArray(state.settings.styles) ? [...state.settings.styles] : [...STYLES];
+    if (current.includes(name)) { toast('Style already exists', 'error'); return; }
+    current.push(name);
+    const updated = await api.put('/api/settings', { styles: current });
+    state.settings = updated;
+    applySettings(updated);
+    modal.close();
+    toast('Style added');
+    renderSettings();
+  });
+}
+
+function openRenameStyle(index, oldName) {
+  modal.open('Rename Beer Style', `
+    <div class="form-group">
+      <label>New Name <span class="required">*</span></label>
+      <input class="form-control" id="f-style-name" value="${esc(oldName)}" />
+    </div>
+    <p class="text-sm text-muted" style="margin-top:8px">All products and inventory with this style will be updated.</p>
+  `, async () => {
+    const newName = val('f-style-name');
+    if (!newName) { toast('Style name is required', 'error'); return; }
+    const current = Array.isArray(state.settings.styles) ? [...state.settings.styles] : [...STYLES];
+    if (current.includes(newName) && newName !== oldName) { toast('Style already exists', 'error'); return; }
+    current[index] = newName;
+    const updated = await api.put('/api/settings/rename-style', { oldName, newName, styles: current });
+    state.settings = updated;
+    applySettings(updated);
+    modal.close();
+    const info = updated._renamed || {};
+    toast(`Style renamed — ${info.productsUpdated || 0} product(s) and ${info.inventoryUpdated || 0} inventory item(s) updated`);
+    renderSettings();
+  });
+}
+
+function removeStyle(index, name) {
+  const current = Array.isArray(state.settings.styles) ? [...state.settings.styles] : [...STYLES];
+  modal.confirm('Remove Style', `Remove "${name}"? Existing products with this style will not be affected.`, async () => {
+    current.splice(index, 1);
+    const updated = await api.put('/api/settings', { styles: current });
+    state.settings = updated;
+    applySettings(updated);
+    modal.close();
+    toast('Style removed');
     renderSettings();
   });
 }

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -38,6 +38,10 @@ function sanitizeSettings(settings) {
     try { settings.accountTags = JSON.parse(settings.accountTags); }
     catch (e) { settings.accountTags = []; }
   }
+  if (settings.styles) {
+    try { settings.styles = JSON.parse(settings.styles); }
+    catch (e) { settings.styles = []; }
+  }
   if (settings.kegDeposits) {
     try { settings.kegDeposits = JSON.parse(settings.kegDeposits); }
     catch (e) { settings.kegDeposits = {}; }
@@ -64,7 +68,7 @@ router.get('/', async (req, res) => {
 // Secrets (qboTokens, apiKeys, google_refresh_token:*, inboundEmailWebhookToken)
 // are managed through dedicated endpoints and cannot be overwritten here.
 const ALLOWED_SETTINGS_KEYS = new Set([
-  'locations', 'accountTags', 'kegDeposits', 'companyName',
+  'locations', 'accountTags', 'styles', 'kegDeposits', 'companyName',
   'inboundEmail', 'geminiApiKey', 'qboTaxCodeId',
 ]);
 
@@ -190,6 +194,57 @@ router.put('/rename-account-tag', async (req, res) => {
     for (const row of updated) result[row.Key] = row.Value;
     const safe = sanitizeSettings(result);
     safe._renamed = { accountsUpdated };
+    res.json(safe);
+  } catch (err) {
+    console.error(`[settings] ${err.message}`);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// PUT /api/settings/rename-style — renames a style and updates all associated products and inventory
+router.put('/rename-style', async (req, res) => {
+  try {
+    const { oldName, newName, styles } = req.body;
+    if (!oldName || !newName) return res.status(400).json({ error: 'oldName and newName are required' });
+
+    // Update the styles list in settings
+    const settingsRows = await getAllRows('SETTINGS');
+    const existingByKey = {};
+    for (const row of settingsRows) existingByKey[row.Key] = row;
+    const stylesValue = JSON.stringify(styles);
+    const now = new Date().toISOString().split('T')[0];
+    if (existingByKey.styles) {
+      await updateRow('SETTINGS', existingByKey.styles.ID, { Value: stylesValue, UpdatedAt: now });
+    } else {
+      await addRow('SETTINGS', { ID: uuidv4(), Key: 'styles', Value: stylesValue, UpdatedAt: now });
+    }
+
+    // Update all product records with the old style
+    const products = await getAllRows('PRODUCTS');
+    let productsUpdated = 0;
+    for (const p of products) {
+      if (p.Style === oldName) {
+        await updateRow('PRODUCTS', p.ID, { Style: newName });
+        productsUpdated++;
+      }
+    }
+
+    // Update all inventory records with the old style
+    const inventory = await getAllRows('INVENTORY');
+    let inventoryUpdated = 0;
+    for (const item of inventory) {
+      if (item.Style === oldName) {
+        await updateRow('INVENTORY', item.ID, { Style: newName });
+        inventoryUpdated++;
+      }
+    }
+
+    // Return updated settings
+    const updated = await getAllRows('SETTINGS');
+    const result = {};
+    for (const row of updated) result[row.Key] = row.Value;
+    const safe = sanitizeSettings(result);
+    safe._renamed = { productsUpdated, inventoryUpdated };
     res.json(safe);
   } catch (err) {
     console.error(`[settings] ${err.message}`);


### PR DESCRIPTION
## Summary
- Beer styles are now manageable from the **Settings** page (add, rename, remove) instead of being hardcoded
- Follows the existing pattern used by Locations and Account Tags
- Renaming a style cascades the change across all PRODUCTS and INVENTORY records
- The hardcoded default list is used until styles are first customized

## Changes
- **`public/js/core.js`** — Changed `STYLES` from `const` to `let` with `DEFAULT_STYLES` fallback
- **`public/js/init.js`** — `applySettings()` populates `STYLES` from settings
- **`public/js/settings.js`** — Beer Styles card with add/rename/remove UI
- **`routes/settings.js`** — Added `styles` to allowed keys, JSON parsing, and `PUT /rename-style` cascade endpoint

## Test plan
- [x] Settings page shows Beer Styles card with all default styles listed
- [x] Add a new style → appears in the list and in the product form dropdown
- [x] Rename a style → all products and inventory with that style are updated
- [x] Remove a style → removed from list; existing products unaffected
- [x] Product form dropdown reflects custom styles after page refresh

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)