### PR TITLE
Prevent iOS auto-zoom on mobile filter inputs (closes #403)

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1834,19 +1834,23 @@ th input[type="checkbox"] {
     flex-direction: column;
   }
 
+  /* ── Filter bar inputs: 16px to prevent iOS auto-zoom on focus (#403) ── */
   .filter-bar input,
   .filter-bar select {
     width: 100%;
     min-height: 40px;
-    font-size: 14px;
+    font-size: 16px;
   }
 
-  /* ── Form touch targets ── */
+  /* ── Form touch targets ──
+     Form controls must be 16px+ to prevent iOS Safari from auto-zooming when
+     the user taps into them (#403). 14px reads as 'small but legible' on
+     desktop but triggers viewport zoom on mobile. */
   .form-control,
   select,
   textarea {
     min-height: 40px;
-    font-size: 14px;
+    font-size: 16px;
   }
 
   /* iOS zoom prevention: inputs must be at least 16px */


### PR DESCRIPTION
## Summary

- Raise mobile \`.filter-bar input/select\` and \`.form-control\` font-size from 14px to 16px so iOS Safari does not auto-zoom on focus.
- Visual change is minimal — selects render the same, free-form inputs are a touch larger.

## Test plan

- [ ] On an iPhone (Safari), open the Orders list, tap the Status / Date / Account dropdowns — page should NOT zoom in.
- [ ] Repeat on the Todos and Accounts filter bars.
- [ ] Confirm desktop layout (>640px) is unaffected.

Closes #403.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>