### PR TITLE
Sort outstanding kegs first in account keg tracking (closes #413)

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -465,7 +465,17 @@ async function loadAccountProfile(accountId) {
   const freqStats = computeOrderFrequencyStats(acctOrders);
 
   // Keg tracking calculations
-  const acctKegs = (kegRecords || []).sort((a, b) => (b.DeliveredDate || '').localeCompare(a.DeliveredDate || ''));
+  // Sort outstanding kegs to the top so they don't get lost on later pages
+  // when an account has a long return history. Within each group sort by
+  // delivered date desc (oldest outstanding still bubbles to the bottom of
+  // the outstanding group, which makes long-overdue kegs easy to spot).
+  const _kegOutstanding = (k) => Math.max(0, (parseInt(k.Quantity) || 0) - (parseInt(k.ReturnedQuantity) || 0));
+  const acctKegs = (kegRecords || []).sort((a, b) => {
+    const aOut = _kegOutstanding(a) > 0 ? 0 : 1;
+    const bOut = _kegOutstanding(b) > 0 ? 0 : 1;
+    if (aOut !== bOut) return aOut - bOut;
+    return (b.DeliveredDate || '').localeCompare(a.DeliveredDate || '');
+  });
   _profileKegsCache = acctKegs;
   _profileKegsContext = { accountId, accountName: acct.Name };
   const outstandingKegs = acctKegs.reduce((sum, k) => {


### PR DESCRIPTION
## Summary
Closes #413. The Keg Tracking section on an account profile sorted by delivered date only, so outstanding (unreturned) kegs got interleaved with fully-returned ones and pushed onto later pages on accounts with long histories — long-overdue kegs were easy to miss.

## Fix
Two-key sort:
1. Outstanding rows first (any keg with `Quantity − ReturnedQuantity > 0`)
2. Delivered date desc within each group

Within the outstanding group, the oldest delivered keg sits at the bottom — that puts long-out kegs at the visual end of the "still out" block where they catch the eye.

## Test plan
- [ ] Account with mixed history: outstanding rows appear before fully-returned rows on page 1
- [ ] Fully-returned-only history: rows render in delivered-date-desc order (no change)
- [ ] Outstanding-only history: same, since the secondary sort takes over
- [ ] After returning kegs on a row, it drops to the bottom of the table on next render

🤖 Generated with [Claude Code](https://claude.com/claude-code)