### PR TITLE
Fix email sending after session store migration

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -123,6 +123,13 @@ router.get('/google/callback',
     failWithError: false,
   }),
   (req, res) => {
+    // If no refresh token is stored, re-authenticate with consent to obtain one.
+    // This happens when sessions are reset or a user logs in for the first time
+    // after the session store was migrated.
+    const stored = getRow('SETTINGS', `google_refresh_token:${req.user.id}`);
+    if (!stored || !stored.Value) {
+      return res.redirect(basePath + '/auth/google?prompt=consent');
+    }
     // Successful authentication – go to the app.
     res.redirect(basePath + '/');
   },


### PR DESCRIPTION
## Summary
- Fixes "No OAuth refresh token found" error that prevents all staff from sending emails
- Caused by the security audit (#339) which removed tokens from sessions and switched to SQLite session store — existing sessions were invalidated, and re-login with `select_account` prompt doesn't get a new refresh token from Google
- The OAuth callback now checks for a stored refresh token after login; if none exists, it automatically redirects through the consent flow to obtain one

## Test plan
- [ ] Deploy and have a staff member log out and back in
- [ ] Google consent screen should appear automatically (one time only)
- [ ] After consenting, verify emails send successfully
- [ ] Subsequent logins should skip the consent screen (token is now stored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)