### PR TITLE
Add Twilio SMS integration

### DIFF
--- a/db.js
+++ b/db.js
@@ -27,6 +27,7 @@ const TABLES = {
   ACCOUNT_CREDITS: 'AccountCredits',
   WEBHOOK_LOG:     'WebhookLog',
   INBOUND_EMAILS:  'InboundEmails',
+  SMS_LOG:         'SmsLog',
 };
 
 // HEADERS defines every column each table should have.
@@ -49,6 +50,7 @@ const HEADERS = {
   ACCOUNT_CREDITS: ['ID', 'AccountID', 'AccountName', 'Type', 'Amount', 'OrderID', 'Reason', 'Notes', 'CreatedAt'],
   WEBHOOK_LOG:     ['ID', 'ApiKeyName', 'Action', 'Payload', 'Status', 'Error', 'CreatedAt'],
   INBOUND_EMAILS:  ['ID', 'GmailMessageId', 'GmailThreadId', 'From', 'FromName', 'To', 'Subject', 'Body', 'ReceivedAt', 'Status', 'ParsedData', 'OrderID', 'Error', 'CreatedAt'],
+  SMS_LOG:         ['ID', 'SenderName', 'SenderEmail', 'Recipient', 'Body', 'Type', 'AccountID', 'AccountName', 'TwilioSid', 'Status', 'Error', 'CreatedAt'],
 };
 
 // ── Database connection ───────────────────────────────────────────────

