### PR TITLE
Suppress notifications on bulk todo reassign (closes #389)

### DIFF
--- a/public/js/todos.js
+++ b/public/js/todos.js
@@ -265,7 +265,8 @@ function openBulkReassignTodos() {
     let succeeded = 0;
     for (const id of ids) {
       try {
-        await api.put(`/api/reminders/${id}`, { StaffID: staffId, StaffName: staffName });
+        // ?silent=1 — bulk reassigns shouldn't email each recipient (see #389).
+        await api.put(`/api/reminders/${id}?silent=1`, { StaffID: staffId, StaffName: staffName });
         succeeded++;
       } catch (err) {
         console.error('[bulk-reassign]', id, err.message);

--- a/routes/reminders.js
+++ b/routes/reminders.js
@@ -91,10 +91,15 @@ router.put('/:id', async (req, res) => {
     const updates = { ...req.body };
     delete updates.ID;
     delete updates.CreatedAt;
+    // ?silent=1 suppresses mention + assignment notifications. Used by the
+    // bulk-reassign UI so reassigning N todos doesn't email recipients N times.
+    const silent = req.query.silent === '1' || req.query.silent === 'true';
     const updated = await updateRow('REMINDERS', req.params.id, updates);
-    const baseUrl = req.protocol + '://' + req.get('host');
-    processMentions({ newText: updated.Notes, oldText: oldNotes, entityType: 'todo', entityName: updated.Title, entityId: updated.ID, accountId: updated.AccountID, user: req.user, mentionerName: req.user.name, baseUrl }).catch(err => console.error('[notifications]', err));
-    processAssignment({ newStaffId: updated.StaffID, oldStaffId, entityType: 'todo', entityName: updated.Title, entityId: updated.ID, accountId: updated.AccountID, user: req.user, assignerName: req.user.name, baseUrl }).catch(err => console.error('[notifications]', err));
+    if (!silent) {
+      const baseUrl = req.protocol + '://' + req.get('host');
+      processMentions({ newText: updated.Notes, oldText: oldNotes, entityType: 'todo', entityName: updated.Title, entityId: updated.ID, accountId: updated.AccountID, user: req.user, mentionerName: req.user.name, baseUrl }).catch(err => console.error('[notifications]', err));
+      processAssignment({ newStaffId: updated.StaffID, oldStaffId, entityType: 'todo', entityName: updated.Title, entityId: updated.ID, accountId: updated.AccountID, user: req.user, assignerName: req.user.name, baseUrl }).catch(err => console.error('[notifications]', err));
+    }
 
     // When completing a recurring reminder, spawn the next occurrence
     if (updates.Completed === 'true' && updated.Recurrence && RECURRENCE_VALUES.has(updated.Recurrence) && updated.Recurrence !== 'none') {


### PR DESCRIPTION
## Summary
Closes #389. Bulk-reassigning todos (added in #387) sent an assignment email per row. Reassigning a departing staff member's 30 todos would email the new assignee 30 times. Add an opt-in silent flag for the bulk path.

## Changes
- `PUT /api/reminders/:id?silent=1` skips `processMentions` + `processAssignment`
- `openBulkReassignTodos` appends `?silent=1` to its PUT calls
- Single-row Edit and the other bulk actions (mark done / reopen / delete) are unchanged — they don't change assignment, and a manual one-row edit should still notify

## Test plan
- [ ] Bulk-reassign 3 todos to staff member X → X receives no assignment email
- [ ] Single-row Edit todo and change assignee → recipient still gets the existing assignment email
- [ ] Single-row Edit todo and add an @mention → recipient still gets the mention email
- [ ] Bulk Mark Done / Reopen / Delete: no new emails generated (no assignment change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)