### PR TITLE
Track CompletedAt on todos and surface it in the UI (closes #412)

### DIFF
--- a/db.js
+++ b/db.js
@@ -36,7 +36,7 @@ const HEADERS = {
   INVENTORY: ['ID', 'Name', 'Location', 'Style', 'ABV', 'Format', 'Units', 'PricePerUnit', 'Prices', 'LowStockThreshold', 'Notes', 'LastUpdated', 'ProductID', 'ProductName'],
   ACCOUNTS:  ['ID', 'Name', 'Type', 'Tags', 'ContactName', 'Email', 'AdditionalEmails', 'Phone', 'PreferredMethod', 'BillingContactName', 'BillingEmail', 'BillingPhone', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'ChargeDeposits', 'Taxable', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'ServicedBy', 'QboCustomerId', 'CreatedAt', 'CheckInFrequency', 'DeliversIndirectly'],
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
-  REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
+  REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'CompletedAt', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
   STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt', 'Locations'],
   ORDERS:          ['ID', 'AccountID', 'AccountName', 'Location', 'StaffID', 'StaffName', 'OrderDate', 'DeliveryDate', 'InvoiceNumber', 'OrderAmount', 'TaxAmount', 'DepositAmount', 'Notes', 'RequestedProducts', 'Status', 'Delivered', 'PaymentMethod', 'PaymentReference', 'PaymentDate', 'QboPaymentId', 'QboInvoiceId', 'QboSyncStatus', 'QboSyncError', 'InvoicePdf', 'CreatedAt'],
   STOCK_MOVEMENTS: ['ID', 'InventoryID', 'InventoryName', 'OrderID', 'Type', 'Quantity', 'Notes', 'Date', 'CreatedAt'],

--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -757,7 +757,7 @@ function renderProfileTodos() {
     : pg.rows.map(t => `<tr class="${t.Completed === 'true' ? 'row-completed' : ''}">
         <td class="fw-600"><span class="td-link" onclick="profileEditTodo('${esc(t.ID)}')">${esc(t.Title)}</span>${t.Recurrence && t.Recurrence !== 'none' ? ' <span class="badge badge-recurrence" title="Recurring">↻</span>' : ''}</td>
         <td class="mobile-hide">${typeBadge(t.Type) || '—'}</td>
-        <td>${urgencyBadge(t.DueDate, t.Completed)}</td>
+        <td>${urgencyBadge(t.DueDate, t.Completed)}${t.Completed === 'true' && t.CompletedAt ? `<br><span class="text-muted text-sm">Done ${formatDate(t.CompletedAt)}</span>` : ''}</td>
         <td class="mobile-hide">${priorityBadge(t.Priority)}</td>
         <td class="mobile-hide text-sm text-muted">${esc(t.Notes) || '—'}</td>
         <td class="td-actions">

--- a/public/js/todos.js
+++ b/public/js/todos.js
@@ -180,7 +180,7 @@ function renderTodos() {
           ${pg.total === 0 ? `<tr><td colspan="9" class="empty-state">No todos found.</td></tr>` :
             pg.rows.map(r => `<tr>
               <td><input type="checkbox" class="todo-row-checkbox" data-id="${esc(r.ID)}" ${_todoSelection.has(r.ID) ? 'checked' : ''} onchange="toggleTodoSelection('${esc(r.ID)}', this.checked)" /></td>
-              <td>${formatDate(r.DueDate)}</td>
+              <td>${formatDate(r.DueDate)}${r.Completed === 'true' && r.CompletedAt ? `<br><span class="text-muted text-sm">Done ${formatDate(r.CompletedAt)}</span>` : ''}</td>
               <td class="mobile-hide">${urgencyBadge(r.DueDate, r.Completed)}</td>
               <td class="fw-600"><span class="td-link" onclick="openEditTodo('${esc(r.ID)}')">${esc(r.Title)}</span>${r.Recurrence && r.Recurrence !== 'none' ? ` <span class="badge badge-recurrence" title="${esc(RECURRENCE_OPTIONS.find(o => o.value === r.Recurrence)?.label || r.Recurrence)}">↻</span>` : ''}</td>
               <td class="mobile-hide text-sm">${r.AccountID ? `<span class="td-link" onclick="loadAccountProfile('${esc(r.AccountID)}')">${esc(r.AccountName)}</span>` : '—'}</td>

--- a/routes/reminders.js
+++ b/routes/reminders.js
@@ -88,9 +88,20 @@ router.put('/:id', async (req, res) => {
     const existing = getRow('REMINDERS', req.params.id);
     const oldNotes = existing?.Notes || '';
     const oldStaffId = existing?.StaffID || '';
+    const wasCompleted = existing?.Completed === 'true';
     const updates = { ...req.body };
     delete updates.ID;
     delete updates.CreatedAt;
+    // Always control CompletedAt server-side based on the Completed transition
+    // so single-row and bulk callers don't have to remember to set it.
+    if (updates.Completed === 'true' && !wasCompleted) {
+      updates.CompletedAt = new Date().toISOString();
+    } else if (updates.Completed === 'false' && wasCompleted) {
+      updates.CompletedAt = '';
+    } else {
+      // Don't let a caller override it on unrelated edits.
+      delete updates.CompletedAt;
+    }
     // ?silent=1 suppresses mention + assignment notifications. Used by the
     // bulk-reassign UI so reassigning N todos doesn't email recipients N times.
     const silent = req.query.silent === '1' || req.query.silent === 'true';


### PR DESCRIPTION
## Summary
Closes #412. Done todos now record *when* they were completed and the date is visible in both the Todos list and on the account profile. Useful for historical lookups like "when did we last clean the draft lines for this account?".

## Backend
- `REMINDERS` gets a new `CompletedAt` column (auto-migrates on boot).
- `PUT /api/reminders/:id` server-stamps `CompletedAt = now` when an open todo transitions to done, and clears it when a done todo is reopened. Drops the field from updates otherwise so unrelated edits can't override the original completion time.
- Single-row Done, bulk Mark Done, and bulk Reopen all work without any client change because all of them route through this PUT.
- Recurrence spawns aren't affected — the next-occurrence object literal doesn't carry CompletedAt.

## UI
- **Todos list**: the Due cell now shows a "Done MM/DD/YYYY" subtitle on completed rows.
- **Account profile Todos section**: same treatment.
- No column added — keeps the table the same width.

## Test plan
- [ ] Mark an open todo as Done → row shows Done date underneath the due date
- [ ] Bulk Mark Done from #387 → same; all rows show their Done date
- [ ] Reopen a done todo → CompletedAt clears, subtitle disappears
- [ ] Re-complete → fresh CompletedAt with today's date
- [ ] Edit a done todo's title/notes → CompletedAt is preserved (not overridden)
- [ ] Complete a recurring todo → CompletedAt stamped on the original; the spawned next occurrence has no CompletedAt
- [ ] Switch Todos filter to Completed → all rows show Done dates
- [ ] Account profile Todos section shows Done dates on completed rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)