### PR TITLE
Skip Account Credit rows in line-item builder (closes #378)

### DIFF
--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -942,13 +942,18 @@ async function refreshOrderProductsFromItems(orderItems, readOnly = false) {
   }
 
   // Editable mode: render line-item builder and populate from order items
+  // Account Credit rows are intentionally skipped — they're managed via the
+  // dedicated "Account Credit" section of the form and re-created on save.
+  // Without this, they fall through to addUnmatchedLineItem which renders a
+  // Delivers-to dropdown that doesn't apply to a credit.
   wrap.innerHTML = orderProductsHtml();
   for (const item of orderItems) {
+    if (item.ProductName === 'Account Credit') continue;
     const ec = item.EndCustomerAccountID || '';
     if (item.InventoryID && _orderFormInventory.find(i => i.ID === item.InventoryID)) {
       addOrderLineItem(item.InventoryID, parseInt(item.Quantity || 0), item.PriceTier || undefined, item.UnitPrice, ec);
-    } else if (!item.InventoryID && item.ProductName && item.ProductName !== 'Account Credit') {
-      // Custom item (no InventoryID, not a credit)
+    } else if (!item.InventoryID && item.ProductName) {
+      // Custom item (no InventoryID)
       addCustomLineItem(item.ProductName, item.UnitPrice, item.Quantity, item.Taxable, ec);
     } else if (item.ProductName) {
       // Try to match by product name + format against current inventory


### PR DESCRIPTION
## Summary
Closes #378 — Account Credit rows on an existing order showed up in the line-item builder with a "Delivers to" dropdown after PR #376 added the per-line picker. Credits are managed through the dedicated **Account Credit** section of the form and re-created on save, so they shouldn't appear as editable line items at all.

Base branch is set to `feat/issue-88-indirect-accounts` so this merges cleanly on top of PR #376.

## Test plan
- [ ] Edit an existing order that has a credit applied — Account Credit row no longer appears in the line-item list
- [ ] Account Credit section continues to show the applied amount with its dedicated controls
- [ ] Save: the credit is still re-created as an order item by the existing save flow
- [ ] Regression: regular custom line items still appear and edit correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)