### PR TITLE
Surface QBO OAuth redirect URI for setup (closes #287)

### DIFF
--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -581,6 +581,14 @@ async function loadQboStatus() {
         <p class="text-sm text-muted" style="margin-bottom:12px">
           Connect your QuickBooks Online account to create invoices in QuickBooks when saving orders.
         </p>
+        ${status.redirectUri ? `
+        <div class="form-group" style="margin-bottom:12px">
+          <label>Redirect URI</label>
+          <input class="form-control" value="${esc(status.redirectUri)}" readonly onclick="this.select()" style="font-family:monospace;font-size:13px;background:var(--bg-secondary)" />
+          <p class="text-sm text-muted" style="margin-top:4px">
+            Add this exact URI to your Intuit Developer app's <strong>Redirect URIs</strong> list before connecting, otherwise Intuit will reject the request with a redirect URI error.
+          </p>
+        </div>` : ''}
         <a class="btn btn-primary" href="${BASE_PATH}/auth/qbo">Connect to QuickBooks</a>`;
       return;
     }

--- a/routes/qbo.js
+++ b/routes/qbo.js
@@ -8,6 +8,17 @@ const { isQboConfigured, getOAuthClient, getStoredTokens, storeTokens, clearToke
 const authRouter = express.Router();
 const apiRouter  = express.Router();
 
+// Build the OAuth redirect URI Intuit will call back. Honors the env override
+// when set, otherwise derives it from the incoming request + BASE_PATH so
+// sub-path deployments (e.g. /trb) get the right public-facing URL. Both the
+// authorize and token-exchange steps must produce IDENTICAL strings or Intuit
+// rejects with "redirect_uri does not match".
+function computeRedirectUri(req) {
+  if (process.env.QBO_REDIRECT_URI) return process.env.QBO_REDIRECT_URI;
+  const basePath = process.env.BASE_PATH || '';
+  return `${req.protocol}://${req.get('host')}${basePath}/auth/qbo/callback`;
+}
+
 // ── OAuth flow (public, mounted at /auth/qbo) ───────────────────
 
 // GET /auth/qbo — redirect to Intuit OAuth
@@ -16,9 +27,8 @@ authRouter.get('/', (req, res) => {
     return res.status(503).json({ error: 'QuickBooks is not configured' });
   }
 
-  const basePath = process.env.BASE_PATH || '';
-  const redirectUri = process.env.QBO_REDIRECT_URI
-    || `${req.protocol}://${req.get('host')}${basePath}/auth/qbo/callback`;
+  const redirectUri = computeRedirectUri(req);
+  console.log(`[qbo] OAuth start — redirect_uri=${redirectUri}`);
 
   // Generate a random nonce to prevent CSRF on the OAuth callback
   const state = crypto.randomBytes(16).toString('hex');
@@ -44,8 +54,7 @@ authRouter.get('/callback', async (req, res) => {
     }
     delete req.session.qboOAuthState;
 
-    const redirectUri = process.env.QBO_REDIRECT_URI
-      || `${req.protocol}://${req.get('host')}${basePath}/auth/qbo/callback`;
+    const redirectUri = computeRedirectUri(req);
 
     const oauthClient = getOAuthClient(redirectUri);
     const authResponse = await oauthClient.createToken(req.url);
@@ -79,6 +88,7 @@ apiRouter.get('/status', async (req, res) => {
       connected,
       realmId: connected ? tokens.realmId : null,
       appUrl:  connected ? QBO_APP_URL : null,
+      redirectUri: computeRedirectUri(req),
     });
   } catch (err) {
     console.error('[qbo]', err.message);


### PR DESCRIPTION
## Summary
- Closes #287 — TRB and other sub-path deployments hit "redirect URI" errors with no easy way to discover the URI to register
- The QBO settings card now shows the exact redirect URI the app will send to Intuit, with instructions to register it in the Intuit Developer dashboard
- Server logs the redirect URI on every OAuth start so admins can verify what's being sent
- Refactored the URI computation into one helper so authorize and token-exchange always produce identical strings (Intuit rejects with "redirect_uri does not match" if they differ)

## How TRB owners use this
1. Open Settings → QuickBooks Online (while not connected)
2. Copy the displayed **Redirect URI** (e.g. `https://app.sandhillsbrewing.com/trb/auth/qbo/callback`)
3. Paste it into the Intuit Developer app's **Redirect URIs** list and save
4. Click **Connect to QuickBooks**

## Test plan
- [ ] Settings → QuickBooks shows redirect URI when not connected
- [ ] Redirect URI matches BASE_PATH (e.g. includes `/trb` on the TRB instance)
- [ ] `QBO_REDIRECT_URI` env override is respected if set
- [ ] Server logs `[qbo] OAuth start — redirect_uri=...` when clicking Connect
- [ ] Existing connections still work (no regression in callback handling)
- [ ] Click-to-select on the URI field for easy copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)