### PR TITLE
Stat tile values stay on a single line (closes #401)

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -437,9 +437,11 @@ body {
 
 .stats-grid {
   display: grid;
-  /* min raised from 160px → 190px so 6 tiles of $XXX,XXX.XX values fit
-     without clipping; auto-fit still collapses gracefully on narrow widths */
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  /* Min raised to 210px so six tiles can hold $XXX,XXX.XX values on one
+     line. Combined with auto-fit, tiles wrap to a second row when the
+     viewport can't accommodate the full set rather than squeezing the
+     value below the readable font floor. */
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
   gap: 14px;
   margin-bottom: 24px;
 }
@@ -468,14 +470,16 @@ body {
 .stat-card.danger  { border-left-color: #e53935; }
 
 .stat-value {
-  /* clamp() scales 24px → 32px across viewport widths so dense six-tile
-     rows with $XXX,XXX.XX numbers shrink the font rather than clip */
-  font-size: clamp(22px, 1.6vw + 14px, 32px);
+  /* clamp() scales the value font with viewport width so dense six-tile
+     rows with $XXX,XXX.XX numbers shrink instead of overflowing. */
+  font-size: clamp(20px, 1.6vw + 12px, 32px);
   font-weight: 800;
   color: var(--green-dark);
   line-height: 1.05;
-  overflow-wrap: anywhere;
-  word-break: break-word;
+  /* Keep dollar amounts on one line — wrapping mid-number reads as a
+     formatting bug (e.g. "$10,616.0\n0"). The tile shrinks the font and
+     the grid drops to fewer columns instead. */
+  white-space: nowrap;
   min-width: 0;
 }
 


### PR DESCRIPTION
## Summary
Closes #401. Follow-up to #400. That PR fixed clipping by letting the value wrap, but with six tiles at ~190px wide and the clamp floor at 22px, \`$10,616.00\` now broke across two lines mid-number (looked like a formatting bug — see the issue screenshot).

## Fix
- `.stat-value` gets `white-space: nowrap` and drops `overflow-wrap`/`word-break`. Numbers always render on one line.
- `.stats-grid` `auto-fit` min raised from `190px` → `210px` so tiles wrap to a new row *before* any individual value runs out of room.
- Clamp floor lowered from `22px` → `20px` so the font can shrink a little further on tight widths before triggering a column drop.
- `.stat-card { overflow: hidden }` from #400 stays as a safety net.

Result: numbers always read cleanly. On a typical desktop the six-tile row still fits; on narrower viewports the grid drops to 3- or 2-per-row instead of breaking values mid-digit.

## Test plan
- [ ] Desktop, six tiles, value like \`$10,616.00\` → renders on one line, no clipping, no mid-number break
- [ ] Push the value larger (\`$999,999.00\`) → still single-line on desktop
- [ ] Narrow the browser window → tiles re-flow from 6 → 3 → 2 columns instead of wrapping within a tile
- [ ] Tablet (≤640px): 2-column layout, all values fit on one line
- [ ] Phone (≤400px): 2-column layout still fits typical amounts
- [ ] Regression: Dashboard, Gallonage, Sales Export, Forecast stat tiles still look good

🤖 Generated with [Claude Code](https://claude.com/claude-code)