### PR TITLE
Resync QBO invoice when editing an unpaid synced order

### DIFF
--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -1464,6 +1464,32 @@ async function openAddOrder(presetAccountId = '') {
   }
 }
 
+// Compose a stable string for the order's "material" state — the fields that
+// matter for QBO invoicing. Used to detect whether an edit changed enough to
+// warrant pushing the update back to the existing QBO invoice and re-sending.
+function orderMaterialSignature(order, items) {
+  const itemSig = (items || [])
+    .filter(i => i.ProductName !== 'Account Credit')
+    .map(i => [
+      i.InventoryID || '',
+      i.ProductName || '',
+      i.Format || '',
+      i.PriceTier || '',
+      String(i.Quantity || ''),
+      String(i.UnitPrice || ''),
+      i.EndCustomerAccountID || '',
+    ].join('|'))
+    .sort()
+    .join(';');
+  return [
+    order.AccountID || '',
+    String(order.OrderAmount || ''),
+    String(order.TaxAmount || ''),
+    String(order.DepositAmount || ''),
+    itemSig,
+  ].join('::');
+}
+
 async function openEditOrder(id) {
   if (state.staff.length === 0) state.staff = await api.get('/api/staff');
   const order = _ordersCache.find(s => s.ID === id);
@@ -1480,6 +1506,16 @@ async function openEditOrder(id) {
       loadOrders();
     }, 'Save');
   } else {
+    // Snapshot the order's current line items + material signature so the save
+    // handler can detect line item / amount / recipient changes and push them
+    // back to QBO (resync + resend) for synced, unpaid orders.
+    const origItems = await api.get(`/api/order-items?orderId=${encodeURIComponent(id)}`);
+    const origSig = orderMaterialSignature(order, origItems);
+    const wasSyncedUnpaid = order.QboInvoiceId
+      && order.QboSyncStatus === 'synced'
+      && !order.QboPaymentId
+      && order.Status !== 'Cancelled';
+
     modal.open('Edit Order', orderForm(order), async () => {
       const staffId = val('f-staff');
       const staffName = staffId ? (state.staff.find(s => s.ID === staffId) || {}).Name || '' : '';
@@ -1548,6 +1584,30 @@ async function openEditOrder(id) {
           toast('Payment synced to QuickBooks');
         } catch (err) {
           toast('Payment saved but QBO sync failed: ' + (err.message || 'unknown error'), 'error');
+        }
+      }
+      // Push edits to the existing QBO invoice when line items, amounts, or
+      // recipients changed. Skipped when the order is becoming Paid (the
+      // payment sync above handles that case; updating + resending an invoice
+      // we just marked paid would be noisy).
+      if (wasSyncedUnpaid && !becomingPaid) {
+        const newSig = orderMaterialSignature(
+          { AccountID: val('f-account') || order.AccountID,
+            OrderAmount: finalAmount,
+            TaxAmount: val('f-tax'),
+            DepositAmount: val('f-deposit-amount') || '0' },
+          collectOrderItems(),
+        );
+        if (newSig !== origSig) {
+          try {
+            const result = await api.post(`/api/qbo/resync/${id}`);
+            if (result.status === 'sent') toast('QBO invoice updated and resent');
+            else if (result.status === 'updated') toast('QBO invoice updated (resend skipped: ' + (result.error || 'no email') + ')');
+            else if (result.status === 'failed') toast('Order saved but QBO update failed: ' + (result.error || 'unknown'), 'error');
+            // 'skipped' (paid/cancelled/etc.) needs no toast — already guarded above
+          } catch (err) {
+            toast('Order saved but QBO update failed: ' + (err.message || 'unknown'), 'error');
+          }
         }
       }
       // Prompt QBO sync when transitioning from Draft to Pending or Paid

--- a/qbo-service.js
+++ b/qbo-service.js
@@ -742,7 +742,19 @@ async function getNextInvoiceNumber() {
 
 // ── Invoice creation ─────────────────────────────────────────────
 
-async function createInvoice(order, lineItems, account, _isRetry) {
+/**
+ * Build the QBO Invoice request body for an order, sharing the layout logic
+ * between createInvoice (initial POST) and updateInvoice (sparse update of
+ * an existing invoice). Honors deposits per keg format, tax via TxnTaxDetail,
+ * and BillEmail/BillEmailCc from the account's email fields.
+ *
+ * @param {object} order - ORDERS row
+ * @param {Array<object>} lineItems - ORDER_ITEMS rows
+ * @param {object} account - ACCOUNTS row
+ * @returns {Promise<object>} invoice body suitable for POST /invoice or
+ *   (with Id/SyncToken/sparse merged in by the caller) POST /invoice?operation=update
+ */
+async function _buildInvoiceBody(order, lineItems, account) {
   const customerId = await findOrCreateCustomer(account);
   const productItemId = await getOrCreateProductItem();
   const taxInfo = await getTaxInfo();
@@ -887,6 +899,12 @@ async function createInvoice(order, lineItems, account, _isRetry) {
   // Remove undefined values
   Object.keys(invoiceBody).forEach(k => invoiceBody[k] === undefined && delete invoiceBody[k]);
 
+  return invoiceBody;
+}
+
+async function createInvoice(order, lineItems, account, _isRetry) {
+  const invoiceBody = await _buildInvoiceBody(order, lineItems, account);
+
   let result;
   try {
     result = await qboApiRequest('POST', 'invoice', invoiceBody);
@@ -908,8 +926,51 @@ async function createInvoice(order, lineItems, account, _isRetry) {
 
   const invoice = result.Invoice;
   // Ensure DocNumber is always set — QBO may not echo it back in some configurations
-  if (invoice && !invoice.DocNumber) invoice.DocNumber = docNumber;
+  if (invoice && !invoice.DocNumber) invoice.DocNumber = invoiceBody.DocNumber;
   return invoice;
+}
+
+/**
+ * Sparse-update an existing QBO invoice with the order's current line items,
+ * amounts, and recipients. Fetches the invoice first to read its SyncToken
+ * (QBO requires it on every update).
+ *
+ * @param {string} invoiceId - QBO invoice Id
+ * @param {object} order - ORDERS row
+ * @param {Array<object>} lineItems - ORDER_ITEMS rows
+ * @param {object} account - ACCOUNTS row
+ * @param {boolean} [_isRetry] - internal; retries on 610 cache-miss errors
+ * @returns {Promise<object>} updated invoice
+ */
+async function updateInvoice(invoiceId, order, lineItems, account, _isRetry) {
+  const existing = await getInvoice(invoiceId);
+  if (!existing) throw new Error(`Invoice ${invoiceId} not found in QBO`);
+
+  const body = await _buildInvoiceBody(order, lineItems, account);
+  body.Id        = String(existing.Id);
+  body.SyncToken = existing.SyncToken;
+  body.sparse    = true;
+  // Preserve the original DocNumber when possible — we don't want to renumber
+  // an invoice that customers have already seen.
+  if (existing.DocNumber) body.DocNumber = existing.DocNumber;
+
+  let result;
+  try {
+    result = await qboApiRequest('POST', 'invoice?operation=update', body);
+  } catch (err) {
+    if (!_isRetry && (err.message.includes('"code":"610"') || /made inactive/i.test(err.message))) {
+      console.warn(`[qbo] Invoice update got 610 (inactive entity), clearing caches and retrying…`);
+      clearAllCaches();
+      if (account.QboCustomerId) {
+        try { await updateRow('ACCOUNTS', account.ID, { QboCustomerId: '' }); } catch (e) { /* ignore */ }
+        account.QboCustomerId = '';
+      }
+      return updateInvoice(invoiceId, order, lineItems, account, true);
+    }
+    throw err;
+  }
+
+  return result.Invoice;
 }
 
 // ── Top-level sync function ──────────────────────────────────────
@@ -1043,6 +1104,86 @@ async function syncOrderToQbo(orderId) {
   }
 }
 
+/**
+ * Push edits to an already-synced order back to its QBO invoice and re-send.
+ * Used after the order header or its line items change locally.
+ *
+ * Guard rails:
+ *   - QBO must be configured and connected
+ *   - The order must have a QboInvoiceId and QboSyncStatus='synced'
+ *   - The order must not be paid in QBO (QboPaymentId unset)
+ *   - The order must not be Cancelled
+ *
+ * On any failure, sets QboSyncStatus='failed' with the error message so the
+ * order form's QBO section surfaces a Retry button. Does not throw.
+ *
+ * @param {string} orderId
+ * @returns {Promise<{ status: string, error?: string, recipients?: string }>}
+ */
+async function resyncOrderToQbo(orderId) {
+  try {
+    if (!isQboConfigured()) return { status: 'disabled' };
+    const tokens = await getValidToken();
+    if (!tokens) {
+      await updateRow('ORDERS', orderId, {
+        QboSyncStatus: 'failed',
+        QboSyncError:  'Not connected to QuickBooks — reconnect in Settings',
+      });
+      return { status: 'failed', error: 'not connected' };
+    }
+
+    const order = getRow('ORDERS', orderId);
+    if (!order) return { status: 'skipped', error: 'order not found' };
+    if (!order.QboInvoiceId || order.QboSyncStatus !== 'synced') {
+      return { status: 'skipped', error: 'order is not synced to QBO' };
+    }
+    if (order.QboPaymentId) {
+      return { status: 'skipped', error: 'invoice already paid in QBO' };
+    }
+    if (order.Status === 'Cancelled') {
+      return { status: 'skipped', error: 'order is cancelled' };
+    }
+
+    const account = getRow('ACCOUNTS', order.AccountID);
+    if (!account) {
+      const msg = `Account ${order.AccountID} not found`;
+      await updateRow('ORDERS', orderId, { QboSyncStatus: 'failed', QboSyncError: msg });
+      return { status: 'failed', error: msg };
+    }
+
+    const allItems = await getAllRows('ORDER_ITEMS');
+    const lineItems = allItems.filter(i => i.OrderID === orderId);
+
+    const updated = await updateInvoice(order.QboInvoiceId, order, lineItems, account);
+    if (!updated || !updated.Id) throw new Error('QBO returned no invoice on update');
+
+    // Make sure local QboSyncStatus is back to synced (clears any prior failure).
+    await updateRow('ORDERS', orderId, { QboSyncStatus: 'synced', QboSyncError: '' });
+
+    // Re-send to BillEmail + BillEmailCc — same shape as the initial sync.
+    const billEmail = account.BillingEmail || account.Email;
+    if (billEmail) {
+      try {
+        await qboApiRequest('POST', `invoice/${order.QboInvoiceId}/send`);
+        const ccs = collectInvoiceCcs(account, billEmail);
+        const recipientList = ccs.length > 0 ? `${billEmail} (cc: ${ccs.join(', ')})` : billEmail;
+        console.log(`[qbo] Invoice ${order.QboInvoiceId} re-sent to ${recipientList}`);
+        return { status: 'sent', recipients: recipientList };
+      } catch (sendErr) {
+        console.error(`[qbo] Invoice ${order.QboInvoiceId} updated but re-send failed:`, sendErr.message);
+        return { status: 'updated', error: sendErr.message };
+      }
+    }
+    return { status: 'updated', error: 'no email address on account' };
+  } catch (err) {
+    console.error(`[qbo] Resync failed for order ${orderId}:`, err.message);
+    try {
+      await updateRow('ORDERS', orderId, { QboSyncStatus: 'failed', QboSyncError: err.message || 'Resync failed' });
+    } catch { /* ignore */ }
+    return { status: 'failed', error: err.message };
+  }
+}
+
 module.exports = {
   isQboConfigured,
   getOAuthClient,
@@ -1051,6 +1192,7 @@ module.exports = {
   clearTokens,
   getValidToken,
   syncOrderToQbo,
+  resyncOrderToQbo,
   fetchTaxCodes,
   clearTaxInfoCache,
   getPayment,

--- a/routes/qbo.js
+++ b/routes/qbo.js
@@ -3,7 +3,7 @@
 const crypto      = require('crypto');
 const express     = require('express');
 const OAuthClient = require('intuit-oauth');
-const { isQboConfigured, getOAuthClient, getStoredTokens, storeTokens, clearTokens, syncOrderToQbo, fetchTaxCodes, clearTaxInfoCache, createPayment, QBO_APP_URL } = require('../qbo-service');
+const { isQboConfigured, getOAuthClient, getStoredTokens, storeTokens, clearTokens, syncOrderToQbo, resyncOrderToQbo, fetchTaxCodes, clearTaxInfoCache, createPayment, QBO_APP_URL } = require('../qbo-service');
 
 const authRouter = express.Router();
 const apiRouter  = express.Router();
@@ -204,6 +204,21 @@ apiRouter.post('/sync/:orderId', async (req, res) => {
       order.QboSyncError = 'QBO sync failed — check Settings for connection issues';
     }
     res.json(order);
+  } catch (err) {
+    console.error('[qbo]', err.message);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /api/qbo/resync/:orderId — push edits to an existing invoice + re-send.
+// Called by the order-edit client when line items, amounts, or recipients
+// change on an already-synced, unpaid order. Skips paid/cancelled orders.
+apiRouter.post('/resync/:orderId', async (req, res) => {
+  try {
+    const result = await resyncOrderToQbo(req.params.orderId);
+    const { getRow } = require('../db');
+    const order = getRow('ORDERS', req.params.orderId);
+    res.json({ ...result, order });
   } catch (err) {
     console.error('[qbo]', err.message);
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
Follow-up to #382. Editing an already-synced order previously had no effect on the QBO invoice — the local row changed but the customer-facing invoice stayed frozen. This PR pushes edits back to the existing QBO invoice and re-sends it so customers always see the latest version.

Base branch is `feat/issue-321-qbo-multi-recipient` (PR #382) so the multi-recipient helpers are available; once that merges this rebases onto main.

## Changes
- New `_buildInvoiceBody()` extracted from `createInvoice` and shared with the new `updateInvoice()` (sparse update using the invoice's current `SyncToken`).
- `resyncOrderToQbo()` guards: must be synced + unpaid (no `QboPaymentId`), not Cancelled, has a `QboInvoiceId`. On failure sets `QboSyncStatus='failed'` with the error so the existing Retry button surfaces.
- `POST /api/qbo/resync/:orderId` exposes it.
- Client snapshots an order "material signature" (account, OrderAmount/TaxAmount/DepositAmount, sorted line items including end-customer) before opening the edit modal and compares it after save. Only fires the resync when something material actually changed — a notes-only edit doesn't email the customer.
- Skips the resync when the same edit is also flipping status to Paid (the existing payment-sync path handles that case).

## Test plan
- [ ] Edit a synced, unpaid order: change a line item quantity → toast "QBO invoice updated and resent", new invoice email arrives at all recipients, QBO shows the updated line
- [ ] Change tax amount only → resync fires
- [ ] Change deposit amount only → resync fires
- [ ] Add a new line item → resync fires
- [ ] Change end customer on a line (indirect-account flow) → resync fires
- [ ] Edit notes only → no resync, no email
- [ ] Edit a paid order → no resync (skipped: invoice already paid in QBO)
- [ ] Edit a cancelled order → no resync
- [ ] Edit an order that flips Pending → Paid → payment-sync runs, resync is suppressed
- [ ] QBO is disconnected → resync fails, QboSyncStatus=failed, Retry button appears, toast surfaces the error
- [ ] Edit an order that was never synced → no resync attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)