### PR TITLE
Reports: distinguish paid from pending revenue (closes #396)

### DIFF
--- a/public/js/reports.js
+++ b/public/js/reports.js
@@ -82,11 +82,19 @@ function renderReports() {
     <div class="stats-grid">
       <div class="stat-card">
         <div class="stat-value">${s.orderCount}</div>
-        <div class="stat-label">Orders</div>
+        <div class="stat-label">Orders<br><span class="text-sm text-muted">${s.paidOrderCount || 0} paid / ${s.pendingOrderCount || 0} pending</span></div>
       </div>
       <div class="stat-card accent">
         <div class="stat-value">${fmtMoney(s.orderAmount)}</div>
-        <div class="stat-label">Revenue</div>
+        <div class="stat-label">Total Revenue</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value text-success">${fmtMoney(s.paidAmount || 0)}</div>
+        <div class="stat-label">Paid Revenue</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">${fmtMoney(s.pendingAmount || 0)}</div>
+        <div class="stat-label">Awaiting Payment</div>
       </div>
       <div class="stat-card">
         <div class="stat-value">${fmtMoney(s.taxAmount)}</div>
@@ -162,10 +170,14 @@ function _renderSalesChart(data) {
         <summary>View Table</summary>
         <div class="table-wrap">
           <table>
-            <thead><tr><th>Period</th><th>Orders</th><th>Revenue</th><th>Tax</th><th>Deposits</th></tr></thead>
+            <thead><tr><th>Period</th><th>Orders</th><th>Paid Revenue</th><th>Pending Revenue</th><th>Total Revenue</th><th>Tax</th><th>Deposits</th></tr></thead>
             <tbody>
               ${buckets.map(b => `<tr>
-                <td>${esc(b.bucket)}</td><td>${b.orderCount}</td><td>${fmtMoney(b.orderAmount)}</td>
+                <td>${esc(b.bucket)}</td>
+                <td>${b.orderCount} <span class="text-muted text-sm">(${b.paidOrderCount || 0}/${b.pendingOrderCount || 0})</span></td>
+                <td class="text-success">${fmtMoney(b.paidAmount || 0)}</td>
+                <td>${fmtMoney(b.pendingAmount || 0)}</td>
+                <td class="fw-600">${fmtMoney(b.orderAmount)}</td>
                 <td>${fmtMoney(b.taxAmount)}</td><td>${fmtMoney(b.depositAmount)}</td>
               </tr>`).join('')}
             </tbody>
@@ -185,8 +197,9 @@ function _buildSalesChart(data) {
     data: {
       labels: buckets.map(b => b.bucket),
       datasets: [
-        { label: 'Revenue', data: buckets.map(b => b.orderAmount), backgroundColor: _chartColors.green },
-        { label: 'Tax', data: buckets.map(b => b.taxAmount), backgroundColor: _chartColors.amber },
+        { label: 'Paid Revenue',    data: buckets.map(b => b.paidAmount    || 0), backgroundColor: _chartColors.green },
+        { label: 'Pending Revenue', data: buckets.map(b => b.pendingAmount || 0), backgroundColor: _chartColors.amber },
+        { label: 'Tax',             data: buckets.map(b => b.taxAmount),         backgroundColor: _chartColors.blue  },
       ],
     },
     options: {
@@ -267,11 +280,13 @@ function _renderAccountActivity(data) {
         <summary>View Table</summary>
         <div class="table-wrap">
           <table>
-            <thead><tr><th>Account</th><th>Type</th><th>Orders</th><th>Total Spent</th><th>Avg Order</th><th>Last Order</th></tr></thead>
+            <thead><tr><th>Account</th><th>Type</th><th>Orders</th><th>Paid</th><th>Pending</th><th>Total Spent</th><th>Avg Order</th><th>Last Order</th></tr></thead>
             <tbody>
               ${accounts.map(a => `<tr>
                 <td>${esc(a.name)}</td><td>${esc(a.type)}</td><td>${a.orderCount}</td>
-                <td>${fmtMoney(a.totalSpent)}</td><td>${fmtMoney(a.avgOrder)}</td><td>${formatDate(a.lastOrderDate)}</td>
+                <td class="text-success">${fmtMoney(a.paidSpent || 0)}</td>
+                <td>${fmtMoney(a.pendingSpent || 0)}</td>
+                <td class="fw-600">${fmtMoney(a.totalSpent)}</td><td>${fmtMoney(a.avgOrder)}</td><td>${formatDate(a.lastOrderDate)}</td>
               </tr>`).join('')}
             </tbody>
           </table>
@@ -363,10 +378,13 @@ function _renderSalesByRep(data) {
         <summary>View Table</summary>
         <div class="table-wrap">
           <table>
-            <thead><tr><th>Rep</th><th>Orders</th><th>Revenue</th><th>Avg Order</th><th>Accounts</th></tr></thead>
+            <thead><tr><th>Rep</th><th>Orders</th><th>Paid Revenue</th><th>Pending Revenue</th><th>Total Revenue</th><th>Avg Order</th><th>Accounts</th></tr></thead>
             <tbody>
               ${reps.map(r => `<tr>
-                <td>${esc(r.name)}</td><td>${r.orderCount}</td><td>${fmtMoney(r.totalRevenue)}</td>
+                <td>${esc(r.name)}</td><td>${r.orderCount}</td>
+                <td class="text-success">${fmtMoney(r.paidRevenue || 0)}</td>
+                <td>${fmtMoney(r.pendingRevenue || 0)}</td>
+                <td class="fw-600">${fmtMoney(r.totalRevenue)}</td>
                 <td>${fmtMoney(r.avgOrder)}</td><td>${r.accountsServed}</td>
               </tr>`).join('')}
             </tbody>
@@ -419,9 +437,9 @@ function _reportsExportCsv() {
 
   // Sales Summary
   lines.push('--- Sales Summary ---');
-  lines.push('Period,Orders,Revenue,Tax,Deposits');
+  lines.push('Period,Orders,Paid Orders,Pending Orders,Paid Revenue,Pending Revenue,Total Revenue,Tax,Deposits');
   for (const b of d.salesSummary.buckets) {
-    lines.push(`${b.bucket},${b.orderCount},${b.orderAmount.toFixed(2)},${b.taxAmount.toFixed(2)},${b.depositAmount.toFixed(2)}`);
+    lines.push(`${b.bucket},${b.orderCount},${b.paidOrderCount || 0},${b.pendingOrderCount || 0},${(b.paidAmount || 0).toFixed(2)},${(b.pendingAmount || 0).toFixed(2)},${b.orderAmount.toFixed(2)},${b.taxAmount.toFixed(2)},${b.depositAmount.toFixed(2)}`);
   }
   lines.push('');
 
@@ -444,9 +462,9 @@ function _reportsExportCsv() {
 
   // Account Activity
   lines.push('--- Account Activity ---');
-  lines.push('Account,Type,Orders,Total Spent,Avg Order,Last Order');
+  lines.push('Account,Type,Orders,Paid Spent,Pending Spent,Total Spent,Avg Order,Last Order');
   for (const a of d.accountActivity) {
-    lines.push(`"${a.name}","${a.type}",${a.orderCount},${a.totalSpent.toFixed(2)},${a.avgOrder.toFixed(2)},${a.lastOrderDate}`);
+    lines.push(`"${a.name}","${a.type}",${a.orderCount},${(a.paidSpent || 0).toFixed(2)},${(a.pendingSpent || 0).toFixed(2)},${a.totalSpent.toFixed(2)},${a.avgOrder.toFixed(2)},${a.lastOrderDate}`);
   }
   lines.push('');
 
@@ -460,9 +478,9 @@ function _reportsExportCsv() {
 
   // Sales by Rep
   lines.push('--- Sales by Rep ---');
-  lines.push('Rep,Orders,Revenue,Avg Order,Accounts');
+  lines.push('Rep,Orders,Paid Revenue,Pending Revenue,Total Revenue,Avg Order,Accounts');
   for (const r of d.salesByRep) {
-    lines.push(`"${r.name}",${r.orderCount},${r.totalRevenue.toFixed(2)},${r.avgOrder.toFixed(2)},${r.accountsServed}`);
+    lines.push(`"${r.name}",${r.orderCount},${(r.paidRevenue || 0).toFixed(2)},${(r.pendingRevenue || 0).toFixed(2)},${r.totalRevenue.toFixed(2)},${r.avgOrder.toFixed(2)},${r.accountsServed}`);
   }
 
   const blob = new Blob([lines.join('\n')], { type: 'text/csv' });

--- a/routes/reports.js
+++ b/routes/reports.js
@@ -61,30 +61,56 @@ router.get('/', async (req, res) => {
     const productMap = Object.fromEntries(products.map(p => [p.ID, p]));
 
     // ── A. Sales Summary ──────────────────────────────────────────
+    // Split each amount into "paid" (Status === 'Paid' — payment received)
+    // and "pending" (Pending — invoiced/delivered but awaiting payment) so
+    // the reports can distinguish booked revenue from outstanding AR.
     const salesBuckets = {};
     let totalOrders = 0, totalAmount = 0, totalTax = 0, totalDeposits = 0;
+    let totalPaidAmount = 0, totalPendingAmount = 0;
+    let totalPaidCount = 0, totalPendingCount = 0;
 
     for (const o of salesOrders) {
       const key = bucketKey(o.OrderDate, granularity);
-      if (!salesBuckets[key]) salesBuckets[key] = { bucket: key, orderCount: 0, orderAmount: 0, taxAmount: 0, depositAmount: 0 };
+      if (!salesBuckets[key]) {
+        salesBuckets[key] = {
+          bucket: key,
+          orderCount: 0, orderAmount: 0, taxAmount: 0, depositAmount: 0,
+          paidOrderCount: 0, pendingOrderCount: 0,
+          paidAmount: 0, pendingAmount: 0,
+        };
+      }
       const b = salesBuckets[key];
       const amt = parseFloat(o.OrderAmount || 0);
       const tax = parseFloat(o.TaxAmount || 0);
       const dep = parseFloat(o.DepositAmount || 0);
+      const isPaid = o.Status === 'Paid';
       b.orderCount++;
       b.orderAmount += amt;
       b.taxAmount += tax;
       b.depositAmount += dep;
+      if (isPaid) { b.paidAmount += amt; b.paidOrderCount++; }
+      else        { b.pendingAmount += amt; b.pendingOrderCount++; }
       totalOrders++;
       totalAmount += amt;
       totalTax += tax;
       totalDeposits += dep;
+      if (isPaid) { totalPaidAmount += amt; totalPaidCount++; }
+      else        { totalPendingAmount += amt; totalPendingCount++; }
     }
 
     const salesSummary = {
       buckets: Object.values(salesBuckets).sort((a, b) => a.bucket.localeCompare(b.bucket)),
       granularity,
-      totals: { orderCount: totalOrders, orderAmount: totalAmount, taxAmount: totalTax, depositAmount: totalDeposits },
+      totals: {
+        orderCount: totalOrders,
+        orderAmount: totalAmount,
+        taxAmount: totalTax,
+        depositAmount: totalDeposits,
+        paidOrderCount: totalPaidCount,
+        pendingOrderCount: totalPendingCount,
+        paidAmount: totalPaidAmount,
+        pendingAmount: totalPendingAmount,
+      },
     };
 
     // ── B. Top Products ───────────────────────────────────────────
@@ -153,11 +179,21 @@ router.get('/', async (req, res) => {
       if (!o.AccountID) continue;
       if (!accountAgg[o.AccountID]) {
         const acct = accountMap[o.AccountID] || {};
-        accountAgg[o.AccountID] = { accountId: o.AccountID, name: o.AccountName || acct.Name || '', type: acct.Type || '', orderCount: 0, totalSpent: 0, lastOrderDate: '' };
+        accountAgg[o.AccountID] = {
+          accountId: o.AccountID,
+          name: o.AccountName || acct.Name || '',
+          type: acct.Type || '',
+          orderCount: 0, totalSpent: 0,
+          paidSpent: 0, pendingSpent: 0,
+          lastOrderDate: '',
+        };
       }
       const a = accountAgg[o.AccountID];
+      const amt = parseFloat(o.OrderAmount || 0);
       a.orderCount++;
-      a.totalSpent += parseFloat(o.OrderAmount || 0);
+      a.totalSpent += amt;
+      if (o.Status === 'Paid') a.paidSpent += amt;
+      else                     a.pendingSpent += amt;
       const d = (o.OrderDate || '').substring(0, 10);
       if (d > a.lastOrderDate) a.lastOrderDate = d;
     }
@@ -218,11 +254,20 @@ router.get('/', async (req, res) => {
       const repId = o.StaffID || '_unassigned';
       if (!repAgg[repId]) {
         const s = staffMap[o.StaffID] || {};
-        repAgg[repId] = { staffId: repId, name: o.StaffName || s.Name || 'Unassigned', orderCount: 0, totalRevenue: 0, accountIds: new Set() };
+        repAgg[repId] = {
+          staffId: repId,
+          name: o.StaffName || s.Name || 'Unassigned',
+          orderCount: 0, totalRevenue: 0,
+          paidRevenue: 0, pendingRevenue: 0,
+          accountIds: new Set(),
+        };
       }
       const r = repAgg[repId];
+      const amt = parseFloat(o.OrderAmount || 0);
       r.orderCount++;
-      r.totalRevenue += parseFloat(o.OrderAmount || 0);
+      r.totalRevenue += amt;
+      if (o.Status === 'Paid') r.paidRevenue += amt;
+      else                     r.pendingRevenue += amt;
       if (o.AccountID) r.accountIds.add(o.AccountID);
     }
 
@@ -232,6 +277,8 @@ router.get('/', async (req, res) => {
         name: r.name,
         orderCount: r.orderCount,
         totalRevenue: r.totalRevenue,
+        paidRevenue: r.paidRevenue,
+        pendingRevenue: r.pendingRevenue,
         avgOrder: r.orderCount > 0 ? r.totalRevenue / r.orderCount : 0,
         accountsServed: r.accountIds.size,
       }))


### PR DESCRIPTION
## Summary
Closes #396. The sales report previously lumped Paid (payment received) and Pending (invoiced/delivered but awaiting payment) orders into a single Revenue total. Split them in every panel so outstanding AR is visible.

## Backend (`routes/reports.js`)
- Each sales bucket, account aggregate, and rep aggregate now tracks `paidAmount` + `pendingAmount` alongside the existing totals
- `salesSummary.totals` adds `paidAmount`, `pendingAmount`, `paidOrderCount`, `pendingOrderCount`
- Cancelled/Pre-Sale/Draft remain excluded as before

## Frontend (`public/js/reports.js`)
- New **Paid Revenue** (green) and **Awaiting Payment** stat cards next to the existing Total Revenue
- Orders stat card now sub-labels "X paid / Y pending"
- Sales Over Time chart: stacks Paid (green) + Pending (amber) + Tax (blue) instead of one combined Revenue series
- Sales Over Time / Account Activity / Sales by Rep tables get Paid + Pending columns alongside Total
- CSV export includes the same split columns

## Test plan
- [ ] Stat cards show Paid + Awaiting Payment with green Paid value
- [ ] Sales Over Time chart shows two revenue colors stacked; Tax sits on top
- [ ] All three tables show Paid (green) and Pending columns in addition to Total
- [ ] CSV export contains the new columns and adds up to the existing totals
- [ ] Date-range / location / preset switches all preserve the split
- [ ] Period with zero pending orders → Pending columns show $0.00 (no breakage)
- [ ] Period with zero paid orders → Paid columns show $0.00

🤖 Generated with [Claude Code](https://claude.com/claude-code)