### PR TITLE
Make paid-order modal truly view-only (closes #385)

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -1039,15 +1039,9 @@ function profileEditOrder(id) {
     if (!order) return;
     const isPaid = order.Status === 'Paid';
     if (isPaid) {
-      modal.open('View Order', orderForm(order, '', true), async () => {
-        await api.put(`/api/orders/${id}`, {
-          InvoiceNumber: val('f-invoice'),
-          Notes: val('f-notes'),
-        });
-        modal.close();
-        toast('Order updated');
-        loadAccountProfile(state.accountProfileId);
-      }, 'Save');
+      // Paid orders are view-only — the only mutation still available is the
+      // Delivered checkbox in the orders list (handled outside this modal).
+      modal.open('View Order', orderForm(order, '', true), () => modal.close(), 'Close');
     } else {
       modal.open('Edit Order', orderForm(order), async () => {
         const staffId = val('f-staff');

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -181,7 +181,7 @@ function orderForm(order = {}, presetAccountId = '', readOnly = false) {
     </div>
     <div class="form-group">
       <label>Invoice Number</label>
-      <input class="form-control" id="f-invoice" value="${esc(order.InvoiceNumber)}" placeholder="e.g. INV-2024-001" />
+      <input class="form-control" id="f-invoice" value="${esc(order.InvoiceNumber)}" placeholder="e.g. INV-2024-001"${dis} />
     </div>
     <hr class="form-divider" />
     <div class="form-section-title">Products</div>
@@ -231,7 +231,7 @@ function orderForm(order = {}, presetAccountId = '', readOnly = false) {
     <div id="order-total-summary" class="order-total-summary" style="display:none"></div>
     <div class="form-group" style="margin-top:14px">
       <label>Notes / Reference</label>
-      <textarea class="form-control" id="f-notes" rows="2" placeholder="Order details, product breakdown, etc.">${esc(order.Notes)}</textarea>
+      <textarea class="form-control" id="f-notes" rows="2" placeholder="Order details, product breakdown, etc."${dis}>${esc(order.Notes)}</textarea>
     </div>
     ${_qboAppUrl && order.ID && !(!order.QboSyncStatus && order.Status === 'Paid' && order.Delivered === 'true') ? `
     <hr class="form-divider" />
@@ -1470,15 +1470,9 @@ async function openEditOrder(id) {
   if (!order) return;
   const isPaid = order.Status === 'Paid';
   if (isPaid) {
-    modal.open('View Order', orderForm(order, '', true), async () => {
-      await api.put(`/api/orders/${id}`, {
-        InvoiceNumber: val('f-invoice'),
-        Notes: val('f-notes'),
-      });
-      modal.close();
-      toast('Order updated');
-      loadOrders();
-    }, 'Save');
+    // Paid orders are view-only — the only mutation still available is the
+    // Delivered checkbox in the orders list (handled outside this modal).
+    modal.open('View Order', orderForm(order, '', true), () => modal.close(), 'Close');
   } else {
     modal.open('Edit Order', orderForm(order), async () => {
       const staffId = val('f-staff');


### PR DESCRIPTION
## Summary
Closes #385. The orders list and account-profile order list already labeled the action button "View" for Paid orders, but clicking it opened a modal where Invoice Number and Notes were still editable with a Save button. This finishes the conversion so the View modal matches its label.

- Disable the Invoice Number input and Notes textarea in `orderForm()` when `readOnly=true`.
- Replace the Save+Cancel pair with a single Close button in both the orders list (`openEditOrder`) and account profile (`profileEditOrder`) paid paths.

The Delivered checkbox in the orders list — the one remaining mutation on paid orders — lives outside the modal and is unaffected.

## Test plan
- [ ] Orders list: row with status=Paid → action button reads "View"
- [ ] Click View → modal opens titled "View Order", footer shows a single "Close" button (no Save)
- [ ] All fields (Account, Location, Sales Rep, Status, Order/Delivery date, Invoice Number, Order Amount, Tax, Notes, Payment Method/Reference/Date) are disabled
- [ ] Mark Delivered checkbox in the orders list still toggles correctly for a Paid order
- [ ] Account profile order list: same behavior on Paid rows
- [ ] Account profile "Indirect Orders" and Credits "View Order" links: still open the same View modal correctly
- [ ] Non-paid orders (Draft/Pending) still open the editable "Edit Order" modal with all fields working

🤖 Generated with [Claude Code](https://claude.com/claude-code)