### PR TITLE
Add tabbed navigation to Settings screen

### DIFF
--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -39,6 +39,12 @@ function renderSettings() {
       </div>
     </div>
 
+    <div class="settings-tabs">
+      <button class="settings-tab active" data-tab="general" onclick="switchSettingsTab('general')">General</button>
+      <button class="settings-tab" data-tab="integrations" onclick="switchSettingsTab('integrations')">Integrations</button>
+    </div>
+
+    <div class="settings-tab-content active" data-tab="general">
     <div class="settings-grid">
       <div class="card">
         <div class="card-header"><h3>Company</h3></div>
@@ -167,7 +173,11 @@ function renderSettings() {
           <button class="btn btn-primary" onclick="saveTaxRate()">Save</button>
         </div>
       </div>
+    </div>
+    </div>
 
+    <div class="settings-tab-content" data-tab="integrations">
+    <div class="settings-grid">
       <div class="card" id="api-keys-card">
         <div class="card-header">
           <h3>API Keys</h3>
@@ -231,11 +241,17 @@ function renderSettings() {
           <p class="text-sm text-muted">Loading QuickBooks status...</p>
         </div>
       </div>
+    </div>
     </div>`);
 
   // Load API keys and QBO status asynchronously
   loadApiKeys();
   loadQboStatus();
+}
+
+function switchSettingsTab(tab) {
+  document.querySelectorAll('.settings-tab').forEach(btn => btn.classList.toggle('active', btn.dataset.tab === tab));
+  document.querySelectorAll('.settings-tab-content').forEach(el => el.classList.toggle('active', el.dataset.tab === tab));
 }
 
 function saveCompanyName() {

--- a/public/style.css
+++ b/public/style.css
@@ -1184,6 +1184,47 @@ tr.row-completed button {
   font-size: 12px;
 }
 
+/* ── Settings Tabs ───────────────────────────────────── */
+
+.settings-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 20px;
+  border-bottom: 2px solid var(--border);
+  max-width: 640px;
+}
+
+.settings-tab {
+  padding: 8px 18px;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  cursor: pointer;
+  font-family: var(--font);
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.settings-tab:hover {
+  color: var(--text);
+}
+
+.settings-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.settings-tab-content {
+  display: none;
+}
+
+.settings-tab-content.active {
+  display: block;
+}
+
 /* ── Settings ────────────────────────────────────────── */
 
 .settings-grid {


### PR DESCRIPTION
## Summary
- Splits the Settings page into **General** and **Integrations** tabs to reduce scrolling
- **General** tab (default): Company, Locations, Account Tags, Beer Styles, Keg Deposits, Tax Rate
- **Integrations** tab: API Keys, Email Order Requests, QuickBooks Online
- CSS-only tab styling with a minimal JS tab switcher (`switchSettingsTab`)

## Test plan
- [ ] Settings page loads with "General" tab active showing 6 cards
- [ ] Click "Integrations" tab → shows API Keys, Email Order Requests, QBO cards
- [ ] Switch back to "General" → original cards visible, no state loss
- [ ] Page refresh defaults to General tab
- [ ] Mobile: tabs display correctly at narrow widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)