### PR TITLE
Exclude Pre-Sale orders from dashboard pending deliveries (closes #395)

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -26,9 +26,19 @@ async function loadDashboard() {
   }
   const _staffAtLocation = (id) => !state.location || LOCATIONS.length <= 1 || !id || locationStaffIds.has(id);
 
-  // Pending deliveries: undelivered orders with a delivery date
+  // Pending deliveries: undelivered orders with a delivery date.
+  // Pre-Sale / Cancelled / Draft orders are excluded — Pre-Sales aren't
+  // deliverable (the date is just an estimate) and the others aren't real
+  // orders yet. Matches the server-side filter in routes/dashboard.js.
   const pendingDeliveries = (allOrders || [])
-    .filter(o => o.Delivered !== 'true' && o.DeliveryDate && _staffAtLocation(o.StaffID))
+    .filter(o =>
+      o.Delivered !== 'true'
+      && o.DeliveryDate
+      && o.Status !== 'Pre-Sale'
+      && o.Status !== 'Cancelled'
+      && o.Status !== 'Draft'
+      && _staffAtLocation(o.StaffID),
+    )
     .map(o => ({
       _type: 'delivery',
       ID: o.ID,


### PR DESCRIPTION
## Summary
Closes #395. The dashboard's "My Todos", overdue, and upcoming sections were including pre-sale orders whose `DeliveryDate` is just an estimate, not a commitment. Pre-sales (and Cancelled/Draft orders) shouldn't appear in the deliveries todo list.

Server-side `routes/dashboard.js` already excludes these from the `pendingDeliveries` count — this brings the client-side list construction in `public/js/dashboard.js` in line with that.

## Test plan
- [ ] Pre-sale order with a delivery date no longer appears under "My Todos" / Overdue / Upcoming
- [ ] Regular Pending order with a delivery date still appears
- [ ] Cancelled / Draft orders with delivery dates also excluded (consistency)
- [ ] Pending-deliveries stat card on the dashboard remains unchanged (it was already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)