### PR TITLE
Refresh cached invoice PDF on QBO resync (closes #426)

### DIFF
--- a/qbo-service.js
+++ b/qbo-service.js
@@ -1062,6 +1062,27 @@ async function updateInvoice(invoiceId, order, lineItems, account, _isRetry) {
 
 // ── Top-level sync function ──────────────────────────────────────
 
+/**
+ * Download the latest invoice PDF from QBO and overwrite the locally-cached
+ * copy at data/invoices/<orderId>.pdf. Used after both the initial sync and
+ * any resync that edits an existing invoice — keeps "Download Invoice" from
+ * serving a stale PDF (issue #426). Failures are logged but never thrown:
+ * a missing/stale cache shouldn't take down the whole sync flow.
+ */
+async function _refreshOrderInvoicePdf(orderId, qboInvoiceId) {
+  try {
+    const pdfBuffer = await downloadInvoicePdf(qboInvoiceId);
+    const pdfDir = path.join(__dirname, 'data', 'invoices');
+    fs.mkdirSync(pdfDir, { recursive: true });
+    const pdfFilename = `${orderId}.pdf`;
+    fs.writeFileSync(path.join(pdfDir, pdfFilename), pdfBuffer);
+    await updateRow('ORDERS', orderId, { InvoicePdf: pdfFilename });
+    console.log(`[qbo] Invoice PDF refreshed for order ${orderId}`);
+  } catch (pdfErr) {
+    console.error(`[qbo] Failed to refresh invoice PDF for order ${orderId}:`, pdfErr.message);
+  }
+}
+
 async function syncOrderToQbo(orderId) {
   try {
     if (!isQboConfigured()) {
@@ -1172,17 +1193,7 @@ async function syncOrderToQbo(orderId) {
     }
 
     // Download and save invoice PDF locally
-    try {
-      const pdfBuffer = await downloadInvoicePdf(qboInvoiceId);
-      const pdfDir = path.join(__dirname, 'data', 'invoices');
-      fs.mkdirSync(pdfDir, { recursive: true });
-      const pdfFilename = `${orderId}.pdf`;
-      fs.writeFileSync(path.join(pdfDir, pdfFilename), pdfBuffer);
-      await updateRow('ORDERS', orderId, { InvoicePdf: pdfFilename });
-      console.log(`[qbo] Invoice PDF saved for order ${orderId}`);
-    } catch (pdfErr) {
-      console.error(`[qbo] Failed to download invoice PDF for order ${orderId}:`, pdfErr.message);
-    }
+    await _refreshOrderInvoicePdf(orderId, qboInvoiceId);
   } catch (err) {
     console.error(`[qbo] Sync failed for order ${orderId}:`, err.message);
     try {
@@ -1246,6 +1257,10 @@ async function resyncOrderToQbo(orderId) {
 
     // Make sure local QboSyncStatus is back to synced (clears any prior failure).
     await updateRow('ORDERS', orderId, { QboSyncStatus: 'synced', QboSyncError: '' });
+
+    // Refresh the locally-cached invoice PDF so "Download Invoice" returns
+    // the updated version, not the original (#426).
+    await _refreshOrderInvoicePdf(orderId, order.QboInvoiceId);
 
     // Re-send to BillEmail + BillEmailCc — same shape as the initial sync.
     const billEmail = account.BillingEmail || account.Email;


### PR DESCRIPTION
## Summary
Closes #426. When an unpaid synced order is edited, \`resyncOrderToQbo\` updates the QBO invoice and re-sends it — but the locally-cached PDF at \`data/invoices/<orderId>.pdf\` was never refreshed. The "Download Invoice" link on the order modal serves that file, so users were getting a stale copy that didn't reflect the edit.

## Fix
- Extracted the existing PDF-download-and-save block from \`syncOrderToQbo\` into a shared \`_refreshOrderInvoicePdf(orderId, qboInvoiceId)\` helper.
- Called from both \`syncOrderToQbo\` (no behavior change) and \`resyncOrderToQbo\` (the fix).
- Filename is keyed on \`orderId\`, so the new download overwrites the old in place — no separate "delete old file" step needed.
- Failures are still swallowed (logged but not thrown) so a flaky PDF endpoint can't break the surrounding sync flow.

## Test plan
- [ ] Create order → sync to QBO → Download Invoice → PDF reflects original items
- [ ] Edit the order (change quantity / add a line) → save → Download Invoice → PDF reflects the edit (new content, same URL)
- [ ] Server log shows `[qbo] Invoice PDF refreshed for order <id>` on both initial sync and on edit-resync
- [ ] Resync where the QBO PDF endpoint is unreachable → log shows the failure but the order still saves, QBO invoice still updates, no user-facing error
- [ ] Paid order — no resync, so no refresh attempted (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)