### PR TITLE
Add option to exclude products from email offerings

### DIFF
--- a/db.js
+++ b/db.js
@@ -32,7 +32,7 @@ const TABLES = {
 // HEADERS defines every column each table should have.
 // On startup, any missing columns are automatically added (migration-safe).
 const HEADERS = {
-  PRODUCTS:  ['ID', 'Name', 'Style', 'ABV', 'Format', 'PricePerUnit', 'Notes', 'CreatedAt'],
+  PRODUCTS:  ['ID', 'Name', 'Style', 'ABV', 'Format', 'PricePerUnit', 'Notes', 'ExcludeFromEmailOfferings', 'CreatedAt'],
   INVENTORY: ['ID', 'Name', 'Location', 'Style', 'ABV', 'Format', 'Units', 'PricePerUnit', 'Prices', 'LowStockThreshold', 'Notes', 'LastUpdated', 'ProductID', 'ProductName'],
   ACCOUNTS:  ['ID', 'Name', 'Type', 'Tags', 'ContactName', 'Email', 'AdditionalEmails', 'Phone', 'PreferredMethod', 'BillingContactName', 'BillingEmail', 'BillingPhone', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'ChargeDeposits', 'Taxable', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'ServicedBy', 'QboCustomerId', 'CreatedAt', 'CheckInFrequency'],
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],

--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -1202,7 +1202,7 @@ function formatItemLine(item, showQty) {
 }
 
 function buildInventoryOfferingText(items, category, showQty) {
-  const inStock = items.filter(i => parseInt(i.Available || i.Units || '0') > 0);
+  const inStock = items.filter(i => parseInt(i.Available || i.Units || '0') > 0 && i.ExcludeFromEmailOfferings !== 'true');
   if (inStock.length === 0) return 'No in-stock inventory found.';
 
   const fmt = item => formatItemLine(item, showQty);

--- a/public/js/products.js
+++ b/public/js/products.js
@@ -37,6 +37,12 @@ function productForm(product = {}) {
     <div class="form-group">
       <label>Notes</label>
       <textarea class="form-control" id="f-notes" rows="2">${esc(product.Notes)}</textarea>
+    </div>
+    <div class="form-group">
+      <label class="checkbox-label">
+        <input type="checkbox" id="f-exclude-email" ${product.ExcludeFromEmailOfferings === 'true' ? 'checked' : ''} />
+        Exclude from email offerings
+      </label>
     </div>`;
 }
 
@@ -295,6 +301,7 @@ function openAddProduct() {
       Style: val('f-style'),
       ABV: val('f-abv'),
       Notes: val('f-notes'),
+      ExcludeFromEmailOfferings: document.getElementById('f-exclude-email').checked ? 'true' : '',
       variations,
     });
     modal.close();
@@ -327,6 +334,7 @@ async function openEditProduct(id) {
       Style: val('f-style'),
       ABV: val('f-abv'),
       Notes: val('f-notes'),
+      ExcludeFromEmailOfferings: document.getElementById('f-exclude-email').checked ? 'true' : '',
     });
 
     // Diff variations: add new ones, remove deleted ones

--- a/routes/inventory.js
+++ b/routes/inventory.js
@@ -22,6 +22,7 @@ async function enrichInventory(items) {
       Format: inv.Format || product.Format || '',
       PricePerUnit: inv.PricePerUnit || product.PricePerUnit || '',
       Prices: inv.Prices || '',
+      ExcludeFromEmailOfferings: product.ExcludeFromEmailOfferings || '',
     };
   });
 }


### PR DESCRIPTION
## Summary
- Adds an `ExcludeFromEmailOfferings` flag to products, with a checkbox on the product add/edit form
- Passes the flag through inventory enrichment so the frontend can read it
- Filters excluded products out of the email compose "Insert Available Inventory" helper

## Test plan
- [ ] Edit an existing product, check "Exclude from email offerings", save
- [ ] Open email compose → Insert Available Inventory → confirm the flagged product is hidden
- [ ] Uncheck the flag → confirm product reappears in the inventory insert
- [ ] Create a new product with the flag checked → confirm it's excluded from the start

🤖 Generated with [Claude Code](https://claude.com/claude-code)