### PR TITLE
Don't prompt QBO invoice on Pre-Sale or Cancelled (closes #422)

### DIFF
--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -1519,7 +1519,9 @@ async function openAddOrder(presetAccountId = '') {
     const reloadFn = state.view === 'account-profile'
       ? () => loadAccountProfile(state.accountProfileId)
       : () => loadOrders();
-    if (newStatus !== 'Draft') {
+    // Only prompt to create a QBO invoice when the order is meant to be a
+    // real receivable — Pre-Sale and Cancelled don't generate invoices.
+    if (newStatus === 'Pending' || newStatus === 'Paid') {
       promptQboSync(order.ID, reloadFn);
     } else {
       reloadFn();
@@ -1695,8 +1697,10 @@ async function openEditOrder(id) {
           }
         }
       }
-      // Prompt QBO sync when transitioning from Draft to Pending or Paid
-      const leavingDraft = order.Status === 'Draft' && newStatus !== 'Draft';
+      // Prompt QBO sync when transitioning from Draft to Pending or Paid.
+      // Pre-Sale and Cancelled aren't real receivables and shouldn't trigger
+      // an invoice — moving to those statuses is a no-op for QBO.
+      const leavingDraft = order.Status === 'Draft' && (newStatus === 'Pending' || newStatus === 'Paid');
       if (leavingDraft && !order.QboInvoiceId) {
         const reloadFn = state.view === 'account-profile'
           ? () => loadAccountProfile(state.accountProfileId)


### PR DESCRIPTION
## Summary
Closes #422. Both the Add Order and Edit Order save paths gated the QBO sync prompt on \`newStatus !== 'Draft'\`, which doesn't match the comment ("Pending or Paid"). Converting a Draft order to Pre-Sale (or to Cancelled) surfaced the "Create QuickBooks Invoice?" prompt — pre-sales aren't real receivables and shouldn't generate invoices.

## Fix
Restrict the prompt to the two statuses that actually represent an invoiceable order:

\`\`\`js
if (newStatus === 'Pending' || newStatus === 'Paid') promptQboSync(...)
\`\`\`

Same fix in two places: `openAddOrder` and `openEditOrder`.

## Test plan
- [ ] New order saved as Draft → no QBO prompt (unchanged)
- [ ] New order saved as Pending → QBO prompt shown (unchanged)
- [ ] New order saved as Paid → QBO prompt shown (unchanged)
- [ ] New order saved as Pre-Sale → **no prompt** (was prompting before)
- [ ] New order saved as Cancelled → **no prompt** (was prompting before)
- [ ] Existing Draft → Pre-Sale conversion → no prompt
- [ ] Existing Draft → Pending → prompt (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)