### PR TITLE
Respect line-item Taxable flag in QBO invoice (refs #384)

### DIFF
--- a/qbo-service.js
+++ b/qbo-service.js
@@ -787,7 +787,11 @@ async function _buildInvoiceBody(order, lineItems, account) {
   const taxAmount = parseFloat(order.TaxAmount || 0);
   const hasTax = taxAmount > 0 && taxInfo;
 
-  // Build QBO line items referencing the generic product item
+  // Build QBO line items referencing the generic product item.
+  // When the order has tax, only lines flagged Taxable='true' are coded TAX;
+  // everything else (Account Credit refund lines, explicitly non-taxable
+  // custom items, etc.) is coded NON so it doesn't shrink the tax base or
+  // get inflated by the tax rate.
   const lines = lineItems.map((li, idx) => {
     const line = {
       DetailType:          'SalesItemLineDetail',
@@ -800,9 +804,8 @@ async function _buildInvoiceBody(order, lineItems, account) {
       },
       LineNum: idx + 1,
     };
-    // Mark product lines as taxable when tax applies
     if (hasTax) {
-      line.SalesItemLineDetail.TaxCodeRef = { value: 'TAX' };
+      line.SalesItemLineDetail.TaxCodeRef = { value: li.Taxable === 'true' ? 'TAX' : 'NON' };
     }
     return line;
   });


### PR DESCRIPTION
## Summary
While confirming #384 ("show keg credits as a line item on the invoice") I traced through the QBO mapping and found that the existing manual-apply credit flow already emits an Account Credit line on the invoice — the user picked Option C, which is to fix the latent tax bug in that mapping and document the manual flow as the intended behavior.

The bug: every order line was being marked \`TaxCodeRef=TAX\` whenever the order had any tax, regardless of the line's own \`Taxable\` flag. So an Account Credit line (negative \`LineTotal\`) was reducing the tax base — applying the tax rate to a smaller subtotal than what the brewery actually charged.

## Fix
Honor each \`ORDER_ITEMS.Taxable\` flag in the QBO mapping. The existing \`NetAmountTaxable\` aggregation already filters on \`TaxCodeRef\`, so the fix is a one-line condition change in \`_buildInvoiceBody\`.

| Line type | Old | New |
| --- | --- | --- |
| Standard product (Taxable='true') | TAX when tax applies | TAX when tax applies (unchanged) |
| Custom item with tax checkbox checked | TAX | TAX (unchanged) |
| Custom item without tax checkbox | TAX (bug) | NON |
| Account Credit (refund line) | TAX (bug) | NON |
| Keg deposit lines (lines.push later) | NON (explicit, unchanged) | NON (unchanged) |

## Test plan
- [ ] Order with tax + standard products only → tax amount matches subtotal × rate
- [ ] Order with tax + manual account credit applied → invoice still shows the Account Credit line; tax = (subtotal − 0) × rate, not (subtotal − credit) × rate
- [ ] Order with tax + custom item marked non-taxable → custom-item line is coded NON, tax base excludes it
- [ ] Order with tax + keg deposit → deposit line still coded NON (no regression)
- [ ] Order with no tax → no TaxCodeRef on any line (unchanged)

## Note
Auto-applying keg-deposit refunds to the same delivery's invoice (so users don't have to open Edit Order and type the amount manually) was deliberately left out of this PR per the discussion — leaving it as documented manual flow. Can revisit if Worldwide still finds the manual step painful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)