### PR TITLE
Add 'Mark Delivered' button to view-only paid-order modal (closes #404)

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -1039,7 +1039,16 @@ function profileEditOrder(id) {
     if (!order) return;
     const isPaid = order.Status === 'Paid';
     if (isPaid) {
-      modal.open('View Order', orderForm(order, '', true), async () => {
+      // Mirror the orders-list paid view: surface a 'Mark Delivered' button
+      // inside the view-only modal (#404) so users don't have to close the
+      // modal and reopen the row's overflow menu.
+      const notDelivered = order.Delivered !== 'true';
+      const deliveryBanner = notDelivered ? `
+        <div class="info-banner" style="margin-bottom:14px;display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+          <span class="fw-600">This order has not been delivered yet.</span>
+          <button type="button" class="btn btn-primary btn-sm" style="margin-left:auto" onclick="profileMarkDeliveredFromView('${esc(id)}')">Mark Delivered</button>
+        </div>` : '';
+      modal.open('View Order', deliveryBanner + orderForm(order, '', true), async () => {
         await api.put(`/api/orders/${id}`, {
           InvoiceNumber: val('f-invoice'),
           Notes: val('f-notes'),

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -1496,7 +1496,17 @@ async function openEditOrder(id) {
   if (!order) return;
   const isPaid = order.Status === 'Paid';
   if (isPaid) {
-    modal.open('View Order', orderForm(order, '', true), async () => {
+    // After #386 the paid-order modal is view-only. Surface a prominent
+    // 'Mark Delivered' button inside the modal so users don't have to close
+    // it and hunt for the action in the row's overflow menu (#404). The
+    // checkbox column is hidden on mobile, so the menu was the only path.
+    const notDelivered = order.Delivered !== 'true';
+    const deliveryBanner = notDelivered ? `
+      <div class="info-banner" style="margin-bottom:14px;display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+        <span class="fw-600">This order has not been delivered yet.</span>
+        <button type="button" class="btn btn-primary btn-sm" style="margin-left:auto" onclick="markDeliveredFromView('${esc(id)}')">Mark Delivered</button>
+      </div>` : '';
+    modal.open('View Order', deliveryBanner + orderForm(order, '', true), async () => {
       await api.put(`/api/orders/${id}`, {
         InvoiceNumber: val('f-invoice'),
         Notes: val('f-notes'),
@@ -1833,6 +1843,14 @@ async function toggleDelivered(id) {
   await openDeliveryConfirmModal(id, order, loadOrders);
 }
 
+// Invoked from the 'Mark Delivered' banner inside the view-only paid-order
+// modal (#404). Closes the view modal first so the delivery confirm modal
+// has a clean slate, then runs the standard delivery flow.
+async function markDeliveredFromView(id) {
+  modal.close();
+  await toggleDelivered(id);
+}
+
 async function profileMarkOrderPaid(id) {
   // Ensure orders cache is populated for the modal
   if (!_ordersCache.find(s => s.ID === id)) {
@@ -1846,6 +1864,14 @@ async function profileToggleDelivered(id) {
   const order = orders.find(s => s.ID === id);
   if (!order) return;
   await openDeliveryConfirmModal(id, order, () => loadAccountProfile(state.accountProfileId));
+}
+
+// Profile-view equivalent of markDeliveredFromView — closes the view-only
+// paid-order modal and runs the standard profile delivery flow so the
+// account profile refreshes correctly afterward (#404).
+async function profileMarkDeliveredFromView(id) {
+  modal.close();
+  await profileToggleDelivered(id);
 }
 
 async function profileEditPreSale(id) {


### PR DESCRIPTION
## Summary

- Adds a 'Mark Delivered' info banner inside the view-only paid-order modal when the order has not been delivered.
- Available on both the main Orders list and Account Profile order tables.
- Closes the view modal and runs the standard delivery confirm flow, so kegs / stock movements are recorded normally.

## Why

After #386 made the paid-order modal view-only, the only path on mobile was the row's overflow menu (the Delivered checkbox column is hidden via \`mobile-hide\`). Users opening the order to verify before delivering had to close it and re-find the action.

## Test plan

- [ ] On a phone, open a Paid + undelivered order from the Orders list. The banner should appear at the top with a 'Mark Delivered' button.
- [ ] Tapping it should close the view modal and open the delivery confirm modal.
- [ ] Repeat from an account profile's Orders sub-table.
- [ ] Confirm Delivered orders don't show the banner.
- [ ] Confirm desktop view still works.

Closes #404.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>