### PR TITLE
Fix Delivers-to picker layout on mobile (closes #379)

### DIFF
--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -631,9 +631,9 @@ function _endCustomerPickerHtml(selectedId) {
   const acctName = acctId ? ((state.accounts || []).find(a => a.ID === acctId) || {}).Name : '';
   const defaultLabel = acctName ? `Stays with ${acctName}` : 'No pass-through (stays with this account)';
   const opts = `<option value="">${esc(defaultLabel)}</option>${accountOptions(selectedId || '')}`;
-  return `<div class="line-item-delivers-to" style="display:${indirect ? 'flex' : 'none'};gap:6px;align-items:center;margin-top:4px;padding-left:8px">
-    <span class="text-sm text-muted" style="white-space:nowrap">→ Delivers to:</span>
-    <select class="form-control line-item-end-customer" style="flex:1;font-size:13px;padding:4px 8px;height:auto">${opts}</select>
+  return `<div class="line-item-delivers-to" style="display:${indirect ? 'flex' : 'none'};gap:6px;align-items:center;flex-wrap:wrap;margin-top:4px;margin-left:12px;padding-left:8px;border-left:2px solid var(--color-border, #e5e7eb)">
+    <span class="line-item-delivers-to-label text-sm text-muted" style="white-space:nowrap">&rarr; Delivers to:</span>
+    <select class="form-control line-item-end-customer" style="flex:1;min-width:140px;font-size:13px;padding:4px 8px;height:auto">${opts}</select>
   </div>`;
 }
 
@@ -703,8 +703,8 @@ function addOrderLineItem(inventoryId, qty, priceTier, savedUnitPrice, endCustom
   const tierHtml = prices.length > 1 ? _buildTierDropdown(prices, selectedTierLabel) : '';
 
   div.innerHTML = `
-    <div style="display:flex;gap:8px;align-items:center">
-      <select class="form-control" onchange="onLineItemProductChange(this)" style="flex:2;min-width:120px">
+    <div class="order-line-item-row" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+      <select class="form-control line-item-product" onchange="onLineItemProductChange(this)" style="flex:2;min-width:120px">
         ${_buildProductOptions(inventoryId || '')}
       </select>
       ${tierHtml}
@@ -761,8 +761,8 @@ function addUnmatchedLineItem(item) {
   div.setAttribute('data-price-tier', item.PriceTier || '');
   div.style.cssText = 'margin-bottom:6px';
   div.innerHTML = `
-    <div style="display:flex;gap:8px;align-items:center">
-      <span style="flex:2;min-width:120px;font-size:13px" title="Not in current location inventory">${esc(item.ProductName)}${item.Format ? ' — ' + esc(item.Format) : ''}</span>
+    <div class="order-line-item-row" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+      <span class="line-item-unmatched" style="flex:2;min-width:120px;font-size:13px" title="Not in current location inventory">${esc(item.ProductName)}${item.Format ? ' — ' + esc(item.Format) : ''}</span>
       <span class="line-item-price text-sm" style="min-width:55px">${price ? '$' + price.toFixed(2) : '—'}</span>
       <input class="form-control line-item-qty" type="number" min="0" value="${qty}" style="width:60px"
         onchange="recalcOrderAmount()" oninput="recalcOrderAmount()" />
@@ -790,7 +790,7 @@ function addCustomLineItem(description, unitPrice, qty, taxable, endCustomerId) 
   div.setAttribute('data-price-tier', '');
   div.style.cssText = 'margin-bottom:6px';
   div.innerHTML = `
-    <div style="display:flex;gap:8px;align-items:center">
+    <div class="order-line-item-row" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
       <input class="form-control custom-item-desc" type="text" value="${esc(description || '')}" placeholder="e.g. T-shirt, service charge" style="flex:2;min-width:120px" />
       <input class="form-control custom-item-price" type="number" step="0.01" min="0" value="${price ? price.toFixed(2) : ''}" placeholder="Price" style="width:80px"
         onchange="onCustomItemPriceChange(this)" oninput="onCustomItemPriceChange(this)" />

--- a/public/style.css
+++ b/public/style.css
@@ -1690,18 +1690,43 @@ th input[type="checkbox"] {
     margin-left: 0;
   }
 
-  /* ── Order line items: stack on mobile ── */
-  .order-line-item {
+  /* ── Order line items: stack on mobile ──
+     PR #376 added a per-line "Delivers to" picker. On narrow screens the main
+     row would cram product select + price + qty + total + delete onto one
+     line, making the product name unreadable. Give the product select its own
+     full-width row, let the qty/price/total cluster below it wrap, and keep
+     the Delivers-to sub-row clearly attached via the indent + left border. */
+  .order-line-item-row {
     flex-wrap: wrap !important;
   }
 
-  .order-line-item select.form-control {
+  .order-line-item-row > select.form-control,
+  .order-line-item-row > .line-item-product,
+  .order-line-item-row > .line-item-unmatched,
+  .order-line-item-row > .custom-item-desc {
     flex: 1 1 100% !important;
     min-width: 0 !important;
+    max-width: 100% !important;
   }
 
-  .order-line-item .line-item-qty {
+  .order-line-item-row .line-item-tier {
+    flex: 1 1 100% !important;
+    max-width: 100% !important;
+  }
+
+  .order-line-item-row .line-item-qty {
     width: 70px !important;
+  }
+
+  /* Delivers-to picker: label on its own line above a full-width select on
+     the narrowest phones so the customer name is actually readable. */
+  .line-item-delivers-to {
+    margin-left: 8px !important;
+  }
+
+  .line-item-delivers-to .line-item-end-customer {
+    flex: 1 1 100% !important;
+    min-width: 0 !important;
   }
 
   /* ── Toast: fit to phone width ── */


### PR DESCRIPTION
## Summary

- Order line items became nearly unreadable on phones after PR #376 added the per-line Delivers-to picker: the main row kept all controls (product select, price, qty, total, delete) on one horizontal flex line, squeezing the product select so the product name was illegible while the Delivers-to sub-row fought for the same narrow width.
- Adds an `order-line-item-row` class on the inner flex div so mobile CSS can target it (PR #376 moved the flex from the outer wrapper to this inner div, which is why the existing `.order-line-item` mobile rules had silently stopped doing anything).
- At `max-width: 640px` the product select / unmatched span / custom-item description input takes a full-width line of its own; qty / price / total / delete (and the Tax checkbox for custom items) cluster onto a second line.
- The Delivers-to row now has a left border + indent so it reads visually as a sub-row attached to its line item; on narrow screens its label and select wrap so the customer name is readable.

Desktop layout is unchanged: the inline `flex-wrap: wrap` is a no-op when the row already fits on one line, and the Delivers-to indent/border is a small visual clarification consistent with its "per-line setting" purpose.

## Test plan

- [ ] On an iPhone-width viewport (~390px), open the New Order modal for an account with `DeliversIndirectly = true`, add a product line: product select is full-width and readable; qty / price / total / delete sit on a second row; Delivers-to picker indented below with a readable customer dropdown.
- [ ] Add a custom line item on phone: description full-width; price / qty / Tax / total / delete wrap onto a second row legibly.
- [ ] Edit an existing order that has tier-priced items on phone: tier dropdown wraps to its own line and is readable.
- [ ] On desktop (>= 1024px), confirm the line item rows still render as a single horizontal row with no wrapping, and the Delivers-to picker (when shown) still sits inline beneath, now with a subtle left-border indent.
- [ ] Switch the order to a non-indirect account and confirm the Delivers-to picker hides as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)