### PR TITLE
Send QBO invoices to multiple recipients (closes #321)

### DIFF
--- a/qbo-service.js
+++ b/qbo-service.js
@@ -531,6 +531,41 @@ function clearAllCaches() {
   _qboPaymentMethods = null;
 }
 
+/**
+ * Collect additional invoice email recipients (CC) for an account, excluding
+ * the address already used as the primary BillEmail. Pulls from the regular
+ * Email field (when BillingEmail is the primary) plus the AdditionalEmails
+ * JSON array. Dedupes case-insensitively.
+ *
+ * @param {object} account - ACCOUNTS row
+ * @param {string} primaryEmail - the address used as BillEmail on the invoice
+ * @returns {string[]} unique CC email addresses (may be empty)
+ */
+function collectInvoiceCcs(account, primaryEmail) {
+  const ccs = [];
+  const seen = new Set();
+  if (primaryEmail) seen.add(primaryEmail.toLowerCase().trim());
+  const add = (e) => {
+    if (!e) return;
+    const norm = String(e).trim();
+    if (!norm) return;
+    const key = norm.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    ccs.push(norm);
+  };
+  // If BillingEmail was used as the primary, include Email as a CC.
+  if (account.BillingEmail && account.Email) add(account.Email);
+  // Append AdditionalEmails (stored as a JSON array of strings).
+  if (account.AdditionalEmails) {
+    try {
+      const extras = JSON.parse(account.AdditionalEmails);
+      if (Array.isArray(extras)) extras.forEach(add);
+    } catch { /* ignore malformed JSON */ }
+  }
+  return ccs;
+}
+
 // ── Payment / Invoice lookup ─────────────────────────────────────
 
 async function getPayment(paymentId) {
@@ -796,8 +831,12 @@ async function createInvoice(order, lineItems, account, _isRetry) {
     }
   }
 
-  // Determine bill email: prefer BillingEmail, fall back to account Email
+  // Determine bill email: prefer BillingEmail, fall back to account Email.
+  // Additional recipients (the regular Email if BillingEmail was used, plus
+  // anything in AdditionalEmails) become CC addresses on the QBO invoice so
+  // they're included both on the initial send and any future re-sends.
   const billEmail = account.BillingEmail || account.Email;
+  const ccEmails = collectInvoiceCcs(account, billEmail);
 
   // Look up QBO Department from order Location
   let departmentRef;
@@ -819,6 +858,7 @@ async function createInvoice(order, lineItems, account, _isRetry) {
     TxnDate:      order.OrderDate ? order.OrderDate.split('T')[0] : undefined,
     DueDate:      order.DeliveryDate ? order.DeliveryDate.split('T')[0] : undefined,
     BillEmail:     billEmail ? { Address: billEmail } : undefined,
+    BillEmailCc:   ccEmails.length > 0 ? { Address: ccEmails.join(', ') } : undefined,
     DepartmentRef: departmentRef,
   };
 
@@ -933,13 +973,17 @@ async function syncOrderToQbo(orderId) {
 
     console.log(`[qbo] Order ${orderId} synced → QBO Invoice ${qboInvoiceId}`);
 
-    // Send the invoice via email
+    // Send the invoice via email. QBO sends to the BillEmail on the invoice
+    // plus any BillEmailCc / BillEmailBcc addresses we set when creating it,
+    // so additional recipients automatically receive the message.
     let invoiceSendNote = '';
     const billEmail = account.BillingEmail || account.Email;
     if (billEmail) {
       try {
         await qboApiRequest('POST', `invoice/${qboInvoiceId}/send`);
-        console.log(`[qbo] Invoice ${qboInvoiceId} sent to ${billEmail}`);
+        const ccs = collectInvoiceCcs(account, billEmail);
+        const recipientList = ccs.length > 0 ? `${billEmail} (cc: ${ccs.join(', ')})` : billEmail;
+        console.log(`[qbo] Invoice ${qboInvoiceId} sent to ${recipientList}`);
       } catch (sendErr) {
         console.error(`[qbo] Invoice ${qboInvoiceId} created but send failed:`, sendErr.message);
         invoiceSendNote = `Invoice ${invoice.DocNumber || qboInvoiceId} was not sent: ${sendErr.message}`;


### PR DESCRIPTION
## Summary
Closes #321 — invoices synced to QBO now go to all configured recipients on the account, not just the primary.

- **BillEmail**: `BillingEmail || Email` (unchanged)
- **BillEmailCc**: built from the regular `Email` (when `BillingEmail` is acting as the primary) plus everything in `AdditionalEmails`, deduped case-insensitively against the primary
- QBO's `/invoice/{id}/send` endpoint sends to BillEmail + BillEmailCc together, so the initial send and any future re-sends from QBO itself all include the full recipient list
- Server log now records the full recipient list (`sent to primary (cc: a@x.com, b@x.com)`)

## Setup
No new UI — recipients come from the existing fields on the Account form:
- **Billing Email** → primary
- **Email** → CC (when Billing Email differs)
- **Additional Emails** → all CC

## Test plan
- [ ] Account with **Billing Email** only → invoice has BillEmail set, no Cc
- [ ] Account with **Email + Billing Email** → BillEmail is the billing address, Email is in Cc
- [ ] Account with **Email + AdditionalEmails** (no Billing Email) → BillEmail is Email, AdditionalEmails are in Cc
- [ ] Account with all three populated → no duplicates in Cc (e.g. if BillingEmail also appears in AdditionalEmails)
- [ ] Account with no email anywhere → still produces the existing "no email address on account" send note
- [ ] Server log shows the full recipient list
- [ ] In QBO, open the invoice and verify BillEmailCc shows the CC addresses
- [ ] Re-send the invoice from inside QBO — all recipients still receive it

Follow-up: edit-time resync of an existing invoice is in #383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)