### PR TITLE
Add bulk actions to Todos (closes #387)

### DIFF
--- a/public/js/todos.js
+++ b/public/js/todos.js
@@ -70,6 +70,9 @@ let _todosCache = [];
 let _todoStatusFilter = 'active';
 let _todoSearchFilter = '';
 let _todoStaffFilter  = '';
+// IDs of todos selected for bulk actions. Survives pagination clicks; cleared
+// when filters/status change or a bulk action completes.
+const _todoSelection = new Set();
 
 async function loadTodos(preservePage = false) {
   if (!preservePage) _paginationReset('todos');
@@ -96,17 +99,14 @@ async function loadTodos(preservePage = false) {
   renderTodos();
 }
 
-function renderTodos() {
-  const todos = _todosCache;
-  const _focused = document.activeElement?.id;
-  const statusFilter = _todoStatusFilter;
+// Apply the current search/staff/navFilter to the cache. Status filtering
+// happens server-side via the loadTodos query param.
+function _currentFilteredTodos() {
   const searchEl = document.getElementById('todo-search');
   const staffEl  = document.getElementById('todo-staff');
   const search = searchEl ? searchEl.value : _todoSearchFilter;
   const staffFilter = (staffEl ? staffEl.value : _todoStaffFilter) || state.navFilters?.staffId || '';
-  const staffFilterName = state.navFilters?.staffName || '';
-
-  let filtered = todos;
+  let filtered = _todosCache;
   if (staffFilter) filtered = filtered.filter(r => r.StaffID === staffFilter);
   if (search) {
     const q = search.toLowerCase();
@@ -116,8 +116,30 @@ function renderTodos() {
       (r.StaffName || '').toLowerCase().includes(q)
     );
   }
+  return { filtered, staffFilter, search };
+}
+
+// Reset bulk selection (e.g. when filters change or after a bulk action).
+function _clearTodoSelection() {
+  _todoSelection.clear();
+}
+
+function renderTodos() {
+  const todos = _todosCache;
+  const _focused = document.activeElement?.id;
+  const statusFilter = _todoStatusFilter;
+  const { filtered, staffFilter, search } = _currentFilteredTodos();
+  const staffFilterName = state.navFilters?.staffName || '';
+
+  // Drop selections that no longer match the active filter (so the bulk bar
+  // count and the header "all selected" check stay accurate).
+  if (_todoSelection.size > 0) {
+    const visibleIds = new Set(filtered.map(r => r.ID));
+    for (const id of _todoSelection) if (!visibleIds.has(id)) _todoSelection.delete(id);
+  }
 
   const pg = paginate(filtered, 'todos');
+  const allFilteredSelected = filtered.length > 0 && filtered.every(r => _todoSelection.has(r.ID));
 
   const staffOpts = `<option value="">All Staff</option>` +
     [...new Map(todos.filter(r => r.StaffID).map(r => [r.StaffID, r.StaffName])).entries()]
@@ -137,9 +159,9 @@ function renderTodos() {
       </div>
     </div>
     <div class="filter-bar">
-      <input type="search" id="todo-search" placeholder="Search title, account, staff..." value="${esc(search)}" oninput="_todoSearchFilter=this.value; _paginationReset('todos'); renderTodos()" />
-      <select id="todo-staff" onchange="_todoStaffFilter=this.value; state.navFilters={}; _paginationReset('todos'); renderTodos()">${staffOpts}</select>
-      <select id="todo-status" onchange="_paginationReset('todos'); loadTodos()">
+      <input type="search" id="todo-search" placeholder="Search title, account, staff..." value="${esc(search)}" oninput="_todoSearchFilter=this.value; _clearTodoSelection(); _paginationReset('todos'); renderTodos()" />
+      <select id="todo-staff" onchange="_todoStaffFilter=this.value; state.navFilters={}; _clearTodoSelection(); _paginationReset('todos'); renderTodos()">${staffOpts}</select>
+      <select id="todo-status" onchange="_clearTodoSelection(); _paginationReset('todos'); loadTodos()">
         <option value="active" ${statusFilter === 'active' ? 'selected' : ''}>Active</option>
         <option value="completed" ${statusFilter === 'completed' ? 'selected' : ''}>Completed</option>
         <option value="all" ${statusFilter === 'all' ? 'selected' : ''}>All</option>
@@ -149,13 +171,15 @@ function renderTodos() {
       <table>
         <thead>
           <tr>
+            <th style="width:32px"><input type="checkbox" id="todo-select-all" ${allFilteredSelected ? 'checked' : ''} onchange="toggleAllTodoSelection(this.checked)" title="Select all filtered" /></th>
             <th>Due</th><th class="mobile-hide">Status</th><th>Title</th><th class="mobile-hide">Account</th>
             <th class="mobile-hide">Type</th><th class="mobile-hide">Assigned To</th><th class="mobile-hide">Priority</th><th>Actions</th>
           </tr>
         </thead>
         <tbody>
-          ${pg.total === 0 ? `<tr><td colspan="8" class="empty-state">No todos found.</td></tr>` :
+          ${pg.total === 0 ? `<tr><td colspan="9" class="empty-state">No todos found.</td></tr>` :
             pg.rows.map(r => `<tr>
+              <td><input type="checkbox" class="todo-row-checkbox" data-id="${esc(r.ID)}" ${_todoSelection.has(r.ID) ? 'checked' : ''} onchange="toggleTodoSelection('${esc(r.ID)}', this.checked)" /></td>
               <td>${formatDate(r.DueDate)}</td>
               <td class="mobile-hide">${urgencyBadge(r.DueDate, r.Completed)}</td>
               <td class="fw-600"><span class="td-link" onclick="openEditTodo('${esc(r.ID)}')">${esc(r.Title)}</span>${r.Recurrence && r.Recurrence !== 'none' ? ` <span class="badge badge-recurrence" title="${esc(RECURRENCE_OPTIONS.find(o => o.value === r.Recurrence)?.label || r.Recurrence)}">↻</span>` : ''}</td>
@@ -178,8 +202,139 @@ function renderTodos() {
         </tbody>
       </table>
     </div>
-    ${pg.total > 0 ? paginationControls('todos', pg, 'renderTodos') : ''}`);
+    ${pg.total > 0 ? paginationControls('todos', pg, 'renderTodos') : ''}
+    ${_bulkTodoBarHtml()}`);
   if (_focused === 'todo-search') refocusSearch('todo-search');
+}
+
+// ── Bulk selection + action bar ──────────────────────────────────
+
+function toggleTodoSelection(id, checked) {
+  if (checked) _todoSelection.add(id);
+  else _todoSelection.delete(id);
+  // Re-render so the bar count and the header "all selected" check update.
+  renderTodos();
+}
+
+function toggleAllTodoSelection(checked) {
+  const { filtered } = _currentFilteredTodos();
+  if (checked) for (const r of filtered) _todoSelection.add(r.ID);
+  else _clearTodoSelection();
+  renderTodos();
+}
+
+// Render the floating bulk action bar at the bottom of the view when one or
+// more todos are selected. The bar's button set depends on whether any of the
+// selected items are still open (Reopen is only useful when all are done).
+function _bulkTodoBarHtml() {
+  if (_todoSelection.size === 0) return '';
+  const selectedTodos = _todosCache.filter(r => _todoSelection.has(r.ID));
+  const anyOpen = selectedTodos.some(r => r.Completed !== 'true');
+  const allDone = selectedTodos.length > 0 && !anyOpen;
+  return `
+    <div class="bulk-action-bar" style="position:sticky;bottom:0;left:0;right:0;margin-top:16px;padding:12px 16px;background:var(--bg-secondary,#f7f7f8);border:1px solid var(--border,#e0e0e0);border-radius:8px;box-shadow:0 -2px 8px rgba(0,0,0,0.06);display:flex;align-items:center;gap:12px;flex-wrap:wrap">
+      <span class="fw-600">${_todoSelection.size} selected</span>
+      <button class="btn btn-secondary btn-sm" onclick="openBulkReassignTodos()">Reassign…</button>
+      ${anyOpen ? `<button class="btn btn-secondary btn-sm" onclick="bulkMarkTodosDone()">Mark Done</button>` : ''}
+      ${allDone ? `<button class="btn btn-secondary btn-sm" onclick="bulkReopenTodos()">Reopen</button>` : ''}
+      <button class="btn btn-danger btn-sm" onclick="bulkDeleteTodos()">Delete</button>
+      <button class="btn btn-ghost btn-sm" style="margin-left:auto" onclick="_clearTodoSelection(); renderTodos()">Clear selection</button>
+    </div>`;
+}
+
+// Open a small modal with a staff dropdown (including "Unassigned") and PUT
+// every selected reminder with the new StaffID/StaffName. Notifications fire
+// per-row via the existing /api/reminders endpoint.
+function openBulkReassignTodos() {
+  const count = _todoSelection.size;
+  if (count === 0) return;
+  modal.open('Reassign Todos', `
+    <p class="text-muted text-sm" style="margin-bottom:12px">
+      Reassign <strong>${count}</strong> selected todo${count !== 1 ? 's' : ''}.
+    </p>
+    <div class="form-group">
+      <label>Assign To</label>
+      <select class="form-control" id="f-bulk-staff">
+        <option value="">-- Unassigned --</option>
+        ${staffOptions()}
+      </select>
+    </div>`, async () => {
+    const staffId = val('f-bulk-staff');
+    const staffName = staffId ? (state.staff.find(s => s.ID === staffId) || {}).Name || '' : '';
+    const ids = [..._todoSelection];
+    let succeeded = 0;
+    for (const id of ids) {
+      try {
+        await api.put(`/api/reminders/${id}`, { StaffID: staffId, StaffName: staffName });
+        succeeded++;
+      } catch (err) {
+        console.error('[bulk-reassign]', id, err.message);
+      }
+    }
+    modal.close();
+    _clearTodoSelection();
+    toast(staffId
+      ? `Reassigned ${succeeded} todo${succeeded !== 1 ? 's' : ''} to ${staffName}`
+      : `Unassigned ${succeeded} todo${succeeded !== 1 ? 's' : ''}`);
+    loadTodos(true);
+  }, 'Reassign');
+}
+
+async function bulkMarkTodosDone() {
+  // Only mark items that aren't already completed (idempotent + avoids spawning
+  // a duplicate next occurrence for an already-completed recurring todo).
+  const ids = _todosCache.filter(r => _todoSelection.has(r.ID) && r.Completed !== 'true').map(r => r.ID);
+  if (ids.length === 0) return;
+  let succeeded = 0;
+  for (const id of ids) {
+    try {
+      await api.put(`/api/reminders/${id}`, { Completed: 'true' });
+      succeeded++;
+    } catch (err) {
+      console.error('[bulk-done]', id, err.message);
+    }
+  }
+  _clearTodoSelection();
+  toast(`Marked ${succeeded} todo${succeeded !== 1 ? 's' : ''} as done`);
+  loadTodos(true);
+}
+
+async function bulkReopenTodos() {
+  const ids = _todosCache.filter(r => _todoSelection.has(r.ID) && r.Completed === 'true').map(r => r.ID);
+  if (ids.length === 0) return;
+  let succeeded = 0;
+  for (const id of ids) {
+    try {
+      await api.put(`/api/reminders/${id}`, { Completed: 'false' });
+      succeeded++;
+    } catch (err) {
+      console.error('[bulk-reopen]', id, err.message);
+    }
+  }
+  _clearTodoSelection();
+  toast(`Reopened ${succeeded} todo${succeeded !== 1 ? 's' : ''}`);
+  loadTodos(true);
+}
+
+function bulkDeleteTodos() {
+  const count = _todoSelection.size;
+  if (count === 0) return;
+  modal.confirm('Delete Todos', `Delete ${count} todo${count !== 1 ? 's' : ''}? This cannot be undone.`, async () => {
+    const ids = [..._todoSelection];
+    let succeeded = 0;
+    for (const id of ids) {
+      try {
+        await api.del(`/api/reminders/${id}`);
+        succeeded++;
+      } catch (err) {
+        console.error('[bulk-delete]', id, err.message);
+      }
+    }
+    modal.close();
+    _clearTodoSelection();
+    toast(`Deleted ${succeeded} todo${succeeded !== 1 ? 's' : ''}`);
+    loadTodos(true);
+  });
 }
 
 function openAddTodo(presetAccountId = '') {


### PR DESCRIPTION
## Summary
Closes #387. Adds bulk editing to the Todos page so a departing staff member's todos can be reassigned in one go and routine cleanup (mark done / delete) doesn't have to be one row at a time.

## What changed
- Leading checkbox column + a header "select all (filtered)" checkbox
- Sticky bottom action bar appears when ≥1 row is selected with: **Reassign…**, **Mark Done**, **Reopen**, **Delete**, **Clear selection**
- Reassign opens a modal with a staff dropdown that includes **— Unassigned —**
- Mark Done loops PUT `/api/reminders/:id` with `Completed: 'true'`, which already handles recurring-todo spawning
- Reopen only appears when every selected item is already done
- Delete prompts the standard confirm modal with a count

## Selection lifecycle
- Persists across pagination clicks
- Cleared when search / staff / status filter changes, when an action completes, or via "Clear selection"
- Auto-pruned to the currently-visible filtered set so the bar count stays accurate

## Implementation
Client-only; no backend or schema changes. Each bulk action loops the existing `/api/reminders/:id` endpoints — keeps recurrence + mention/assignment-notification logic in one place. All in `public/js/todos.js`.

## Test plan
- [ ] Select 3 todos → bar shows "3 selected" with Reassign / Mark Done / Delete buttons
- [ ] Header select-all checks every visible filtered row; unchecking clears them
- [ ] Bulk **Reassign** to a staff member → all 3 now show that name
- [ ] Bulk **Reassign** to "Unassigned" → StaffID/StaffName clear
- [ ] Bulk **Mark Done** on open recurring todos spawns next occurrences
- [ ] Bulk **Reopen** only appears when all selected are done; flips them to open
- [ ] Bulk **Delete** prompts confirm with count, removes all on confirm
- [ ] Change search/staff/status filter while items selected → selection clears
- [ ] Paginate to page 2 → selection from page 1 is preserved
- [ ] Mobile width: action bar wraps and remains usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)