### PR TITLE
Fix Reports stat tile overflow (closes #399)

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -437,7 +437,9 @@ body {
 
 .stats-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  /* min raised from 160px → 190px so 6 tiles of $XXX,XXX.XX values fit
+     without clipping; auto-fit still collapses gracefully on narrow widths */
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
   gap: 14px;
   margin-bottom: 24px;
 }
@@ -450,6 +452,10 @@ body {
   border-left: 4px solid var(--green-mid);
   cursor: pointer;
   transition: box-shadow 0.15s, transform 0.1s;
+  /* min-width:0 lets grid item shrink below content size so overflow-wrap
+     can break long values instead of pushing past the card */
+  min-width: 0;
+  overflow: hidden;
 }
 
 .stat-card:hover {
@@ -462,10 +468,15 @@ body {
 .stat-card.danger  { border-left-color: #e53935; }
 
 .stat-value {
-  font-size: 32px;
+  /* clamp() scales 24px → 32px across viewport widths so dense six-tile
+     rows with $XXX,XXX.XX numbers shrink the font rather than clip */
+  font-size: clamp(22px, 1.6vw + 14px, 32px);
   font-weight: 800;
   color: var(--green-dark);
-  line-height: 1;
+  line-height: 1.05;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  min-width: 0;
 }
 
 .stat-card.accent  .stat-value { color: var(--accent); }
@@ -1605,9 +1616,10 @@ th input[type="checkbox"] {
     padding: 14px 16px;
   }
 
-  /* ── Stats grid: smaller minimums ── */
+  /* ── Stats grid: 2 columns on tablets/large phones so values like
+     $XXX,XXX.XX have room without clipping ── */
   .stats-grid {
-    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
     gap: 10px;
   }
 


### PR DESCRIPTION
## Summary

Closes #399. Six stat tiles introduced on the Reports page in #398 (Orders / Total Revenue / Paid Revenue / Awaiting Payment / Tax Collected / Deposits) were clipping dollar values at healthy monthly revenue — e.g. `$10,616.00` rendered as `$10,616.0` because `.stats-grid` reserved only 160px per card and `.stat-value` was a fixed `32px` with no overflow handling.

## What changed

**`public/style.css` — `.stats-grid` / `.stat-card` / `.stat-value`:**

- `.stats-grid` `minmax(160px, 1fr)` → `minmax(190px, 1fr)`. Six tiles of `$XXX,XXX.XX` now fit comfortably; `auto-fit` still wraps the row on narrower viewports (5+1, then 4+2, etc.).
- `.stat-value` font-size `32px` → `clamp(22px, 1.6vw + 14px, 32px)`. The headline number scales down on narrow viewports instead of overflowing the card. Desktop renders at 32px as before.
- `.stat-card` got `min-width: 0` + `overflow: hidden`, and `.stat-value` got `overflow-wrap: anywhere` + `word-break: break-word` + `min-width: 0`. This is the safety net — if a value still doesn't fit (e.g. >$999,999.99), it wraps inside the tile rather than pushing past the border.
- `line-height` nudged `1` → `1.05` so wrapped values aren't visually cramped.
- Mobile `@media (max-width: 640px)` rule: `minmax(130px, 1fr)` → `minmax(160px, 1fr)` so tablets/large phones land on a clean 2-column layout. The existing `@media (max-width: 400px)` rule (which already forces `grid-template-columns: 1fr 1fr` with 20px font) is untouched.

## Regression check (other consumers of `.stats-grid` / `.stat-card`)

Grepped for `stats-grid` and `stat-card` across `public/js/`:

- **`dashboard.js`** — 5 tiles, mostly small counts; the one money value (`monthlyOrdersTotal`) is rendered with zero decimals. Looks better, not worse — 5 columns × ~220px on a typical desktop content area.
- **`gallonage.js`** — 4 tiles, all short numeric values. Unaffected.
- **`sales-export.js`** — 4 tiles. Fits trivially.
- **`forecast.js`** — 4 tiles. Fits trivially.
- **Account profile (`accounts.js`)** — uses the separate `.profile-stat` / `.profile-stats` classes, not `.stat-card` / `.stats-grid`. Untouched by this change.

## Test plan

- [ ] Reports page at desktop width (≥1280px) with a month showing >$10,000 revenue — verify `$10,616.00`, `$999,999.00`, and similar values render fully without clipping
- [ ] Reports page at ~1024px tablet width — tiles wrap to two rows rather than clip
- [ ] Reports page at 640px mobile — tiles stack to 2 columns at the 24px mobile font
- [ ] Reports page at 400px small phone — tiles stack to 2 columns at the 20px font (existing rule)
- [ ] Dashboard view — 5 stat tiles still look visually balanced and clickable
- [ ] Account profile view — profile stats unchanged (different class)
- [ ] Forecast / Gallonage / Sales Export views — stat tiles look the same as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)