### PR TITLE
Fix My Todos showing incomplete list on dashboard

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -60,11 +60,19 @@ async function loadDashboard() {
   const allOverdue = [...(dash.overdueReminders || []), ...overdueDeliveries]
     .sort((a, b) => (a.DueDate || '').localeCompare(b.DueDate || ''));
 
-  // Build "My Todos" — overdue + upcoming assigned to current staff, including pending deliveries
-  const myOverdue = currentStaffId ? allOverdue.filter(r => r.StaffID === currentStaffId) : [];
-  const myUpcoming = currentStaffId ? allUpcoming.filter(r => r.StaffID === currentStaffId) : [];
-  const myTodos = [...myOverdue, ...myUpcoming]
-    .sort((a, b) => (a.DueDate || '').localeCompare(b.DueDate || ''));
+  // Build "My Todos" — ALL active reminders + pending deliveries assigned to current staff
+  const allMyItems = currentStaffId
+    ? [...(dash.activeReminders || []), ...pendingDeliveries].filter(r => r.StaffID === currentStaffId)
+    : [];
+  const myOverdue = allMyItems.filter(r => r.DueDate && daysFromToday(r.DueDate) !== null && daysFromToday(r.DueDate) < 0);
+  const myTodos = allMyItems
+    .sort((a, b) => {
+      // Items with no due date sort to the end
+      if (!a.DueDate && !b.DueDate) return 0;
+      if (!a.DueDate) return 1;
+      if (!b.DueDate) return -1;
+      return a.DueDate.localeCompare(b.DueDate);
+    });
 
   const lowStockHtml = dash.lowStockItems.length === 0
     ? '<li class="empty-state" style="padding:12px 0">All products are well stocked.</li>'

--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -87,6 +87,7 @@ router.get('/', async (req, res) => {
       prospectAccounts: prospectAccounts.length,
       totalActiveReminders: activeReminders.length,
       overdueCount: overdueReminders.length,
+      activeReminders,
       upcomingReminders,
       overdueReminders: overdueReminders.sort((a, b) => a.DueDate.localeCompare(b.DueDate)),
       lowStockItems,


### PR DESCRIPTION
## Summary
- Dashboard "My Todos" was only showing overdue items and upcoming items within 7 days (capped at 8 from the backend)
- Todos with no due date or due dates beyond 7 days were completely excluded
- Now returns all active reminders from the backend and uses the full set to build My Todos
- Items with no due date sort to the end of the list

## Test plan
- [ ] Verify todos assigned to you with due dates beyond 7 days now appear in My Todos
- [ ] Verify todos assigned to you with no due date appear at the bottom of My Todos
- [ ] Verify overdue count badge still shows correctly
- [ ] Verify the separate "Upcoming (7 days)" and "Overdue" sections are unchanged

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)