### PR TITLE
Surface QBO payment history + Pay-in-QBO link (closes #424)

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -648,6 +648,7 @@ async function loadAccountProfile(accountId) {
 
     <div class="profile-info card" style="margin-bottom:24px">
       ${infoRows || '<span class="text-muted">No additional info on file.</span>'}
+      <div id="qbo-payment-info-slot" data-account-id="${esc(accountId)}"></div>
     </div>
 
     <div class="profile-section">
@@ -764,6 +765,27 @@ async function loadAccountProfile(accountId) {
   renderProfileTodos();
   renderProfileOrders();
   renderProfileKegs();
+  loadQboPaymentInfoForProfile(accountId);
+}
+
+// Fetch the QBO customer's recent-payment summary (last method used + last
+// payment date) and render it into the profile info panel slot. Quiet when
+// QBO isn't connected, the account isn't synced, or the customer has no
+// payment history — the slot just stays empty.
+async function loadQboPaymentInfoForProfile(accountId) {
+  const slot = document.getElementById('qbo-payment-info-slot');
+  if (!slot || slot.dataset.accountId !== accountId) return;
+  let data;
+  try {
+    data = await api.get(`/api/qbo/customer/${encodeURIComponent(accountId)}/payment-summary`);
+  } catch { return; }
+  if (!data?.available || !data.summary) return;
+  const { lastMethod, lastPaymentDate, methodsUsed } = data.summary;
+  const distinctMethods = methodsUsed.filter(m => m && m !== 'Other');
+  const methodsBlurb = distinctMethods.length > 1
+    ? ` <span class="text-muted text-sm">(also: ${distinctMethods.filter(m => m !== lastMethod).map(esc).join(', ')})</span>`
+    : '';
+  slot.innerHTML = `<div class="profile-info-item"><span class="profile-info-label">QBO Last Paid</span><span>${esc(lastMethod) || '—'}${lastPaymentDate ? ' on ' + formatDate(lastPaymentDate) : ''}${methodsBlurb}</span></div>`;
 }
 
 function renderProfileOutreach() {
@@ -1163,6 +1185,9 @@ function profileEditOrder(id) {
     if (!isPaid) initOrderCredit(order.AccountID, id);
     if (order.Delivered === 'true' && typeof loadOrderKegReturns === 'function') {
       loadOrderKegReturns(id);
+    }
+    if (typeof loadOrderQboPaymentSummary === 'function') {
+      loadOrderQboPaymentSummary(order.AccountID);
     }
   });
 }

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -250,12 +250,13 @@ function orderForm(order = {}, presetAccountId = '', readOnly = false) {
     <hr class="form-divider" />
     <div class="form-section-title">QuickBooks</div>
     <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
-      ${order.QboSyncStatus === 'synced' ? `<span class="badge badge-success">Synced</span>${qboInvoiceUrl(order) ? `<a href="${qboInvoiceUrl(order)}" target="_blank" rel="noopener" class="btn btn-ghost btn-sm">View in QuickBooks</a>` : `<span class="text-sm text-muted">Invoice ID: ${esc(order.QboInvoiceId)}</span>`}${order.InvoicePdf ? `<a href="/api/qbo/invoice-pdf/${esc(order.ID)}" target="_blank" class="btn btn-ghost btn-sm">Download Invoice</a>` : ''}` : ''}
+      ${order.QboSyncStatus === 'synced' ? `<span class="badge badge-success">Synced</span>${qboInvoiceUrl(order) ? `<a href="${qboInvoiceUrl(order)}" target="_blank" rel="noopener" class="btn btn-ghost btn-sm">View in QuickBooks</a>` : `<span class="text-sm text-muted">Invoice ID: ${esc(order.QboInvoiceId)}</span>`}${order.InvoicePdf ? `<a href="/api/qbo/invoice-pdf/${esc(order.ID)}" target="_blank" class="btn btn-ghost btn-sm">Download Invoice</a>` : ''}${qboInvoiceUrl(order) && !order.QboPaymentId && order.Status !== 'Paid' && order.Status !== 'Cancelled' ? `<a href="${qboInvoiceUrl(order)}" target="_blank" rel="noopener" class="btn btn-secondary btn-sm">Pay in QuickBooks</a>` : ''}` : ''}
       ${order.QboSyncStatus === 'failed' ? `<span class="badge badge-danger">Sync Failed</span>${order.QboSyncError ? `<span class="text-sm text-danger">${esc(order.QboSyncError)}</span>` : ''}<button class="btn btn-ghost btn-sm" onclick="retryQboSync('${esc(order.ID)}')">Retry</button>` : ''}
       ${order.QboSyncStatus === 'disabled' ? '<span class="badge badge-neutral">Not Connected</span>' : ''}
       ${order.QboSyncStatus === 'skipped' ? `<span class="badge badge-neutral">Sync Disabled</span><button class="btn btn-ghost btn-sm" onclick="retryQboSync('${esc(order.ID)}')">Create Invoice</button>` : ''}
       ${!order.QboSyncStatus ? `<span class="badge badge-neutral">Pending</span><button class="btn btn-ghost btn-sm" onclick="retryQboSync('${esc(order.ID)}')">Create Invoice</button>` : ''}
-    </div>` : ''}`;
+    </div>
+    ${order.AccountID ? `<div id="qbo-payment-summary-slot" data-account-id="${esc(order.AccountID)}" class="text-sm text-muted" style="margin-top:6px"></div>` : ''}` : ''}`;
 }
 
 function preSaleForm(ps = {}, presetAccountId = '') {
@@ -1731,6 +1732,24 @@ async function openEditOrder(id) {
   if (!isPaid) await initOrderCredit(order.AccountID, id);
   refreshOrderBillingTermHint();
   if (order.Delivered === 'true') loadOrderKegReturns(id);
+  loadOrderQboPaymentSummary(order.AccountID);
+}
+
+// Populate the "Last paid by X on DATE" hint in the QBO section of the order
+// modal. Quietly does nothing when QBO isn't connected or the customer
+// isn't synced yet. Server caches the lookup so opening multiple orders
+// for the same account doesn't re-query QBO each time.
+async function loadOrderQboPaymentSummary(accountId) {
+  const slot = document.getElementById('qbo-payment-summary-slot');
+  if (!slot || !accountId || slot.dataset.accountId !== accountId) return;
+  let data;
+  try {
+    data = await api.get(`/api/qbo/customer/${encodeURIComponent(accountId)}/payment-summary`);
+  } catch { return; }
+  if (!data?.available || !data.summary) return;
+  const { lastMethod, lastPaymentDate } = data.summary;
+  if (!lastMethod && !lastPaymentDate) return;
+  slot.textContent = `Last paid by ${lastMethod}${lastPaymentDate ? ' on ' + formatDate(lastPaymentDate) : ''}`;
 }
 
 async function deleteOrder(id) {

--- a/qbo-service.js
+++ b/qbo-service.js
@@ -554,6 +554,7 @@ function clearAllCaches() {
   _qboTaxInfo = null;
   _qboDepartments = null;
   _qboPaymentMethods = null;
+  if (typeof _qboPaymentSummaryCache !== 'undefined') _qboPaymentSummaryCache.clear();
 }
 
 /**
@@ -734,6 +735,64 @@ async function createPayment(order, account) {
 
   const result = await qboApiRequest('POST', 'payment', paymentBody);
   return result.Payment;
+}
+
+// ── Customer payment summary ─────────────────────────────────────
+// Cached briefly so opening multiple orders for the same account doesn't
+// re-query QBO on every render.
+const _qboPaymentSummaryCache = new Map(); // qboCustomerId -> { summary, expiresAt }
+const PAYMENT_SUMMARY_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Look up a QBO customer's recent payment activity. Returns the most-recent
+ * payment date, the inferred method used (Card / ACH / Check / Cash / Other),
+ * and the distinct methods seen across the last batch — useful as a heuristic
+ * for "has the customer paid by card before?" since QBO doesn't expose
+ * saved-on-file methods through the Accounting API.
+ *
+ * Returns null when QBO isn't connected or the customer has no payments.
+ *
+ * @param {string} qboCustomerId
+ * @returns {Promise<{lastPaymentDate: string, lastMethod: string, methodsUsed: string[], paymentCount: number} | null>}
+ */
+async function getCustomerPaymentSummary(qboCustomerId) {
+  if (!qboCustomerId) return null;
+  const cached = _qboPaymentSummaryCache.get(qboCustomerId);
+  if (cached && cached.expiresAt > Date.now()) return cached.summary;
+
+  // QBO's Payment.CustomerRef = '<id>' must be quoted; ORDER BY MetaData.CreateTime DESC gets newest first.
+  const query = `SELECT * FROM Payment WHERE CustomerRef = '${qboCustomerId}' ORDER BY MetaData.CreateTime DESC MAXRESULTS 25`;
+  let payments = [];
+  try {
+    const result = await qboApiRequest('GET', `query?query=${encodeURIComponent(query)}`);
+    payments = result.QueryResponse?.Payment || [];
+  } catch (err) {
+    console.error('[qbo] payment-summary query failed:', err.message);
+    return null;
+  }
+
+  if (payments.length === 0) {
+    _qboPaymentSummaryCache.set(qboCustomerId, { summary: null, expiresAt: Date.now() + PAYMENT_SUMMARY_TTL_MS });
+    return null;
+  }
+
+  const classify = (p) => {
+    let method = p.PaymentMethodRef?.name || '';
+    if (!method && p.CreditCardPayment?.CreditChargeInfo) method = 'Credit Card';
+    if (/credit\s*card|visa|master|amex|discover/i.test(method)) return 'Card';
+    if (/ach|bank|e[-_ ]?check/i.test(method)) return 'ACH';
+    if (/check/i.test(method)) return 'Check';
+    if (/cash/i.test(method)) return 'Cash';
+    return method || 'Other';
+  };
+
+  const lastPaymentDate = payments[0].TxnDate || '';
+  const lastMethod = classify(payments[0]);
+  const methodsUsed = [...new Set(payments.map(classify))];
+
+  const summary = { lastPaymentDate, lastMethod, methodsUsed, paymentCount: payments.length };
+  _qboPaymentSummaryCache.set(qboCustomerId, { summary, expiresAt: Date.now() + PAYMENT_SUMMARY_TTL_MS });
+  return summary;
 }
 
 // ── Invoice number generation ────────────────────────────────────
@@ -1229,5 +1288,6 @@ module.exports = {
   voidInvoice,
   processQboPaymentWebhook,
   createPayment,
+  getCustomerPaymentSummary,
   QBO_APP_URL,
 };

--- a/routes/qbo.js
+++ b/routes/qbo.js
@@ -3,7 +3,7 @@
 const crypto      = require('crypto');
 const express     = require('express');
 const OAuthClient = require('intuit-oauth');
-const { isQboConfigured, getOAuthClient, getStoredTokens, storeTokens, clearTokens, syncOrderToQbo, resyncOrderToQbo, fetchTaxCodes, clearTaxInfoCache, createPayment, QBO_APP_URL } = require('../qbo-service');
+const { isQboConfigured, getOAuthClient, getStoredTokens, storeTokens, clearTokens, syncOrderToQbo, resyncOrderToQbo, fetchTaxCodes, clearTaxInfoCache, createPayment, getCustomerPaymentSummary, QBO_APP_URL } = require('../qbo-service');
 
 const authRouter = express.Router();
 const apiRouter  = express.Router();
@@ -219,6 +219,28 @@ apiRouter.post('/resync/:orderId', async (req, res) => {
     const { getRow } = require('../db');
     const order = getRow('ORDERS', req.params.orderId);
     res.json({ ...result, order });
+  } catch (err) {
+    console.error('[qbo]', err.message);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /api/qbo/customer/:accountId/payment-summary — heuristic look at the
+// customer's recent QBO payments to surface "last paid by Card", etc. on
+// the account profile and order modal. Returns { available: false } when
+// QBO isn't connected or the account isn't synced — UI hides itself.
+apiRouter.get('/customer/:accountId/payment-summary', async (req, res) => {
+  try {
+    if (!isQboConfigured()) return res.json({ available: false, reason: 'not-configured' });
+    const tokens = await getStoredTokens();
+    if (!tokens || !tokens.accessToken) return res.json({ available: false, reason: 'not-connected' });
+    const { getRow } = require('../db');
+    const account = getRow('ACCOUNTS', req.params.accountId);
+    if (!account) return res.status(404).json({ error: 'Account not found' });
+    if (!account.QboCustomerId) return res.json({ available: false, reason: 'not-synced' });
+    const summary = await getCustomerPaymentSummary(account.QboCustomerId);
+    if (!summary) return res.json({ available: true, summary: null });
+    res.json({ available: true, summary });
   } catch (err) {
     console.error('[qbo]', err.message);
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
Closes #424. The QBO Accounting API doesn't expose saved payment methods on customers, but it does expose recent \`Payment\` records — enough to infer "has the customer paid by card / ACH / check before?" as a heuristic, plus a one-click path to QBO's hosted invoice (which already shows a Pay Now button when the customer has a method on file).

This is the "(B)" option from the planning discussion — soft detection from payment history, plus a Pay-in-QBO link that delegates the actual collection to QBO. No new OAuth scopes required.

## Changes
- **\`qbo-service.js\`**: \`getCustomerPaymentSummary(qboCustomerId)\` queries the last 25 payments for a customer and classifies each method into Card / ACH / Check / Cash / Other. Returns the last payment date, the most recent method, and the distinct methods seen. 5-minute in-memory cache so opening multiple orders for the same account doesn't re-query QBO.
- **\`routes/qbo.js\`**: \`GET /api/qbo/customer/:accountId/payment-summary\` returns \`{ available, summary }\`. Gracefully reports \`available: false\` when QBO isn't connected or the account isn't synced.
- **Account profile**: info panel renders a "QBO Last Paid" row when a summary exists.
- **Order modal**: "Pay in QuickBooks" button next to "View in QuickBooks" on synced, unpaid, non-cancelled orders (links to the hosted invoice URL we already construct), plus a "Last paid by X on DATE" hint below the buttons.

## Test plan
- [ ] Account with QboCustomerId + payment history → account profile shows "QBO Last Paid: Card on MM/DD/YYYY"
- [ ] Same account, open a synced unpaid order → modal shows "Pay in QuickBooks" button + the same hint
- [ ] Already-paid order (QboPaymentId set) → no Pay button, hint still appears
- [ ] Cancelled order → no Pay button
- [ ] Account never synced to QBO → no payment row, no hint, no buttons (silent failure)
- [ ] QBO disconnected → same (silent failure)
- [ ] Customer with multiple methods used → row shows last method with "(also: …)" for the others
- [ ] Click "Pay in QuickBooks" → opens QBO hosted invoice in new tab

## Out of scope (per discussion)
- Triggering a charge directly via QBO Payments MSP API — requires merchant-account enrollment and additional OAuth scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)