### PR TITLE
Fix modal select auto-open on iOS and dashboard overdue layout

### DIFF
--- a/public/js/core.js
+++ b/public/js/core.js
@@ -346,8 +346,8 @@ const modal = {
     };
     document.getElementById('modal-overlay').addEventListener('keydown', modal._enterSubmit);
 
-    // Focus first input
-    const first = document.querySelector('#modal-body input:not([type="hidden"]), #modal-body select, #modal-body textarea');
+    // Focus first input (skip selects — on iOS, focusing a <select> opens the native picker)
+    const first = document.querySelector('#modal-body input:not([type="hidden"]), #modal-body textarea');
     if (first) first.focus();
   },
 

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -109,10 +109,12 @@ async function loadDashboard() {
       <ul class="dash-list">
         ${allOverdue.map(r => `
           <li class="clickable" onclick="${r.AccountID ? `loadAccountProfile('${esc(r.AccountID)}')` : `navigate('todos')`}">
-            ${urgencyBadge(r.DueDate, r.Completed)}
-            ${typeBadge(r.Type)}
-            <span class="dash-label">${esc(r.Title)}</span>
-            ${r.AccountName ? `<span class="text-muted text-sm"> &mdash; ${esc(r.AccountName)}</span>` : ''}
+            <div>
+              ${urgencyBadge(r.DueDate, r.Completed)}
+              ${typeBadge(r.Type)}
+              <span class="dash-label">${esc(r.Title)}</span>
+              ${r.AccountName ? `<span class="text-muted text-sm"> &mdash; ${esc(r.AccountName)}</span>` : ''}
+            </div>
             ${r._type !== 'delivery' ? `<button class="btn btn-ghost btn-sm text-success" onclick="event.stopPropagation();completeTodo('${esc(r.ID)}')">Done</button>` : ''}
           </li>`).join('')}
       </ul>


### PR DESCRIPTION
## Summary
- **Order edit on iOS**: Skip `<select>` elements when auto-focusing the first input in modals. On iOS Safari, focusing a `<select>` immediately opens the native picker, which is jarring when opening the Edit Order modal since the Account dropdown auto-opens.
- **Dashboard overdue todos**: Wrap overdue todo item content (badges + title + account name) in a `<div>`, matching the structure used by the "Upcoming" and "My Todos" sections. Without the wrapper, all elements were separate flex children competing for horizontal space, causing the title text to be squeezed into a single-character-wide vertical column on mobile.

## Test plan
- [ ] On iOS: edit an order — account dropdown should NOT auto-open
- [ ] On iOS: other modals with text inputs should still auto-focus the first input
- [ ] Dashboard overdue section: todo titles display normally on mobile, no vertical character stacking

🤖 Generated with [Claude Code](https://claude.com/claude-code)