### PR TITLE
Support indirect / pass-through orders (closes #88)

### DIFF
--- a/db.js
+++ b/db.js
@@ -34,7 +34,7 @@ const TABLES = {
 const HEADERS = {
   PRODUCTS:  ['ID', 'Name', 'Style', 'ABV', 'Format', 'PricePerUnit', 'Notes', 'ExcludeFromEmailOfferings', 'CreatedAt'],
   INVENTORY: ['ID', 'Name', 'Location', 'Style', 'ABV', 'Format', 'Units', 'PricePerUnit', 'Prices', 'LowStockThreshold', 'Notes', 'LastUpdated', 'ProductID', 'ProductName'],
-  ACCOUNTS:  ['ID', 'Name', 'Type', 'Tags', 'ContactName', 'Email', 'AdditionalEmails', 'Phone', 'PreferredMethod', 'BillingContactName', 'BillingEmail', 'BillingPhone', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'ChargeDeposits', 'Taxable', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'ServicedBy', 'QboCustomerId', 'CreatedAt', 'CheckInFrequency'],
+  ACCOUNTS:  ['ID', 'Name', 'Type', 'Tags', 'ContactName', 'Email', 'AdditionalEmails', 'Phone', 'PreferredMethod', 'BillingContactName', 'BillingEmail', 'BillingPhone', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'ChargeDeposits', 'Taxable', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'ServicedBy', 'QboCustomerId', 'CreatedAt', 'CheckInFrequency', 'DeliversIndirectly'],
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
   REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
   STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt', 'Locations'],
@@ -44,7 +44,7 @@ const HEADERS = {
   KEG_TRACKING:    ['ID', 'AccountID', 'AccountName', 'OrderID', 'InventoryID', 'ProductName', 'Format', 'Quantity', 'DepositPerUnit', 'DepositTotal', 'DepositRefunded', 'DeliveredDate', 'ReturnedDate', 'ReturnedQuantity', 'Notes', 'CreatedAt'],
   TAP_HANDLES:     ['ID', 'AccountID', 'AccountName', 'Quantity', 'DeployedDate', 'CollectedDate', 'CollectedQuantity', 'Notes', 'CreatedAt'],
   EMAIL_LOG:       ['ID', 'SenderName', 'SenderEmail', 'Recipients', 'Subject', 'Body', 'Type', 'AccountIDs', 'Status', 'Error', 'CreatedAt'],
-  ORDER_ITEMS:     ['ID', 'OrderID', 'InventoryID', 'ProductName', 'Format', 'PriceTier', 'Quantity', 'UnitPrice', 'LineTotal', 'Taxable', 'CreatedAt'],
+  ORDER_ITEMS:     ['ID', 'OrderID', 'InventoryID', 'ProductName', 'Format', 'PriceTier', 'Quantity', 'UnitPrice', 'LineTotal', 'Taxable', 'EndCustomerAccountID', 'EndCustomerName', 'CreatedAt'],
   NOTIFICATIONS:   ['ID', 'Type', 'Channel', 'RecipientStaffID', 'RecipientName', 'RecipientEmail', 'SenderName', 'SenderEmail', 'EntityType', 'EntityID', 'EntityName', 'Message', 'Status', 'Error', 'CreatedAt'],
   ACCOUNT_CREDITS: ['ID', 'AccountID', 'AccountName', 'Type', 'Amount', 'OrderID', 'Reason', 'Notes', 'CreatedAt'],
   WEBHOOK_LOG:     ['ID', 'ApiKeyName', 'Action', 'Payload', 'Status', 'Error', 'CreatedAt'],

--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -10,6 +10,7 @@ let _profileOutreachCache = [];
 let _profileTodosCache = [];
 let _profileOrdersCache = [];
 let _profileOrderFooter = '';
+let _profileOrderEndCustomers = {}; // { orderId: ['Venue', ...] }
 let _profileKegsCache = [];
 let _profileKegsContext = {};
 
@@ -214,6 +215,12 @@ function accountForm(acct = {}) {
         Charge tax for this account
       </label>
     </div>
+    <div class="form-group">
+      <label class="checkbox-label">
+        <input type="checkbox" id="f-delivers-indirectly" ${acct.DeliversIndirectly === 'true' ? 'checked' : ''} />
+        This account delivers to other accounts (orders pass through to end venues)
+      </label>
+    </div>
     <hr class="form-divider" />
     <div class="form-group">
       <label>Notes</label>
@@ -405,13 +412,14 @@ async function loadAccountProfile(accountId) {
   });
   showLoading();
 
-  const [outreach, todos, orders, kegRecords, tapHandleRecords, acctCredits] = await Promise.all([
+  const [outreach, todos, orders, kegRecords, tapHandleRecords, acctCredits, allOrderItems] = await Promise.all([
     api.get('/api/outreach'),
     api.get('/api/reminders?status=all'),
     api.get('/api/orders'),
     api.get(`/api/keg-tracking?accountId=${accountId}`),
     api.get(`/api/tap-handles?accountId=${accountId}`),
     api.get(`/api/credits?accountId=${accountId}`),
+    api.get('/api/order-items'),
   ]);
   if (state.accounts.length === 0) state.accounts = await api.get('/api/accounts');
 
@@ -432,9 +440,25 @@ async function loadAccountProfile(accountId) {
   const acctOrders = orders
     .filter(s => s.AccountID === accountId)
     .sort((a, b) => (b.OrderDate || '').localeCompare(a.OrderDate || ''));
+  // Indirect orders: line items where this account is the end customer (i.e.
+  // shipped to here but billed/owned by a different distributor account).
+  const orderById = Object.fromEntries(orders.map(o => [o.ID, o]));
+  const indirectItems = (allOrderItems || [])
+    .filter(it => it.EndCustomerAccountID === accountId && orderById[it.OrderID])
+    .map(it => ({ item: it, order: orderById[it.OrderID] }))
+    .sort((a, b) => (b.order.OrderDate || '').localeCompare(a.order.OrderDate || ''));
   _profileOutreachCache = acctOutreach;
   _profileTodosCache = acctTodos;
   _profileOrdersCache = acctOrders;
+  // Build a per-order list of distinct end-customer names for the "→ Venue"
+  // hint shown beneath the order date (only relevant when this account
+  // delivers indirectly).
+  _profileOrderEndCustomers = {};
+  for (const it of (allOrderItems || [])) {
+    if (!it.OrderID || !it.EndCustomerName) continue;
+    const list = _profileOrderEndCustomers[it.OrderID] || (_profileOrderEndCustomers[it.OrderID] = []);
+    if (!list.includes(it.EndCustomerName)) list.push(it.EndCustomerName);
+  }
 
   const totalRevenue = acctOrders.reduce((sum, s) => sum + (parseFloat(s.OrderAmount || 0) + parseFloat(s.TaxAmount || 0) + parseFloat(s.DepositAmount || 0)), 0);
   const activeTodos  = acctTodos.filter(t => t.Completed !== 'true').length;
@@ -606,6 +630,27 @@ async function loadAccountProfile(accountId) {
       <div id="profile-orders-container"></div>
     </div>
 
+    ${indirectItems.length > 0 ? `
+    <div class="profile-section">
+      <div class="profile-section-header">
+        <h3>Indirect Orders <span class="text-muted text-sm">(${indirectItems.length} line item${indirectItems.length !== 1 ? 's' : ''} delivered here via other accounts)</span></h3>
+      </div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Date</th><th>Through</th><th>Product</th><th class="mobile-hide">Format</th><th>Qty</th><th class="mobile-hide">Invoice</th><th>Actions</th></tr></thead>
+          <tbody>${indirectItems.map(({ item, order }) => `<tr>
+            <td class="text-sm">${formatDate(order.OrderDate)}</td>
+            <td><span class="td-link" onclick="loadAccountProfile('${esc(order.AccountID)}')">${esc(order.AccountName) || '—'}</span></td>
+            <td class="fw-600">${esc(item.ProductName || '—')}</td>
+            <td class="mobile-hide text-sm">${esc(item.Format) || '—'}</td>
+            <td class="fw-600">${esc(item.Quantity || '0')}</td>
+            <td class="mobile-hide text-sm">${esc(order.InvoiceNumber) || '—'}</td>
+            <td class="td-actions"><button class="btn btn-ghost btn-sm" onclick="profileEditOrder('${esc(order.ID)}')">View Order</button></td>
+          </tr>`).join('')}</tbody>
+        </table>
+      </div>
+    </div>` : ''}
+
     <div class="profile-section">
       <div class="profile-section-header">
         <h3>Credits <span class="text-muted text-sm">(${sortedCredits.length}${totalCreditAvailable > 0 ? ' · Balance: ' + fmtMoney(totalCreditAvailable) + (creditOnPending > 0 ? ' · ' + fmtMoney(creditOnPending) + ' on pending' : '') : ''})</span></h3>
@@ -745,8 +790,11 @@ function renderProfileOrders() {
     : pg.rows.map(s => {
         const total = parseFloat(s.OrderAmount || 0) + parseFloat(s.TaxAmount || 0) + parseFloat(s.DepositAmount || 0);
         const isPreSale = s.Status === 'Pre-Sale';
+        const ec = _profileOrderEndCustomers[s.ID] || [];
+        const ecHtml = ec.length === 0 ? ''
+          : `<br><span class="text-muted text-sm" title="${esc(ec.join(', '))}" style="cursor:default">${ec.length === 1 ? '→ ' + esc(ec[0]) : '→ ' + ec.length + ' venues'}</span>`;
         return `<tr>
-          <td class="text-sm">${formatDate(s.OrderDate)}${formatProductsSummary(s.RequestedProducts)}</td>
+          <td class="text-sm">${formatDate(s.OrderDate)}${ecHtml}${formatProductsSummary(s.RequestedProducts)}</td>
           <td class="mobile-hide text-sm">${esc(s.InvoiceNumber) || '—'}</td>
           <td class="mobile-hide text-sm">${s.DeliveryDate ? formatDate(s.DeliveryDate) : '—'}</td>
           <td class="mobile-hide">${isPreSale && !parseFloat(s.OrderAmount) ? '<span class="text-muted">—</span>' : fmtMoney(s.OrderAmount)}</td>
@@ -1160,6 +1208,7 @@ function openAddAccount() {
       ABCLicense: val('f-abc-license'),
       ChargeDeposits: document.getElementById('f-charge-deposits').checked ? 'true' : 'false',
       Taxable: document.getElementById('f-taxable').checked ? 'true' : 'false',
+      DeliversIndirectly: document.getElementById('f-delivers-indirectly').checked ? 'true' : 'false',
       CheckInFrequency: val('f-checkin-frequency'),
       Notes: val('f-notes'), StaffID: staffId, StaffName: staffName,
       ServicedBy: val('f-serviced-by') || '',
@@ -1188,6 +1237,7 @@ function openEditAccount(id) {
       ABCLicense: val('f-abc-license'),
       ChargeDeposits: document.getElementById('f-charge-deposits').checked ? 'true' : 'false',
       Taxable: document.getElementById('f-taxable').checked ? 'true' : 'false',
+      DeliversIndirectly: document.getElementById('f-delivers-indirectly').checked ? 'true' : 'false',
       CheckInFrequency: val('f-checkin-frequency'),
       Notes: val('f-notes'), StaffID: staffId, StaffName: staffName,
       ServicedBy: val('f-serviced-by') || '',

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -622,10 +622,15 @@ function _orderAccountIsIndirect() {
 
 // Inline HTML for the optional per-line "Delivers to (end customer)" picker.
 // Hidden by default; refreshLineItemDeliversTo() toggles visibility based on
-// the selected account's DeliversIndirectly flag.
+// the selected account's DeliversIndirectly flag. The default option is
+// labeled with the distributor's own account name so it's clear that leaving
+// it blank means the line stays with that account (no pass-through).
 function _endCustomerPickerHtml(selectedId) {
   const indirect = _orderAccountIsIndirect();
-  const opts = `<option value="">— Distributor —</option>${accountOptions(selectedId || '')}`;
+  const acctId = document.getElementById('f-account-hidden')?.value || val('f-account');
+  const acctName = acctId ? ((state.accounts || []).find(a => a.ID === acctId) || {}).Name : '';
+  const defaultLabel = acctName ? `Stays with ${acctName}` : 'No pass-through (stays with this account)';
+  const opts = `<option value="">${esc(defaultLabel)}</option>${accountOptions(selectedId || '')}`;
   return `<div class="line-item-delivers-to" style="display:${indirect ? 'flex' : 'none'};gap:6px;align-items:center;margin-top:4px;padding-left:8px">
     <span class="text-sm text-muted" style="white-space:nowrap">→ Delivers to:</span>
     <select class="form-control line-item-end-customer" style="flex:1;font-size:13px;padding:4px 8px;height:auto">${opts}</select>
@@ -635,13 +640,21 @@ function _endCustomerPickerHtml(selectedId) {
 // Toggle visibility of all per-line "Delivers to" pickers when the order's
 // account changes. Clears the selection when hiding so saved end-customer
 // data isn't smuggled along after switching to a non-indirect account.
+// Also refreshes the default option label so it tracks the new account name.
 function refreshLineItemDeliversTo() {
   const indirect = _orderAccountIsIndirect();
+  const acctId = document.getElementById('f-account-hidden')?.value || val('f-account');
+  const acctName = acctId ? ((state.accounts || []).find(a => a.ID === acctId) || {}).Name : '';
+  const defaultLabel = acctName ? `Stays with ${acctName}` : 'No pass-through (stays with this account)';
   document.querySelectorAll('.line-item-delivers-to').forEach(el => {
     el.style.display = indirect ? 'flex' : 'none';
+    const sel = el.querySelector('.line-item-end-customer');
+    if (!sel) return;
     if (!indirect) {
-      const sel = el.querySelector('.line-item-end-customer');
-      if (sel) sel.value = '';
+      sel.value = '';
+    } else {
+      const blank = sel.querySelector('option[value=""]');
+      if (blank) blank.textContent = defaultLabel;
     }
   });
 }

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -121,7 +121,7 @@ function orderForm(order = {}, presetAccountId = '', readOnly = false) {
     <div class="form-row">
       <div class="form-group">
         <label>Account <span class="required">*</span></label>
-        <select class="form-control" id="f-account" ${presetAccountId || readOnly ? 'disabled' : ''} onchange="initOrderDepositCheckbox(); initOrderTaxCheckbox()">
+        <select class="form-control" id="f-account" ${presetAccountId || readOnly ? 'disabled' : ''} onchange="initOrderDepositCheckbox(); initOrderTaxCheckbox(); refreshLineItemDeliversTo()">
           <option value="">-- Select Account --</option>
           ${accountOptions(selAcctId, order.Location || state.location)}
         </select>
@@ -299,7 +299,7 @@ let _ordersDateFrom = '';
 let _ordersDateTo = '';
 let _orderFormInventory = [];
 let _ordersSort = { col: 'OrderDate', dir: 'desc' };
-let _orderItemCounts = {}; // { orderId: count } for item count badges
+let _orderItemSummary = {}; // { orderId: { count, endCustomers: [] } }
 
 function togglePaymentFields() {
   const status = val('f-status');
@@ -476,6 +476,15 @@ function sortOrders(col) {
   renderOrders();
 }
 
+// Render the "→ Venue" indirect-delivery hint under an order's account name.
+// Pulls from _orderItemSummary built by /api/order-items/counts.
+function formatEndCustomers(orderId) {
+  const ec = _orderItemSummary[orderId]?.endCustomers || [];
+  if (ec.length === 0) return '';
+  const label = ec.length === 1 ? `→ ${ec[0]}` : `→ ${ec.length} venues`;
+  return `<br><span class="text-muted text-sm" title="${esc(ec.join(', '))}" style="cursor:default">${esc(label)}</span>`;
+}
+
 function formatProductsSummary(products) {
   if (!products) return '';
   const items = products.split(',').map(s => s.trim()).filter(Boolean);
@@ -601,6 +610,42 @@ function _parsePrices(item) {
   return [];
 }
 
+// True if the currently-selected order account is flagged as a pass-through
+// distributor — used to decide whether to show per-line "Delivers to" pickers.
+function _orderAccountIsIndirect() {
+  const presetId = document.getElementById('f-account-hidden')?.value || '';
+  const acctId = presetId || val('f-account');
+  if (!acctId) return false;
+  const acct = (state.accounts || []).find(a => a.ID === acctId);
+  return acct && acct.DeliversIndirectly === 'true';
+}
+
+// Inline HTML for the optional per-line "Delivers to (end customer)" picker.
+// Hidden by default; refreshLineItemDeliversTo() toggles visibility based on
+// the selected account's DeliversIndirectly flag.
+function _endCustomerPickerHtml(selectedId) {
+  const indirect = _orderAccountIsIndirect();
+  const opts = `<option value="">— Distributor —</option>${accountOptions(selectedId || '')}`;
+  return `<div class="line-item-delivers-to" style="display:${indirect ? 'flex' : 'none'};gap:6px;align-items:center;margin-top:4px;padding-left:8px">
+    <span class="text-sm text-muted" style="white-space:nowrap">→ Delivers to:</span>
+    <select class="form-control line-item-end-customer" style="flex:1;font-size:13px;padding:4px 8px;height:auto">${opts}</select>
+  </div>`;
+}
+
+// Toggle visibility of all per-line "Delivers to" pickers when the order's
+// account changes. Clears the selection when hiding so saved end-customer
+// data isn't smuggled along after switching to a non-indirect account.
+function refreshLineItemDeliversTo() {
+  const indirect = _orderAccountIsIndirect();
+  document.querySelectorAll('.line-item-delivers-to').forEach(el => {
+    el.style.display = indirect ? 'flex' : 'none';
+    if (!indirect) {
+      const sel = el.querySelector('.line-item-end-customer');
+      if (sel) sel.value = '';
+    }
+  });
+}
+
 function _buildTierDropdown(prices, selectedTier) {
   if (prices.length <= 1) return '';
   return `<select class="form-control line-item-tier" onchange="onLineItemTierChange(this)" style="flex:1;min-width:100px;max-width:140px">
@@ -612,7 +657,7 @@ function _buildTierDropdown(prices, selectedTier) {
   </select>`;
 }
 
-function addOrderLineItem(inventoryId, qty, priceTier, savedUnitPrice) {
+function addOrderLineItem(inventoryId, qty, priceTier, savedUnitPrice, endCustomerId) {
   const wrap = document.getElementById('order-line-items');
   if (!wrap) return;
 
@@ -640,20 +685,23 @@ function addOrderLineItem(inventoryId, qty, priceTier, savedUnitPrice) {
   div.setAttribute('data-inventory-id', inventoryId || '');
   div.setAttribute('data-unit-price', selectedPrice.toFixed(2));
   div.setAttribute('data-price-tier', selectedTierLabel);
-  div.style.cssText = 'display:flex;gap:8px;align-items:center;margin-bottom:6px';
+  div.style.cssText = 'margin-bottom:6px';
 
   const tierHtml = prices.length > 1 ? _buildTierDropdown(prices, selectedTierLabel) : '';
 
   div.innerHTML = `
-    <select class="form-control" onchange="onLineItemProductChange(this)" style="flex:2;min-width:120px">
-      ${_buildProductOptions(inventoryId || '')}
-    </select>
-    ${tierHtml}
-    <span class="line-item-price text-sm" style="min-width:55px">${selectedPrice ? '$' + selectedPrice.toFixed(2) : '—'}</span>
-    <input class="form-control line-item-qty" type="number" min="0" value="${lineQty}" style="width:60px"
-      onchange="recalcOrderAmount()" oninput="recalcOrderAmount()" />
-    <span class="line-item-total text-sm fw-600" style="min-width:55px">${lineTotal ? '$' + lineTotal.toFixed(2) : ''}</span>
-    <button type="button" class="btn btn-ghost btn-sm text-danger" onclick="removeOrderLineItem(this)" style="flex-shrink:0">&times;</button>`;
+    <div style="display:flex;gap:8px;align-items:center">
+      <select class="form-control" onchange="onLineItemProductChange(this)" style="flex:2;min-width:120px">
+        ${_buildProductOptions(inventoryId || '')}
+      </select>
+      ${tierHtml}
+      <span class="line-item-price text-sm" style="min-width:55px">${selectedPrice ? '$' + selectedPrice.toFixed(2) : '—'}</span>
+      <input class="form-control line-item-qty" type="number" min="0" value="${lineQty}" style="width:60px"
+        onchange="recalcOrderAmount()" oninput="recalcOrderAmount()" />
+      <span class="line-item-total text-sm fw-600" style="min-width:55px">${lineTotal ? '$' + lineTotal.toFixed(2) : ''}</span>
+      <button type="button" class="btn btn-ghost btn-sm text-danger" onclick="removeOrderLineItem(this)" style="flex-shrink:0">&times;</button>
+    </div>
+    ${_endCustomerPickerHtml(endCustomerId)}`;
   wrap.appendChild(div);
   recalcOrderAmount();
 }
@@ -698,19 +746,22 @@ function addUnmatchedLineItem(item) {
   div.setAttribute('data-inventory-id', item.InventoryID || '');
   div.setAttribute('data-unit-price', price.toFixed(2));
   div.setAttribute('data-price-tier', item.PriceTier || '');
-  div.style.cssText = 'display:flex;gap:8px;align-items:center;margin-bottom:6px';
+  div.style.cssText = 'margin-bottom:6px';
   div.innerHTML = `
-    <span style="flex:2;min-width:120px;font-size:13px" title="Not in current location inventory">${esc(item.ProductName)}${item.Format ? ' — ' + esc(item.Format) : ''}</span>
-    <span class="line-item-price text-sm" style="min-width:55px">${price ? '$' + price.toFixed(2) : '—'}</span>
-    <input class="form-control line-item-qty" type="number" min="0" value="${qty}" style="width:60px"
-      onchange="recalcOrderAmount()" oninput="recalcOrderAmount()" />
-    <span class="line-item-total text-sm fw-600" style="min-width:55px">${total ? '$' + total.toFixed(2) : ''}</span>
-    <button type="button" class="btn btn-ghost btn-sm text-danger" onclick="removeOrderLineItem(this)" style="flex-shrink:0">&times;</button>`;
+    <div style="display:flex;gap:8px;align-items:center">
+      <span style="flex:2;min-width:120px;font-size:13px" title="Not in current location inventory">${esc(item.ProductName)}${item.Format ? ' — ' + esc(item.Format) : ''}</span>
+      <span class="line-item-price text-sm" style="min-width:55px">${price ? '$' + price.toFixed(2) : '—'}</span>
+      <input class="form-control line-item-qty" type="number" min="0" value="${qty}" style="width:60px"
+        onchange="recalcOrderAmount()" oninput="recalcOrderAmount()" />
+      <span class="line-item-total text-sm fw-600" style="min-width:55px">${total ? '$' + total.toFixed(2) : ''}</span>
+      <button type="button" class="btn btn-ghost btn-sm text-danger" onclick="removeOrderLineItem(this)" style="flex-shrink:0">&times;</button>
+    </div>
+    ${_endCustomerPickerHtml(item.EndCustomerAccountID || '')}`;
   wrap.appendChild(div);
   recalcOrderAmount();
 }
 
-function addCustomLineItem(description, unitPrice, qty, taxable) {
+function addCustomLineItem(description, unitPrice, qty, taxable, endCustomerId) {
   const wrap = document.getElementById('order-line-items');
   if (!wrap) return;
   const price = parseFloat(unitPrice || 0);
@@ -724,18 +775,21 @@ function addCustomLineItem(description, unitPrice, qty, taxable) {
   div.setAttribute('data-custom', 'true');
   div.setAttribute('data-unit-price', price.toFixed(2));
   div.setAttribute('data-price-tier', '');
-  div.style.cssText = 'display:flex;gap:8px;align-items:center;margin-bottom:6px';
+  div.style.cssText = 'margin-bottom:6px';
   div.innerHTML = `
-    <input class="form-control custom-item-desc" type="text" value="${esc(description || '')}" placeholder="e.g. T-shirt, service charge" style="flex:2;min-width:120px" />
-    <input class="form-control custom-item-price" type="number" step="0.01" min="0" value="${price ? price.toFixed(2) : ''}" placeholder="Price" style="width:80px"
-      onchange="onCustomItemPriceChange(this)" oninput="onCustomItemPriceChange(this)" />
-    <input class="form-control line-item-qty" type="number" min="0" value="${lineQty}" style="width:60px"
-      onchange="recalcOrderAmount()" oninput="recalcOrderAmount()" />
-    <label class="custom-item-tax-label" style="display:flex;align-items:center;gap:3px;font-size:12px;white-space:nowrap;cursor:pointer">
-      <input type="checkbox" class="custom-item-taxable" ${isTaxable ? 'checked' : ''} onchange="recalcOrderAmount()" /> Tax
-    </label>
-    <span class="line-item-total text-sm fw-600" style="min-width:55px">${lineTotal ? '$' + lineTotal.toFixed(2) : ''}</span>
-    <button type="button" class="btn btn-ghost btn-sm text-danger" onclick="removeOrderLineItem(this)" style="flex-shrink:0">&times;</button>`;
+    <div style="display:flex;gap:8px;align-items:center">
+      <input class="form-control custom-item-desc" type="text" value="${esc(description || '')}" placeholder="e.g. T-shirt, service charge" style="flex:2;min-width:120px" />
+      <input class="form-control custom-item-price" type="number" step="0.01" min="0" value="${price ? price.toFixed(2) : ''}" placeholder="Price" style="width:80px"
+        onchange="onCustomItemPriceChange(this)" oninput="onCustomItemPriceChange(this)" />
+      <input class="form-control line-item-qty" type="number" min="0" value="${lineQty}" style="width:60px"
+        onchange="recalcOrderAmount()" oninput="recalcOrderAmount()" />
+      <label class="custom-item-tax-label" style="display:flex;align-items:center;gap:3px;font-size:12px;white-space:nowrap;cursor:pointer">
+        <input type="checkbox" class="custom-item-taxable" ${isTaxable ? 'checked' : ''} onchange="recalcOrderAmount()" /> Tax
+      </label>
+      <span class="line-item-total text-sm fw-600" style="min-width:55px">${lineTotal ? '$' + lineTotal.toFixed(2) : ''}</span>
+      <button type="button" class="btn btn-ghost btn-sm text-danger" onclick="removeOrderLineItem(this)" style="flex-shrink:0">&times;</button>
+    </div>
+    ${_endCustomerPickerHtml(endCustomerId)}`;
   wrap.appendChild(div);
   recalcOrderAmount();
 }
@@ -877,16 +931,17 @@ async function refreshOrderProductsFromItems(orderItems, readOnly = false) {
   // Editable mode: render line-item builder and populate from order items
   wrap.innerHTML = orderProductsHtml();
   for (const item of orderItems) {
+    const ec = item.EndCustomerAccountID || '';
     if (item.InventoryID && _orderFormInventory.find(i => i.ID === item.InventoryID)) {
-      addOrderLineItem(item.InventoryID, parseInt(item.Quantity || 0), item.PriceTier || undefined, item.UnitPrice);
+      addOrderLineItem(item.InventoryID, parseInt(item.Quantity || 0), item.PriceTier || undefined, item.UnitPrice, ec);
     } else if (!item.InventoryID && item.ProductName && item.ProductName !== 'Account Credit') {
       // Custom item (no InventoryID, not a credit)
-      addCustomLineItem(item.ProductName, item.UnitPrice, item.Quantity, item.Taxable);
+      addCustomLineItem(item.ProductName, item.UnitPrice, item.Quantity, item.Taxable, ec);
     } else if (item.ProductName) {
       // Try to match by product name + format against current inventory
       const resolved = resolveInventoryMatch(item.ProductName, item.Format);
       if (resolved) {
-        addOrderLineItem(resolved.ID, parseInt(item.Quantity || 0), item.PriceTier || undefined, item.UnitPrice);
+        addOrderLineItem(resolved.ID, parseInt(item.Quantity || 0), item.PriceTier || undefined, item.UnitPrice, ec);
       } else {
         addUnmatchedLineItem(item);
       }
@@ -906,8 +961,11 @@ function orderItemsReadOnlyHtml(orderItems) {
     const fmtDisplay = item.PriceTier
       ? `${esc(item.Format)} (${esc(item.PriceTier)})`
       : (esc(item.Format) || '—');
+    const endCustomer = item.EndCustomerAccountID && item.EndCustomerName
+      ? `<div class="text-sm text-muted">→ ${esc(item.EndCustomerName)}</div>`
+      : '';
     return `<tr>
-      <td class="fw-600">${esc(item.ProductName || '—')}</td>
+      <td class="fw-600">${esc(item.ProductName || '—')}${endCustomer}</td>
       <td class="text-sm">${fmtDisplay}</td>
       <td class="text-sm">${qty}</td>
       <td class="text-sm"${isNeg ? ' style="color:#2e7d32"' : ''}>${price ? '$' + price.toFixed(2) : '—'}</td>
@@ -1026,6 +1084,9 @@ function collectOrderProducts() {
 function collectOrderItems() {
   const items = [];
   const rows = document.querySelectorAll('#order-line-items .order-line-item');
+  // End-customer fields are only meaningful when the order's account is
+  // flagged as DeliversIndirectly; otherwise we always send empty strings.
+  const indirect = _orderAccountIsIndirect();
   rows.forEach(row => {
     const invId = row.getAttribute('data-inventory-id') || '';
     const qtyEl = row.querySelector('.line-item-qty');
@@ -1037,6 +1098,11 @@ function collectOrderItems() {
     const price = unitPrice ? parseFloat(unitPrice) : (item ? parseFloat(item.PricePerUnit || 0) : 0);
     const isCustom = row.getAttribute('data-custom') === 'true';
     const taxable = isCustom ? (row.querySelector('.custom-item-taxable')?.checked ? 'true' : '') : 'true';
+    const endCustomerSel = indirect ? row.querySelector('.line-item-end-customer') : null;
+    const endCustomerId   = endCustomerSel?.value || '';
+    const endCustomerName = endCustomerId
+      ? ((state.accounts || []).find(a => a.ID === endCustomerId) || {}).Name || ''
+      : '';
     if (item) {
       items.push({
         InventoryID: item.ID,
@@ -1047,6 +1113,8 @@ function collectOrderItems() {
         UnitPrice: price.toFixed(2),
         LineTotal: (qty * price).toFixed(2),
         Taxable: taxable,
+        EndCustomerAccountID: endCustomerId,
+        EndCustomerName: endCustomerName,
       });
     } else {
       // Custom or unmatched item
@@ -1069,6 +1137,8 @@ function collectOrderItems() {
         UnitPrice: price.toFixed(2),
         LineTotal: (qty * price).toFixed(2),
         Taxable: taxable,
+        EndCustomerAccountID: endCustomerId,
+        EndCustomerName: endCustomerName,
       });
     }
   });
@@ -1094,7 +1164,7 @@ async function loadOrders(preservePage = false) {
   _ordersDateTo = '';
   showLoading();
   const locParam = state.location ? `?location=${encodeURIComponent(state.location)}` : '';
-  const [orders, accounts, staff, itemCounts] = await Promise.all([
+  const [orders, accounts, staff, itemSummary] = await Promise.all([
     api.get(`/api/orders${locParam}`),
     api.get('/api/accounts'),
     api.get('/api/staff'),
@@ -1103,7 +1173,7 @@ async function loadOrders(preservePage = false) {
   state.accounts = accounts;
   state.staff = staff;
   _ordersCache = orders;
-  _orderItemCounts = itemCounts || {};
+  _orderItemSummary = itemSummary || {};
   renderOrders();
 }
 
@@ -1255,8 +1325,8 @@ function renderOrders() {
               const isPreSale = s.Status === 'Pre-Sale';
               return `<tr>
                 <td>${formatDate(s.OrderDate)}</td>
-                <td class="fw-600"><span class="td-link" onclick="loadAccountProfile('${esc(s.AccountID)}')">${esc(s.AccountName)}</span>${formatProductsSummary(s.RequestedProducts)}</td>
-                <td class="mobile-hide text-sm">${esc(s.InvoiceNumber) || '—'}${_orderItemCounts[s.ID] ? ` <span class="badge badge-items" title="${_orderItemCounts[s.ID]} line item${_orderItemCounts[s.ID] > 1 ? 's' : ''}">${_orderItemCounts[s.ID]} items</span>` : ''}${qboSyncBadge(s)}</td>
+                <td class="fw-600"><span class="td-link" onclick="loadAccountProfile('${esc(s.AccountID)}')">${esc(s.AccountName)}</span>${formatEndCustomers(s.ID)}${formatProductsSummary(s.RequestedProducts)}</td>
+                <td class="mobile-hide text-sm">${esc(s.InvoiceNumber) || '—'}${(_orderItemSummary[s.ID]?.count) ? ` <span class="badge badge-items" title="${_orderItemSummary[s.ID].count} line item${_orderItemSummary[s.ID].count > 1 ? 's' : ''}">${_orderItemSummary[s.ID].count} items</span>` : ''}${qboSyncBadge(s)}</td>
                 <td class="mobile-hide">${isPreSale && !parseFloat(s.OrderAmount) ? '<span class="text-muted">—</span>' : fmtMoney(s.OrderAmount)}${s.DepositAmount && parseFloat(s.DepositAmount) > 0 ? `<br><span class="text-muted text-sm">+${fmtMoney(s.DepositAmount)} deposit</span>` : ''}</td>
                 <td class="mobile-hide">${s.TaxAmount && parseFloat(s.TaxAmount) > 0 ? fmtMoney(s.TaxAmount) : '—'}</td>
                 <td class="fw-600">${isPreSale && !parseFloat(s.OrderAmount) ? '<span class="text-muted">—</span>' : fmtMoney(total)}</td>

--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -25,7 +25,7 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
   try {
-    const { Name, Type, Tags, ContactName, Email, AdditionalEmails, Phone, PreferredMethod, BillingContactName, BillingEmail, BillingPhone, Address, City, State, Zip, ABCLicense, Status, Notes, StaffID, StaffName, ServicedBy, CheckInFrequency } = req.body;
+    const { Name, Type, Tags, ContactName, Email, AdditionalEmails, Phone, PreferredMethod, BillingContactName, BillingEmail, BillingPhone, Address, City, State, Zip, ABCLicense, ChargeDeposits, Taxable, DeliversIndirectly, Status, Notes, StaffID, StaffName, ServicedBy, CheckInFrequency } = req.body;
     if (!Name) return res.status(400).json({ error: 'Account name is required' });
 
     const account = {
@@ -46,6 +46,9 @@ router.post('/', async (req, res) => {
       State: State || '',
       Zip: Zip || '',
       ABCLicense: ABCLicense || '',
+      ChargeDeposits: ChargeDeposits || 'false',
+      Taxable: Taxable || 'false',
+      DeliversIndirectly: DeliversIndirectly || 'false',
       Status: Status || 'Prospect',
       Notes: Notes || '',
       LastContacted: '',

--- a/routes/order-items.js
+++ b/routes/order-items.js
@@ -19,17 +19,23 @@ router.get('/', async (req, res) => {
   }
 });
 
-// GET /api/order-items/counts — get item counts per order (for badges)
+// GET /api/order-items/counts — line-item count and end-customer summary per
+// order, used by the orders list for the items badge and the indirect-delivery
+// "→ Venue" annotation. Shape: { [orderId]: { count: N, endCustomers: [...] } }.
 router.get('/counts', async (req, res) => {
   try {
     const items = await getAllRows('ORDER_ITEMS');
-    const counts = {};
+    const summary = {};
     for (const item of items) {
-      if (item.OrderID) {
-        counts[item.OrderID] = (counts[item.OrderID] || 0) + 1;
+      if (!item.OrderID) continue;
+      if (!summary[item.OrderID]) summary[item.OrderID] = { count: 0, endCustomers: [] };
+      summary[item.OrderID].count++;
+      const name = item.EndCustomerName || '';
+      if (name && !summary[item.OrderID].endCustomers.includes(name)) {
+        summary[item.OrderID].endCustomers.push(name);
       }
     }
-    res.json(counts);
+    res.json(summary);
   } catch (err) {
     console.error(`[order-items] ${err.message}`);
     res.status(500).json({ error: 'Internal server error' });
@@ -39,7 +45,7 @@ router.get('/counts', async (req, res) => {
 // POST /api/order-items — create a single item
 router.post('/', async (req, res) => {
   try {
-    const { OrderID, InventoryID, ProductName, Format, PriceTier, Quantity, UnitPrice, LineTotal } = req.body;
+    const { OrderID, InventoryID, ProductName, Format, PriceTier, Quantity, UnitPrice, LineTotal, EndCustomerAccountID, EndCustomerName } = req.body;
     if (!OrderID) return res.status(400).json({ error: 'OrderID is required' });
 
     const item = {
@@ -52,6 +58,8 @@ router.post('/', async (req, res) => {
       Quantity: Quantity || '0',
       UnitPrice: UnitPrice || '0',
       LineTotal: LineTotal || '0',
+      EndCustomerAccountID: EndCustomerAccountID || '',
+      EndCustomerName: EndCustomerName || '',
       CreatedAt: new Date().toISOString(),
     };
 
@@ -98,6 +106,8 @@ router.post('/bulk', async (req, res) => {
         UnitPrice: String(raw.UnitPrice || '0'),
         LineTotal: String(raw.LineTotal || '0'),
         Taxable: raw.Taxable || '',
+        EndCustomerAccountID: raw.EndCustomerAccountID || '',
+        EndCustomerName: raw.EndCustomerName || '',
         CreatedAt: new Date().toISOString(),
       };
       await addRow('ORDER_ITEMS', item);


### PR DESCRIPTION
## Summary
Closes #88 — handle orders placed with a distributor (e.g. Craft Republic, DJ Liquor) that pass through to end venues (Kauffman Center, Rusty Needle). A single order can be partially indirect (some lines for the distributor's shelves, some pass through), so the end-customer link lives on each order line item, not on the order header.

To keep the order modal uncluttered for normal accounts, the per-line "Delivers to" picker only appears when the order's account has the new **DeliversIndirectly** flag set.

## Changes

**Schema**
- `ACCOUNTS.DeliversIndirectly` (text, 'true'/'false')
- `ORDER_ITEMS.EndCustomerAccountID`, `ORDER_ITEMS.EndCustomerName`

**Account form**
- New checkbox: "This account delivers to other accounts (orders pass through to end venues)"

**Order form**
- Each line item gets an inline "→ Delivers to:" dropdown, hidden by default
- Visibility tied to the selected account's flag; switching to a non-indirect account hides and clears the pickers
- Read-only (Paid) view shows the end customer beneath the product name when set
- Custom and unmatched line items also support the picker

**Orders list & distributor profile**
- "→ Venue" hint (or "→ N venues" if mixed) appears under the account name when any line items are flagged
- `/api/order-items/counts` now returns `{ count, endCustomers }` per order

**Venue profile**
- New "Indirect Orders" section lists the line items delivered to this venue via other accounts, each linking to the parent order

## Test plan
- [ ] Edit an account, check **Delivers to other accounts**, save, reload — the flag persists
- [ ] Open an order on that account: each line shows a "→ Delivers to:" dropdown with `— Distributor —` default
- [ ] Open an order on a normal account: no pickers appear, layout unchanged
- [ ] On the indirect account, change the order's account in the form to a normal one mid-edit — pickers hide and clear
- [ ] Save an order with mixed lines (3 own-shelf + 1 to Rusty Needle); orders list shows `→ Rusty Needle` under the distributor name
- [ ] Multiple distinct end customers → list shows `→ N venues`
- [ ] Distributor's account profile order list shows the same hint
- [ ] Rusty Needle's account profile shows an **Indirect Orders** section with the pass-through line, linking to the parent order
- [ ] Edit the order, change the end customer on a line, save — the change persists and reflects in both views
- [ ] Read-only paid view shows `→ Venue` beneath the product name
- [ ] Reports / gallonage / dashboard / QBO are unchanged (intentionally out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)