--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -302,12 +302,14 @@ function renderAccounts() {
       </div>
       <div class="view-header-actions">
         ${state.emailConfigured ? '<button class="btn btn-secondary" onclick="openBulkEmail()">Email Selected</button>' : ''}
+        ${state.smsConfigured ? '<button class="btn btn-secondary" onclick="openBulkSms()">Text Selected</button>' : ''}
         <button class="btn btn-primary" onclick="openAddAccount()">+ Add Account</button>
       </div>
     </div>
     <div id="bulk-actions-bar" class="bulk-actions-bar" style="display:none">
       <span id="bulk-selected-count" class="text-sm fw-600">0 selected</span>
-      <button class="btn btn-sm btn-secondary" onclick="openBulkEmail()">Email Selected</button>
+      ${state.emailConfigured ? '<button class="btn btn-sm btn-secondary" onclick="openBulkEmail()">Email Selected</button>' : ''}
+      ${state.smsConfigured ? '<button class="btn btn-sm btn-secondary" onclick="openBulkSms()">Text Selected</button>' : ''}
     </div>
     <div class="filter-bar">
       <input type="search" id="acct-search" placeholder="Search accounts..." value="${esc(search)}" oninput="_paginationReset('accounts'); renderAccounts()" />
@@ -332,15 +334,15 @@ function renderAccounts() {
       <table>
         <thead>
           <tr>
-            ${state.emailConfigured ? '<th style="width:32px"><input type="checkbox" onchange="toggleAllAccounts(this)" title="Select all" /></th>' : ''}
+            ${(state.emailConfigured || state.smsConfigured) ? '<th style="width:32px"><input type="checkbox" onchange="toggleAllAccounts(this)" title="Select all" /></th>' : ''}
             <th class="sortable-th${_acctSort.col === 'Name' ? ' sorted' : ''}" onclick="sortAccounts('Name')">Name${_acctSort.col === 'Name' ? (_acctSort.dir === 'asc' ? ' ▲' : ' ▼') : ''}</th><th class="mobile-hide">Type</th>
             <th class="mobile-hide">Preferred</th><th class="mobile-hide">Location</th><th>Status</th><th class="mobile-hide sortable-th${_acctSort.col === 'LastContacted' ? ' sorted' : ''}" onclick="sortAccounts('LastContacted')">Last Contact${_acctSort.col === 'LastContacted' ? (_acctSort.dir === 'asc' ? ' ▲' : ' ▼') : ''}</th><th class="mobile-hide">Check-in</th><th>Actions</th>
           </tr>
         </thead>
         <tbody>
-          ${pg.total === 0 ? `<tr><td colspan="${state.emailConfigured ? 9 : 8}" class="empty-state">No accounts found.</td></tr>` :
+          ${pg.total === 0 ? `<tr><td colspan="${(state.emailConfigured || state.smsConfigured) ? 9 : 8}" class="empty-state">No accounts found.</td></tr>` :
             pg.rows.map(a => `<tr>
-              ${state.emailConfigured ? `<td><input type="checkbox" class="acct-select" data-account-id="${esc(a.ID)}" onchange="updateBulkEmailBar()" /></td>` : ''}
+              ${(state.emailConfigured || state.smsConfigured) ? `<td><input type="checkbox" class="acct-select" data-account-id="${esc(a.ID)}" onchange="updateBulkEmailBar()" /></td>` : ''}
               <td class="fw-600"><span class="td-link" onclick="loadAccountProfile('${esc(a.ID)}')">${esc(a.Name)}</span><br><span class="text-muted text-sm">${esc(a.City)}${a.City && (a.State || a.Zip) ? ', ' : ''}${esc(a.State)}${a.State && a.Zip ? ' ' : ''}${esc(a.Zip)}</span>${(() => { let t = []; try { t = JSON.parse(a.Tags || '[]'); } catch(e) {} return t.length > 0 ? '<div class="tag-badges">' + t.map(x => '<span class="badge badge-tag">' + esc(x) + '</span>').join(' ') + '</div>' : ''; })()}</td>
               <td class="mobile-hide">${esc(a.Type)}</td>
               <td class="mobile-hide">${methodBadge(a.PreferredMethod)}</td>
@@ -531,6 +533,7 @@ async function loadAccountProfile(accountId) {
         <button class="btn btn-ghost btn-sm" onclick="openAddTodo('${esc(accountId)}')">+ Add Todo</button>
         <button class="btn btn-ghost btn-sm" onclick="openAddOrder('${esc(accountId)}')">+ Log Order</button>
         ${state.emailConfigured && accountHasEmail(acct) ? `<button class="btn btn-ghost btn-sm" onclick="openEmailCompose('${esc(accountId)}')">Email</button>` : ''}
+        ${state.smsConfigured && acct.Phone ? `<button class="btn btn-ghost btn-sm" onclick="openSmsCompose('${esc(accountId)}')">Text</button>` : ''}
         <button class="btn btn-ghost btn-sm" onclick="openMergeAccount('${esc(accountId)}')">Merge</button>
         </div>
         <button class="btn btn-primary btn-sm" onclick="openEditAccount('${esc(accountId)}')">Edit Account</button>
@@ -1295,7 +1298,7 @@ function updateInventoryPreview() {
 }
 
 function insertInventoryText() {
-  const textarea = document.getElementById('f-email-body');
+  const textarea = document.getElementById('f-email-body') || document.getElementById('f-sms-body');
   const preview = document.getElementById('inventory-preview');
   if (!textarea || !preview) return;
   const text = preview.textContent;
@@ -1489,6 +1492,159 @@ function openBulkEmail() {
       updateBulkEmailBar();
     } catch (err) {
       toast('Failed to send email: ' + (err.message || 'Unknown error'), 'error');
+    }
+  }, 'Send');
+}
+
+// ── SMS Functions ─────────────────────────────────────────────────
+
+function openSmsCompose(accountId) {
+  const acct = state.accounts.find(a => a.ID === accountId);
+  if (!acct) return;
+  _emailInventoryCache = null;
+  _emailInventoryCategory = 'All';
+  _emailInventoryShowQty = true;
+
+  if (!acct.Phone) {
+    toast('This account has no phone number on file', 'error');
+    return;
+  }
+
+  const formHtml = `
+    <div class="form-group">
+      <label>To</label>
+      <input class="form-control" value="${esc(formatPhone(acct.Phone))}" readonly style="background:#f5f5f5;cursor:default" />
+    </div>
+    ${inventoryHelperHtml()}
+    <div class="form-group">
+      <label>Message <span class="required">*</span></label>
+      <textarea class="form-control" id="f-sms-body" rows="6" placeholder="Type your message..." oninput="updateSmsCharCount()"></textarea>
+      <span class="text-sm text-muted" id="sms-char-count">0 characters</span>
+    </div>`;
+
+  modal.open('Send SMS', formHtml, async () => {
+    const body = val('f-sms-body');
+    if (!body) { toast('Message is required', 'error'); return; }
+
+    try {
+      await api.post('/api/sms/send', {
+        to:          acct.Phone,
+        body,
+        accountId:   acct.ID,
+        accountName: acct.Name,
+      });
+      modal.close();
+      toast('SMS sent successfully');
+      if (state.view === 'account-profile') loadAccountProfile(state.accountProfileId);
+    } catch (err) {
+      toast('Failed to send SMS: ' + (err.message || 'Unknown error'), 'error');
+    }
+  }, 'Send');
+}
+
+function updateSmsCharCount() {
+  const body = val('f-sms-body');
+  const counter = document.getElementById('sms-char-count');
+  if (counter) {
+    const len = (body || '').length;
+    const segments = Math.ceil(len / 160) || 1;
+    counter.textContent = `${len} character${len !== 1 ? 's' : ''}${len > 160 ? ` (${segments} segments)` : ''}`;
+  }
+}
+
+function insertSmsInventoryText() {
+  const textarea = document.getElementById('f-sms-body');
+  const preview = document.getElementById('inventory-preview');
+  if (!textarea || !preview) return;
+  const text = preview.textContent;
+  if (!text || text === 'Loading...') return;
+
+  const start = textarea.selectionStart;
+  const end = textarea.selectionEnd;
+  const current = textarea.value;
+
+  if (start !== end || start > 0) {
+    const before = current.substring(0, start);
+    const after = current.substring(end);
+    const sep = before && !before.endsWith('\n') ? '\n\n' : '';
+    textarea.value = before + sep + text + after;
+  } else if (current) {
+    textarea.value = current + '\n\n' + text;
+  } else {
+    textarea.value = text;
+  }
+  textarea.focus();
+  updateSmsCharCount();
+}
+
+function openBulkSms() {
+  const checked = document.querySelectorAll('.acct-select:checked');
+  if (checked.length === 0) {
+    toast('Select at least one account first', 'error');
+    return;
+  }
+  _emailInventoryCache = null;
+  _emailInventoryCategory = 'All';
+  _emailInventoryShowQty = true;
+
+  const selectedIds = Array.from(checked).map(cb => cb.dataset.accountId);
+  const selectedAccounts = selectedIds.map(id => state.accounts.find(a => a.ID === id)).filter(Boolean);
+
+  const withPhone    = selectedAccounts.filter(a => a.Phone);
+  const withoutPhone = selectedAccounts.filter(a => !a.Phone);
+
+  if (withPhone.length === 0) {
+    toast('None of the selected accounts have phone numbers', 'error');
+    return;
+  }
+
+  const recipientList = withPhone.map(a =>
+    `<li>${esc(a.Name)} &mdash; ${esc(formatPhone(a.Phone))}</li>`
+  ).join('');
+  const warningHtml = withoutPhone.length > 0
+    ? `<div style="margin-bottom:12px;padding:8px 12px;background:#fff3e0;border-radius:6px;border:1px solid #ffe0b2">
+        <strong class="text-sm">Note:</strong>
+        <span class="text-sm">${withoutPhone.length} account${withoutPhone.length > 1 ? 's' : ''} skipped (no phone):
+          ${withoutPhone.map(a => esc(a.Name)).join(', ')}
+        </span>
+      </div>`
+    : '';
+
+  const formHtml = `
+    ${warningHtml}
+    <div class="form-group">
+      <label>Recipients (${withPhone.length} account${withPhone.length !== 1 ? 's' : ''})</label>
+      <ul class="text-sm" style="max-height:120px;overflow-y:auto;margin:4px 0;padding-left:20px;color:var(--text-secondary)">
+        ${recipientList}
+      </ul>
+    </div>
+    ${inventoryHelperHtml()}
+    <div class="form-group">
+      <label>Message <span class="required">*</span></label>
+      <textarea class="form-control" id="f-sms-body" rows="6" placeholder="Type your message..." oninput="updateSmsCharCount()"></textarea>
+      <span class="text-sm text-muted" id="sms-char-count">0 characters</span>
+    </div>`;
+
+  modal.open('Send Bulk SMS', formHtml, async () => {
+    const body = val('f-sms-body');
+    if (!body) { toast('Message is required', 'error'); return; }
+
+    const recipients = withPhone.map(a => ({
+      phone:       a.Phone,
+      accountId:   a.ID,
+      accountName: a.Name,
+    }));
+
+    try {
+      const result = await api.post('/api/sms/bulk', { recipients, body });
+      modal.close();
+      let msg = `SMS sent to ${result.sent} account${result.sent !== 1 ? 's' : ''}`;
+      if (result.failed > 0) msg += ` (${result.failed} failed)`;
+      toast(msg);
+      document.querySelectorAll('.acct-select:checked').forEach(cb => { cb.checked = false; });
+      updateBulkEmailBar();
+    } catch (err) {
+      toast('Failed to send SMS: ' + (err.message || 'Unknown error'), 'error');
     }
   }, 'Send');
 }

--- a/public/js/init.js
+++ b/public/js/init.js
@@ -184,12 +184,18 @@ async function init() {
     renderLocationSwitcher();
   }
 
-  // Check email configuration
+  // Check email and SMS configuration
   try {
     const emailStatus = await api.get('/api/email/status');
     state.emailConfigured = emailStatus.configured;
   } catch (e) {
     state.emailConfigured = false;
+  }
+  try {
+    const smsStatus = await api.get('/api/sms/status');
+    state.smsConfigured = smsStatus.configured;
+  } catch (e) {
+    state.smsConfigured = false;
   }
 
   // Mobile sidebar toggle

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -235,6 +235,28 @@ function renderSettings() {
         </div>
       </div>
 
+      <div class="card" id="twilio-settings-card">
+        <div class="card-header"><h3>SMS / Twilio</h3></div>
+        <div style="padding:0 18px 18px">
+          <p class="text-sm text-muted" style="margin-bottom:12px">
+            Send SMS messages to accounts via Twilio. Add your Twilio credentials to enable individual and bulk texting.
+          </p>
+          <div class="form-group">
+            <label>Account SID</label>
+            <input class="form-control" id="settings-twilio-sid" type="password" value="" placeholder="${s.twilioConfigured ? '••••••••  (saved)' : 'Enter Twilio Account SID'}" />
+          </div>
+          <div class="form-group">
+            <label>Auth Token</label>
+            <input class="form-control" id="settings-twilio-token" type="password" value="" placeholder="${s.twilioConfigured ? '••••••••  (saved)' : 'Enter Twilio Auth Token'}" />
+          </div>
+          <div class="form-group">
+            <label>From Number</label>
+            <input class="form-control" id="settings-twilio-from" type="tel" value="${esc(s.twilioFromNumber || '')}" placeholder="+15551234567" />
+          </div>
+          <button class="btn btn-primary" onclick="saveTwilioSettings()">Save</button>
+        </div>
+      </div>
+
       <div class="card" id="qbo-settings-card">
         <div class="card-header"><h3>QuickBooks Online</h3></div>
         <div style="padding:0 18px 18px" id="qbo-settings-body">
@@ -648,6 +670,33 @@ async function disconnectQbo() {
       toast(err.message, 'error');
     }
   });
+}
+
+// ── Twilio SMS ────────────────────────────────────────────────────
+
+async function saveTwilioSettings() {
+  const settings = {};
+  const sid   = val('settings-twilio-sid');
+  const token = val('settings-twilio-token');
+  const from  = val('settings-twilio-from');
+
+  if (sid)   settings.twilioAccountSid = sid;
+  if (token) settings.twilioAuthToken  = token;
+  if (from !== undefined) settings.twilioFromNumber = from;
+
+  if (Object.keys(settings).length === 0) {
+    toast('No changes to save', 'error');
+    return;
+  }
+
+  try {
+    const updated = await api.put('/api/settings', settings);
+    state.settings = updated;
+    state.smsConfigured = !!updated.twilioConfigured;
+    toast('Twilio settings saved');
+  } catch (err) {
+    toast(err.message, 'error');
+  }
 }
 
 // ── Inbound Email Order Requests ──────────────────────────────────

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -14,12 +14,15 @@ function sanitizeSettings(settings) {
   // Flag presence of secrets before removing them
   const hasGeminiKey = !!settings.geminiApiKey;
   const hasWebhookToken = !!settings.inboundEmailWebhookToken;
+  const twilioConfigured = !!(settings.twilioAccountSid && settings.twilioAuthToken && settings.twilioFromNumber);
 
   // Remove known secret keys
   delete settings.qboTokens;
   delete settings.apiKeys;
   delete settings.geminiApiKey;
   delete settings.inboundEmailWebhookToken;
+  delete settings.twilioAccountSid;
+  delete settings.twilioAuthToken;
 
   // Remove Google refresh tokens (stored as google_refresh_token:<profileId>)
   for (const key of Object.keys(settings)) {
@@ -28,6 +31,7 @@ function sanitizeSettings(settings) {
 
   if (hasGeminiKey) settings.geminiApiKeySet = true;
   if (hasWebhookToken) settings.inboundEmailWebhookTokenSet = true;
+  if (twilioConfigured) settings.twilioConfigured = true;
 
   // Parse JSON values
   if (settings.locations) {
@@ -70,6 +74,7 @@ router.get('/', async (req, res) => {
 const ALLOWED_SETTINGS_KEYS = new Set([
   'locations', 'accountTags', 'styles', 'kegDeposits', 'companyName',
   'inboundEmail', 'geminiApiKey', 'qboTaxCodeId',
+  'twilioAccountSid', 'twilioAuthToken', 'twilioFromNumber',
 ]);
 
 // PUT /api/settings — accepts a key-value map, upserts each key

--- a/routes/sms.js
+++ b/routes/sms.js
@@ -1,0 +1,151 @@
+'use strict';
+
+const express = require('express');
+const { v4: uuidv4 } = require('uuid');
+const { addRow, updateRow } = require('../db');
+const { isSmsConfigured, sendSms, formatPhoneE164 } = require('../sms-service');
+
+const router = express.Router();
+
+function today() {
+  return new Date().toISOString().split('T')[0];
+}
+
+/**
+ * Create an Outreach log entry for a texted account and update LastContacted.
+ */
+async function logOutreach(accountId, accountName, bodyPreview) {
+  const preview = (bodyPreview || '').substring(0, 80);
+  const entry = {
+    ID:              uuidv4(),
+    AccountID:       accountId,
+    AccountName:     accountName || '',
+    Date:            today(),
+    Method:          'SMS',
+    Notes:           `SMS: ${preview}${bodyPreview && bodyPreview.length > 80 ? '...' : ''}`,
+    FollowUpDate:    '',
+    FollowUpStatus:  'None',
+    CreatedAt:       new Date().toISOString(),
+  };
+  await addRow('OUTREACH', entry);
+
+  try {
+    await updateRow('ACCOUNTS', accountId, { LastContacted: entry.Date });
+  } catch (_) { /* ignore */ }
+}
+
+// GET /api/sms/status — Check if SMS is configured
+router.get('/status', (req, res) => {
+  res.json({ configured: isSmsConfigured() });
+});
+
+// POST /api/sms/send — Send individual SMS to one account
+router.post('/send', async (req, res) => {
+  try {
+    if (!isSmsConfigured()) {
+      return res.status(503).json({ error: 'SMS is not configured. Add Twilio credentials in Settings.' });
+    }
+
+    const { to, body, accountId, accountName } = req.body;
+
+    if (!to)   return res.status(400).json({ error: 'Recipient phone number is required' });
+    if (!body) return res.status(400).json({ error: 'Message body is required' });
+
+    const senderName  = req.user.name  || 'Brewery Team';
+    const senderEmail = req.user.email || '';
+
+    const result = await sendSms({ to, body });
+
+    // Log to SmsLog table
+    const logEntry = {
+      ID:          uuidv4(),
+      SenderName:  senderName,
+      SenderEmail: senderEmail,
+      Recipient:   formatPhoneE164(to),
+      Body:        body,
+      Type:        'individual',
+      AccountID:   accountId || '',
+      AccountName: accountName || '',
+      TwilioSid:   result.messageSid || '',
+      Status:      result.success ? 'sent' : 'failed',
+      Error:       result.error || '',
+      CreatedAt:   new Date().toISOString(),
+    };
+    await addRow('SMS_LOG', logEntry);
+
+    if (!result.success) {
+      return res.status(500).json({ error: `Failed to send SMS: ${result.error}` });
+    }
+
+    // Auto-log outreach
+    if (accountId) {
+      await logOutreach(accountId, accountName, body);
+    }
+
+    res.json({ success: true, messageSid: result.messageSid });
+  } catch (err) {
+    console.error(`[sms] ${err.message}`);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /api/sms/bulk — Send bulk SMS to multiple accounts
+router.post('/bulk', async (req, res) => {
+  try {
+    if (!isSmsConfigured()) {
+      return res.status(503).json({ error: 'SMS is not configured. Add Twilio credentials in Settings.' });
+    }
+
+    const { recipients, body } = req.body;
+
+    if (!recipients || !Array.isArray(recipients) || recipients.length === 0) {
+      return res.status(400).json({ error: 'At least one recipient is required' });
+    }
+    if (!body) return res.status(400).json({ error: 'Message body is required' });
+
+    const senderName  = req.user.name  || 'Brewery Team';
+    const senderEmail = req.user.email || '';
+
+    let sent = 0;
+    let failed = 0;
+
+    for (const r of recipients) {
+      if (!r.phone) { failed++; continue; }
+
+      const result = await sendSms({ to: r.phone, body });
+
+      // Log each send
+      const logEntry = {
+        ID:          uuidv4(),
+        SenderName:  senderName,
+        SenderEmail: senderEmail,
+        Recipient:   formatPhoneE164(r.phone),
+        Body:        body,
+        Type:        'bulk',
+        AccountID:   r.accountId || '',
+        AccountName: r.accountName || '',
+        TwilioSid:   result.messageSid || '',
+        Status:      result.success ? 'sent' : 'failed',
+        Error:       result.error || '',
+        CreatedAt:   new Date().toISOString(),
+      };
+      await addRow('SMS_LOG', logEntry);
+
+      if (result.success) {
+        sent++;
+        if (r.accountId) {
+          await logOutreach(r.accountId, r.accountName, body);
+        }
+      } else {
+        failed++;
+      }
+    }
+
+    res.json({ success: true, sent, failed });
+  } catch (err) {
+    console.error(`[sms] ${err.message}`);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -44,6 +44,7 @@ const creditsRoutes        = require('./routes/credits');
 const apiWebhooksRoutes    = require('./routes/api-webhooks');
 const inboundEmailRoutes   = require('./routes/inbound-emails');
 const inboundEmailService  = require('./inbound-email-service');
+const smsRoutes            = require('./routes/sms');
 
 const app  = express();
 const PORT = process.env.PORT || 3000;
@@ -72,6 +73,7 @@ app.use(helmet({
 // ── Rate limiting ────────────────────────────────────────────────────────
 app.use('/auth',      rateLimit({ windowMs: 60_000, max: 10,  standardHeaders: true, legacyHeaders: false }));
 app.use('/api/email', rateLimit({ windowMs: 60_000, max: 20,  standardHeaders: true, legacyHeaders: false }));
+app.use('/api/sms',   rateLimit({ windowMs: 60_000, max: 20,  standardHeaders: true, legacyHeaders: false }));
 app.use('/api',      rateLimit({ windowMs: 60_000, max: 100, standardHeaders: true, legacyHeaders: false }));
 
 // ── Body parsing ──────────────────────────────────────────────────────────
@@ -166,6 +168,7 @@ app.use('/api/forecast',      requireAuth, forecastRoutes);
 app.use('/api/credits',        requireAuth, creditsRoutes);
 app.use('/api/webhooks',       requireAuth, apiWebhooksRoutes);
 app.use('/api/inbound-emails', requireAuth, inboundEmailRoutes);
+app.use('/api/sms',            requireAuth, smsRoutes);
 
 // Status endpoint (public – used by the frontend before auth).
 app.get('/api/status', (req, res) => {

--- a/sms-service.js
+++ b/sms-service.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const https = require('https');
+const { getAllRows } = require('./db');
+
+/**
+ * Get a setting value from the SETTINGS table.
+ */
+function getSetting(key) {
+  const rows = getAllRows('SETTINGS');
+  const row = rows.find(r => r.Key === key);
+  return (row && row.Value) || '';
+}
+
+/**
+ * Returns true if all three Twilio settings are configured.
+ */
+function isSmsConfigured() {
+  return !!(getSetting('twilioAccountSid') && getSetting('twilioAuthToken') && getSetting('twilioFromNumber'));
+}
+
+/**
+ * Format a phone number to E.164. Strips non-digits, prepends +1 for 10-digit US numbers.
+ */
+function formatPhoneE164(phone) {
+  if (!phone) return '';
+  const digits = phone.replace(/\D/g, '');
+  if (digits.length === 10) return '+1' + digits;
+  if (digits.length === 11 && digits[0] === '1') return '+' + digits;
+  if (phone.startsWith('+')) return phone;
+  return '+' + digits;
+}
+
+/**
+ * Send an SMS via Twilio REST API (no SDK needed).
+ *
+ * @param {object} opts
+ * @param {string} opts.to   - Recipient phone number
+ * @param {string} opts.body - Message text
+ * @returns {Promise<{success: boolean, messageSid?: string, error?: string}>}
+ */
+function sendSms({ to, body }) {
+  const accountSid = getSetting('twilioAccountSid');
+  const authToken  = getSetting('twilioAuthToken');
+  const fromNumber = getSetting('twilioFromNumber');
+
+  if (!accountSid || !authToken || !fromNumber) {
+    return Promise.resolve({ success: false, error: 'Twilio is not configured' });
+  }
+
+  const toFormatted = formatPhoneE164(to);
+  if (!toFormatted) {
+    return Promise.resolve({ success: false, error: 'Invalid phone number' });
+  }
+
+  const postData = new URLSearchParams({
+    To:   toFormatted,
+    From: formatPhoneE164(fromNumber),
+    Body: body,
+  }).toString();
+
+  const auth = Buffer.from(`${accountSid}:${authToken}`).toString('base64');
+
+  const options = {
+    hostname: 'api.twilio.com',
+    path:     `/2010-04-01/Accounts/${accountSid}/Messages.json`,
+    method:   'POST',
+    headers: {
+      'Content-Type':   'application/x-www-form-urlencoded',
+      'Content-Length':  Buffer.byteLength(postData),
+      'Authorization':  `Basic ${auth}`,
+    },
+  };
+
+  return new Promise((resolve) => {
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', chunk => { data += chunk; });
+      res.on('end', () => {
+        try {
+          const json = JSON.parse(data);
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            resolve({ success: true, messageSid: json.sid });
+          } else {
+            resolve({ success: false, error: json.message || `Twilio error (${res.statusCode})` });
+          }
+        } catch (e) {
+          resolve({ success: false, error: `Failed to parse Twilio response (${res.statusCode})` });
+        }
+      });
+    });
+
+    req.on('error', (err) => {
+      resolve({ success: false, error: err.message });
+    });
+
+    req.write(postData);
+    req.end();
+  });
+}
+
+module.exports = { isSmsConfigured, sendSms, formatPhoneE164 };


### PR DESCRIPTION
## Summary
- Adds Twilio-powered SMS sending that mirrors the existing email flow: individual send from account profiles, bulk send from the accounts list, with automatic outreach logging
- New "SMS / Twilio" settings card in Settings → Integrations for configuring Account SID, Auth Token, and From Number (credentials stripped from API responses like other secrets)
- New `sms-service.js` uses Twilio REST API directly via `https` (no SDK dependency), with E.164 phone formatting
- New `routes/sms.js` with `GET /status`, `POST /send`, `POST /bulk` endpoints (rate-limited at 20 req/60s)
- SMS_LOG table tracks all sent messages with Twilio SID, status, and error details
- Account list checkboxes now appear when either email or SMS is configured
- Accounts without phone numbers show a warning in bulk SMS compose (same pattern as email)

## Test plan
- [ ] Add Twilio credentials in Settings → Integrations → SMS / Twilio card, confirm save works and fields show "saved" placeholder on reload
- [ ] Reload app → confirm checkboxes appear on accounts list and "Text Selected" button is visible
- [ ] Open an account with a phone number → click "Text" → send individual SMS → confirm delivery + outreach log created
- [ ] Select multiple accounts → click "Text Selected" → send bulk SMS → confirm each received + outreach logs created
- [ ] Confirm accounts without phone numbers show a warning in bulk SMS compose
- [ ] Remove Twilio credentials → confirm SMS buttons/checkboxes hide appropriately
- [ ] Verify inventory helper insert works in SMS compose modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)