### PR TITLE
Surface orphaned orders in orders list (closes #371)

### DIFF
--- a/routes/orders.js
+++ b/routes/orders.js
@@ -42,7 +42,23 @@ router.get('/', async (req, res) => {
     let orders = await getAllRows('ORDERS');
     if (accountId) orders = orders.filter(s => s.AccountID === accountId);
     if (staffId)   orders = orders.filter(s => s.StaffID === staffId);
-    if (location)  orders = orders.filter(s => s.Location === location);
+    if (location) {
+      // Surface orphaned orders (empty Location, or a Location no longer
+      // configured) in every location's list so they remain editable.
+      // Without this, orders with no/invalid Location are hidden from the
+      // orders view but still appear in allocations and pending deliveries.
+      const settings = await getAllRows('SETTINGS');
+      const locRow = settings.find(s => s.Key === 'locations');
+      let validLocations = new Set();
+      if (locRow) {
+        try { validLocations = new Set(JSON.parse(locRow.Value)); } catch { /* ignore */ }
+      }
+      orders = orders.filter(s =>
+        s.Location === location ||
+        !s.Location ||
+        (validLocations.size > 0 && !validLocations.has(s.Location))
+      );
+    }
     // Sort newest first by OrderDate, then by CreatedAt as tiebreaker
     orders.sort((a, b) => (b.OrderDate || '').localeCompare(a.OrderDate || '') || (b.CreatedAt || '').localeCompare(a.CreatedAt || ''));
     res.json(orders);


### PR DESCRIPTION
## Summary
- Closes #371 — gives the user a way to open/delete orders that were stuck out of the orders list
- `GET /api/orders?location=X` now also returns orders whose Location is empty or no longer in the configured locations list, so they appear in every location's orders view
- These orders previously showed in stock allocations and pending deliveries but were hidden from the orders view, making them impossible to clean up

## Test plan
- [ ] Create/identify an order with an empty Location → appears in every location's orders list
- [ ] Create/identify an order with a Location not in Settings → also appears in every location's orders list
- [ ] Open such an order: location dropdown defaults to the current location; saving repairs the record
- [ ] Orders with a valid Location only appear at that location (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)