### PR TITLE
Per-account billing terms (closes #377)

### DIFF
--- a/db.js
+++ b/db.js
@@ -34,7 +34,7 @@ const TABLES = {
 const HEADERS = {
   PRODUCTS:  ['ID', 'Name', 'Style', 'ABV', 'Format', 'PricePerUnit', 'Notes', 'ExcludeFromEmailOfferings', 'CreatedAt'],
   INVENTORY: ['ID', 'Name', 'Location', 'Style', 'ABV', 'Format', 'Units', 'PricePerUnit', 'Prices', 'LowStockThreshold', 'Notes', 'LastUpdated', 'ProductID', 'ProductName'],
-  ACCOUNTS:  ['ID', 'Name', 'Type', 'Tags', 'ContactName', 'Email', 'AdditionalEmails', 'Phone', 'PreferredMethod', 'BillingContactName', 'BillingEmail', 'BillingPhone', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'ChargeDeposits', 'Taxable', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'ServicedBy', 'QboCustomerId', 'CreatedAt', 'CheckInFrequency', 'DeliversIndirectly'],
+  ACCOUNTS:  ['ID', 'Name', 'Type', 'Tags', 'ContactName', 'Email', 'AdditionalEmails', 'Phone', 'PreferredMethod', 'BillingContactName', 'BillingEmail', 'BillingPhone', 'BillingTerm', 'Address', 'City', 'State', 'Zip', 'ABCLicense', 'ChargeDeposits', 'Taxable', 'Status', 'Notes', 'LastContacted', 'StaffID', 'StaffName', 'ServicedBy', 'QboCustomerId', 'CreatedAt', 'CheckInFrequency', 'DeliversIndirectly'],
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
   REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'CompletedAt', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
   STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt', 'Locations'],

--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -1,6 +1,14 @@
 'use strict';
 
 const ACCOUNT_TYPES = ['Bar', 'Distributor', 'Restaurant', 'Retail Store', 'Grocery Store', 'Hotel', 'Event Venue', 'Individual', 'Other'];
+
+// Billing terms drive QBO invoice DueDate. Empty string is treated as COD.
+// Net X = DueDate is X days after the order's DeliveryDate.
+const BILLING_TERMS = [
+  { value: '',       label: 'COD (due on delivery)', days: 0 },
+  { value: 'Net 15', label: 'Net 15',                days: 15 },
+  { value: 'Net 30', label: 'Net 30',                days: 30 },
+];
 const CONTACT_METHODS = ['Email', 'Phone', 'SMS', 'In-Person', 'Any'];
 const ACCOUNT_STATUSES = ['Active', 'Prospect', 'Inactive'];
 const CHECK_IN_FREQUENCIES = ['Weekly', 'Biweekly', 'Monthly', 'Quarterly'];
@@ -178,6 +186,13 @@ function accountForm(acct = {}) {
         <label>Billing Phone</label>
         <input class="form-control" id="f-billing-phone" type="tel" value="${esc(formatPhone(acct.BillingPhone))}" placeholder="(555) 000-0000" onblur="this.value=formatPhone(this.value)" />
       </div>
+    </div>
+    <div class="form-group">
+      <label>Billing Term</label>
+      <select class="form-control" id="f-billing-term">
+        ${BILLING_TERMS.map(t => `<option value="${esc(t.value)}" ${(acct.BillingTerm || '') === t.value ? 'selected' : ''}>${esc(t.label)}</option>`).join('')}
+      </select>
+      <p class="text-sm text-muted" style="margin-top:4px">Sets the QuickBooks invoice due date — calculated as the delivery date plus the term days.</p>
     </div>
     <hr class="form-divider" />
     <div class="form-section-title">Location</div>
@@ -523,6 +538,7 @@ async function loadAccountProfile(accountId) {
     acct.BillingContactName ? `<div class="profile-info-item"><span class="profile-info-label">Billing Contact</span><span>${esc(acct.BillingContactName)}</span></div>` : '',
     acct.BillingEmail ? `<div class="profile-info-item"><span class="profile-info-label">Billing Email</span><span>${esc(acct.BillingEmail)}</span></div>` : '',
     acct.BillingPhone ? `<div class="profile-info-item"><span class="profile-info-label">Billing Phone</span><span>${esc(formatPhone(acct.BillingPhone))}</span></div>` : '',
+    acct.BillingTerm ? `<div class="profile-info-item"><span class="profile-info-label">Billing Term</span><span>${esc(acct.BillingTerm)}</span></div>` : '',
     (acct.Address || acct.City) ? `<div class="profile-info-item"><span class="profile-info-label">Address</span><span>${esc(acct.Address || '')}${acct.Address && (acct.City || acct.State || acct.Zip) ? ', ' : ''}${[acct.City, (acct.State && acct.Zip ? acct.State + ' ' + acct.Zip : acct.State || acct.Zip)].filter(Boolean).map(esc).join(', ')}</span></div>` : '',
     acct.ABCLicense   ? `<div class="profile-info-item"><span class="profile-info-label">ABC License</span><span>${esc(acct.ABCLicense)}</span></div>` : '',
     (() => { let tags = []; try { tags = JSON.parse(acct.Tags || '[]'); } catch (e) {} return tags.length > 0 ? `<div class="profile-info-item"><span class="profile-info-label">Tags</span><span class="tag-badges">${tags.map(t => '<span class="badge badge-tag">' + esc(t) + '</span>').join(' ')}</span></div>` : ''; })(),
@@ -1223,6 +1239,7 @@ function openAddAccount() {
       ContactName: val('f-contact'), PreferredMethod: val('f-method'),
       Email: val('f-email'), AdditionalEmails: collectAdditionalEmails(), Phone: val('f-phone'),
       BillingContactName: val('f-billing-contact'), BillingEmail: val('f-billing-email'), BillingPhone: val('f-billing-phone'),
+      BillingTerm: val('f-billing-term'),
       Address: val('f-address'), City: val('f-city'), State: val('f-state'), Zip: val('f-zip'),
       ABCLicense: val('f-abc-license'),
       ChargeDeposits: document.getElementById('f-charge-deposits').checked ? 'true' : 'false',
@@ -1252,6 +1269,7 @@ function openEditAccount(id) {
       ContactName: val('f-contact'), PreferredMethod: val('f-method'),
       Email: val('f-email'), AdditionalEmails: collectAdditionalEmails(), Phone: val('f-phone'),
       BillingContactName: val('f-billing-contact'), BillingEmail: val('f-billing-email'), BillingPhone: val('f-billing-phone'),
+      BillingTerm: val('f-billing-term'),
       Address: val('f-address'), City: val('f-city'), State: val('f-state'), Zip: val('f-zip'),
       ABCLicense: val('f-abc-license'),
       ChargeDeposits: document.getElementById('f-charge-deposits').checked ? 'true' : 'false',

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -132,7 +132,7 @@ function orderForm(order = {}, presetAccountId = '', readOnly = false) {
     <div class="form-row">
       <div class="form-group">
         <label>Account <span class="required">*</span></label>
-        <select class="form-control" id="f-account" ${presetAccountId || readOnly ? 'disabled' : ''} onchange="initOrderDepositCheckbox(); initOrderTaxCheckbox(); refreshLineItemDeliversTo()">
+        <select class="form-control" id="f-account" ${presetAccountId || readOnly ? 'disabled' : ''} onchange="initOrderDepositCheckbox(); initOrderTaxCheckbox(); refreshLineItemDeliversTo(); refreshOrderBillingTermHint()">
           <option value="">-- Select Account --</option>
           ${accountOptions(selAcctId, order.Location || state.location)}
         </select>
@@ -187,7 +187,8 @@ function orderForm(order = {}, presetAccountId = '', readOnly = false) {
       </div>
       <div class="form-group">
         <label>Delivery Date</label>
-        <input class="form-control" id="f-delivery-date" type="date" value="${esc(order.DeliveryDate)}"${dis} />
+        <input class="form-control" id="f-delivery-date" type="date" value="${esc(order.DeliveryDate)}"${dis}${readOnly ? '' : ' onchange="refreshOrderBillingTermHint()"'} />
+        <p id="order-billing-term-hint" class="text-sm text-muted" style="margin-top:4px;min-height:18px"></p>
       </div>
     </div>
     <div class="form-group">
@@ -668,6 +669,28 @@ function refreshLineItemDeliversTo() {
       if (blank) blank.textContent = defaultLabel;
     }
   });
+}
+
+// Show the selected account's billing term + computed QBO invoice due date
+// underneath the Delivery Date input. Recomputed on account or delivery-date
+// change. Mirrors the server-side calculation in qbo-service.js._computeInvoiceDueDate.
+function refreshOrderBillingTermHint() {
+  const hint = document.getElementById('order-billing-term-hint');
+  if (!hint) return;
+  const acctId = document.getElementById('f-account-hidden')?.value || val('f-account');
+  const acct = acctId ? (state.accounts || []).find(a => a.ID === acctId) : null;
+  if (!acct) { hint.textContent = ''; return; }
+  const term = acct.BillingTerm || '';
+  const m = term.match(/(\d+)/);
+  const days = m ? parseInt(m[1], 10) : 0;
+  const termLabel = term || 'COD';
+  const base = val('f-delivery-date') || val('f-order-date') || '';
+  if (!base) { hint.textContent = `Billing term: ${termLabel}`; return; }
+  const d = new Date(base + 'T00:00:00');
+  if (Number.isNaN(d.getTime())) { hint.textContent = `Billing term: ${termLabel}`; return; }
+  d.setDate(d.getDate() + days);
+  const due = d.toISOString().split('T')[0];
+  hint.textContent = `Billing term: ${termLabel} — invoice due ${formatDate(due)}`;
 }
 
 function _buildTierDropdown(prices, selectedTier) {
@@ -1467,6 +1490,7 @@ async function openAddOrder(presetAccountId = '') {
   initOrderDepositCheckbox(presetAccountId);
   initOrderTaxCheckbox(presetAccountId);
   initOrderCredit(presetAccountId);
+  refreshOrderBillingTermHint();
   // Wire up account dropdown change to also refresh credit
   const acctSelect = document.getElementById('f-account');
   if (acctSelect) {
@@ -1661,6 +1685,7 @@ async function openEditOrder(id) {
     }
   }
   if (!isPaid) await initOrderCredit(order.AccountID, id);
+  refreshOrderBillingTermHint();
 }
 
 async function deleteOrder(id) {

--- a/qbo-service.js
+++ b/qbo-service.js
@@ -26,6 +26,31 @@ function isQboConfigured() {
   return !!(QBO_CLIENT_ID && QBO_CLIENT_SECRET);
 }
 
+/**
+ * Parse account.BillingTerm (e.g. "Net 15", "Net 30", or "" for COD) into a
+ * day count to add to the base date when computing invoice DueDate.
+ */
+function _termDays(billingTerm) {
+  if (!billingTerm) return 0;
+  const m = String(billingTerm).match(/(\d+)/);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+/**
+ * Compute the invoice DueDate (YYYY-MM-DD) for an order using the account's
+ * billing term. Base date is DeliveryDate, falling back to OrderDate. Returns
+ * undefined when neither date is present so the QBO API call omits the field.
+ */
+function _computeInvoiceDueDate(order, account) {
+  const base = order.DeliveryDate || order.OrderDate;
+  if (!base) return undefined;
+  const days = _termDays(account?.BillingTerm);
+  const d = new Date(base.split('T')[0] + 'T00:00:00Z');
+  if (Number.isNaN(d.getTime())) return undefined;
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().split('T')[0];
+}
+
 // ── OAuth client ─────────────────────────────────────────────────
 
 function getOAuthClient(redirectUri) {
@@ -868,7 +893,7 @@ async function _buildInvoiceBody(order, lineItems, account) {
     Line:         lines,
     DocNumber:    docNumber,
     TxnDate:      order.OrderDate ? order.OrderDate.split('T')[0] : undefined,
-    DueDate:      order.DeliveryDate ? order.DeliveryDate.split('T')[0] : undefined,
+    DueDate:      _computeInvoiceDueDate(order, account),
     BillEmail:     billEmail ? { Address: billEmail } : undefined,
     BillEmailCc:   ccEmails.length > 0 ? { Address: ccEmails.join(', ') } : undefined,
     DepartmentRef: departmentRef,

--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -25,7 +25,7 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
   try {
-    const { Name, Type, Tags, ContactName, Email, AdditionalEmails, Phone, PreferredMethod, BillingContactName, BillingEmail, BillingPhone, Address, City, State, Zip, ABCLicense, ChargeDeposits, Taxable, DeliversIndirectly, Status, Notes, StaffID, StaffName, ServicedBy, CheckInFrequency } = req.body;
+    const { Name, Type, Tags, ContactName, Email, AdditionalEmails, Phone, PreferredMethod, BillingContactName, BillingEmail, BillingPhone, BillingTerm, Address, City, State, Zip, ABCLicense, ChargeDeposits, Taxable, DeliversIndirectly, Status, Notes, StaffID, StaffName, ServicedBy, CheckInFrequency } = req.body;
     if (!Name) return res.status(400).json({ error: 'Account name is required' });
 
     const account = {
@@ -41,6 +41,7 @@ router.post('/', async (req, res) => {
       BillingContactName: BillingContactName || '',
       BillingEmail: BillingEmail || '',
       BillingPhone: BillingPhone || '',
+      BillingTerm: BillingTerm || '',
       Address: Address || '',
       City: City || '',
       State: State || '',


### PR DESCRIPTION
## Summary
Closes #377. Lets each account opt into Net 15 or Net 30 billing instead of the implicit COD ("due on delivery") that's been in place. The term drives the QBO invoice DueDate so payment expectations match the account's agreed terms.

## Changes
- **Schema**: \`ACCOUNTS\` gains \`BillingTerm\` (auto-migrates on boot).
- **Account form**: new Billing Term dropdown in the Billing section (\`COD (due on delivery)\` / \`Net 15\` / \`Net 30\`). Surfaced read-only on the account profile.
- **QBO** (\`_computeInvoiceDueDate\` in \`qbo-service.js\`): \`DueDate = DeliveryDate + term days\` (fallback: \`OrderDate + term days\` when DeliveryDate is empty). COD / unset preserves the current "due on delivery" behavior, so existing accounts see no change until their term is set.
- **Order form**: small read-only hint under Delivery Date showing the selected account's term and computed invoice due date — refreshes when account or delivery date changes.
- Existing resync (\#383) already recomputes the invoice body on edit, so changing an account's term immediately affects any unpaid synced order the next time it's edited.

## Out of scope (deliberate)
- A/R aging report (worth its own follow-up issue)
- Sending \`SalesTermRef\` to QBO (user opted for due-date-only)
- Retroactively re-cutting past invoices

## Test plan
- [ ] Edit an account → set Billing Term to Net 30 → save → reload → value persists
- [ ] Account profile shows "Billing Term: Net 30"
- [ ] Open a new order for that account → "Billing term: Net 30 — invoice due MM/DD/YYYY" appears under Delivery Date and updates when you change the date
- [ ] Order for COD account shows "Billing term: COD — invoice due {DeliveryDate}"
- [ ] Sync the order to QBO → invoice DueDate in QBO = DeliveryDate + 30 days (or DeliveryDate for COD)
- [ ] Order with no DeliveryDate → DueDate falls back to OrderDate + term days
- [ ] Edit an unpaid synced order on a Net 30 account → resync (\#383) carries the new DueDate
- [ ] Existing accounts (no term set) sync identically to before — DueDate = DeliveryDate

🤖 Generated with [Claude Code](https://claude.com/claude-code)