### PR TITLE
Fix multi-tag filter to use AND matching

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -269,7 +269,7 @@ function renderAccounts() {
     filtered = filtered.filter(a => {
       let tags = [];
       try { tags = JSON.parse(a.Tags || '[]'); } catch (e) { tags = []; }
-      return tagFilter.some(t => tags.includes(t));
+      return tagFilter.every(t => tags.includes(t));
     });
   }
   if (methodFilter) {


### PR DESCRIPTION
## Summary
- Fixes multi-tag account filter to use AND matching instead of OR
- Selecting multiple tags now shows only accounts that have **all** selected tags, not just any of them

## Test plan
- [ ] Select two tags (e.g., `CMB` and `Cans`) — verify only accounts with both tags appear
- [ ] Select a single tag — verify behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)