### PR TITLE
Re-download invoice PDF on cache miss (closes #428)

### DIFF
--- a/qbo-service.js
+++ b/qbo-service.js
@@ -1069,7 +1069,7 @@ async function updateInvoice(invoiceId, order, lineItems, account, _isRetry) {
  * serving a stale PDF (issue #426). Failures are logged but never thrown:
  * a missing/stale cache shouldn't take down the whole sync flow.
  */
-async function _refreshOrderInvoicePdf(orderId, qboInvoiceId) {
+async function refreshOrderInvoicePdf(orderId, qboInvoiceId) {
   try {
     const pdfBuffer = await downloadInvoicePdf(qboInvoiceId);
     const pdfDir = path.join(__dirname, 'data', 'invoices');
@@ -1193,7 +1193,7 @@ async function syncOrderToQbo(orderId) {
     }
 
     // Download and save invoice PDF locally
-    await _refreshOrderInvoicePdf(orderId, qboInvoiceId);
+    await refreshOrderInvoicePdf(orderId, qboInvoiceId);
   } catch (err) {
     console.error(`[qbo] Sync failed for order ${orderId}:`, err.message);
     try {
@@ -1260,7 +1260,7 @@ async function resyncOrderToQbo(orderId) {
 
     // Refresh the locally-cached invoice PDF so "Download Invoice" returns
     // the updated version, not the original (#426).
-    await _refreshOrderInvoicePdf(orderId, order.QboInvoiceId);
+    await refreshOrderInvoicePdf(orderId, order.QboInvoiceId);
 
     // Re-send to BillEmail + BillEmailCc — same shape as the initial sync.
     const billEmail = account.BillingEmail || account.Email;
@@ -1304,5 +1304,6 @@ module.exports = {
   processQboPaymentWebhook,
   createPayment,
   getCustomerPaymentSummary,
+  refreshOrderInvoicePdf,
   QBO_APP_URL,
 };

--- a/routes/qbo.js
+++ b/routes/qbo.js
@@ -3,7 +3,7 @@
 const crypto      = require('crypto');
 const express     = require('express');
 const OAuthClient = require('intuit-oauth');
-const { isQboConfigured, getOAuthClient, getStoredTokens, storeTokens, clearTokens, syncOrderToQbo, resyncOrderToQbo, fetchTaxCodes, clearTaxInfoCache, createPayment, getCustomerPaymentSummary, QBO_APP_URL } = require('../qbo-service');
+const { isQboConfigured, getOAuthClient, getStoredTokens, storeTokens, clearTokens, syncOrderToQbo, resyncOrderToQbo, fetchTaxCodes, clearTaxInfoCache, createPayment, getCustomerPaymentSummary, refreshOrderInvoicePdf, QBO_APP_URL } = require('../qbo-service');
 
 const authRouter = express.Router();
 const apiRouter  = express.Router();
@@ -140,24 +140,44 @@ apiRouter.post('/tax-code', async (req, res) => {
   }
 });
 
-// GET /api/qbo/invoice-pdf/:orderId — serve saved invoice PDF
-apiRouter.get('/invoice-pdf/:orderId', (req, res) => {
+// GET /api/qbo/invoice-pdf/:orderId — serve saved invoice PDF.
+// If the local cache is missing for any reason (InvoicePdf not set, or the
+// file was deleted/never persisted), re-download from QBO and try once more
+// before giving up. Requires the order to have a QboInvoiceId.
+apiRouter.get('/invoice-pdf/:orderId', async (req, res) => {
   try {
     const { getRow } = require('../db');
     const path = require('path');
     const fs = require('fs');
-    const order = getRow('ORDERS', req.params.orderId);
-    if (!order || !order.InvoicePdf) {
-      return res.status(404).json({ error: 'Invoice PDF not found' });
-    }
+    let order = getRow('ORDERS', req.params.orderId);
+    if (!order) return res.status(404).json({ error: 'Order not found' });
     const invoicesDir = path.resolve(path.join(__dirname, '..', 'data', 'invoices'));
-    const pdfPath = path.resolve(path.join(invoicesDir, order.InvoicePdf));
-    // Prevent path traversal — resolved path must stay within invoices directory
-    if (!pdfPath.startsWith(invoicesDir + path.sep)) {
-      return res.status(400).json({ error: 'Invalid invoice path' });
-    }
-    if (!fs.existsSync(pdfPath)) {
-      return res.status(404).json({ error: 'Invoice PDF file missing' });
+
+    // Resolve a path candidate that's guarded against traversal. Returns
+    // null when InvoicePdf is unset or the resolved path escapes the dir.
+    const candidatePath = () => {
+      if (!order.InvoicePdf) return null;
+      const p = path.resolve(path.join(invoicesDir, order.InvoicePdf));
+      if (!p.startsWith(invoicesDir + path.sep)) return null;
+      return p;
+    };
+
+    let pdfPath = candidatePath();
+    if (!pdfPath || !fs.existsSync(pdfPath)) {
+      // Cache miss — refetch from QBO if we have an invoice id to refetch with.
+      if (!order.QboInvoiceId) {
+        return res.status(404).json({ error: 'Invoice PDF not found' });
+      }
+      try {
+        await refreshOrderInvoicePdf(req.params.orderId, order.QboInvoiceId);
+      } catch (err) {
+        console.error('[qbo] PDF refetch failed:', err.message);
+      }
+      order = getRow('ORDERS', req.params.orderId);
+      pdfPath = candidatePath();
+      if (!pdfPath || !fs.existsSync(pdfPath)) {
+        return res.status(404).json({ error: 'Invoice PDF unavailable' });
+      }
     }
     res.sendFile(pdfPath, { headers: { 'Content-Type': 'application/pdf' } });
   } catch (err) {


### PR DESCRIPTION
## Summary
Closes #428. If the locally-cached PDF at \`data/invoices/<orderId>.pdf\` was missing (file deleted, disk wiped, never persisted), the download endpoint returned 404 instead of refetching. Now the route attempts a refetch from QBO via the existing refresh helper before giving up — casual filesystem mishaps self-heal on next click.

## Changes
- Promoted \`_refreshOrderInvoicePdf\` → \`refreshOrderInvoicePdf\` and exported it from \`qbo-service.js\` so the route can use it.
- \`GET /api/qbo/invoice-pdf/:orderId\` is now async. On cache miss (either \`InvoicePdf\` unset *or* the resolved path doesn't exist on disk), if the order has a \`QboInvoiceId\`, the helper refetches the PDF from QBO and the route serves the freshly-cached file.
- Still 404s when there's no \`QboInvoiceId\` (nothing to refetch from).
- Path-traversal guard preserved — the resolved path must stay inside \`data/invoices/\`.

## Test plan
- [ ] Synced order, PDF present → downloads normally (unchanged)
- [ ] Synced order, manually delete \`data/invoices/<orderId>.pdf\` → click Download Invoice → PDF re-appears in the directory and downloads
- [ ] Order without \`QboInvoiceId\` (never synced) → 404 "Invoice PDF not found"
- [ ] Synced order but QBO unreachable during refetch → 404 "Invoice PDF unavailable", server log shows the failure
- [ ] Path traversal attempt (\`InvoicePdf\` manipulated to \`../../etc/passwd\`) → 404 (treated as cache miss; refetch resets to a valid filename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)