### PR TITLE
Ignore prefixed DocNumbers when picking next invoice number

### DIFF
--- a/qbo-service.js
+++ b/qbo-service.js
@@ -798,30 +798,33 @@ async function getCustomerPaymentSummary(qboCustomerId) {
 // ── Invoice number generation ────────────────────────────────────
 
 async function getNextInvoiceNumber() {
-  // Fetch recent invoices and find the highest numeric DocNumber
+  // Fetch recent invoices and find the highest purely-numeric DocNumber.
+  // Earlier this scan also matched prefixed numbers (e.g. "PO 8197") via
+  //   /^(.*?)(\d+)$/
+  // and copied the prefix forward to the next generated number. A stray
+  // manual entry in QBO with a "PO " prefix and a higher trailing number
+  // would then poison every subsequent invoice the app created. Restrict
+  // to pure-digit DocNumbers so the brewery's own numeric sequence is the
+  // only signal used.
   const query = "SELECT DocNumber FROM Invoice ORDER BY MetaData.CreateTime DESC MAXRESULTS 100";
   const result = await qboApiRequest('GET', `query?query=${encodeURIComponent(query)}`);
   const invoices = result.QueryResponse?.Invoice || [];
 
   let maxNum = 0;
-  let bestPrefix = '';
   let bestPadding = 0;
 
   for (const inv of invoices) {
     if (!inv.DocNumber) continue;
-    const match = inv.DocNumber.match(/^(.*?)(\d+)$/);
-    if (match) {
-      const num = parseInt(match[2], 10);
-      if (num > maxNum) {
-        maxNum = num;
-        bestPrefix = match[1];
-        bestPadding = match[2].length;
-      }
+    if (!/^\d+$/.test(inv.DocNumber)) continue;
+    const num = parseInt(inv.DocNumber, 10);
+    if (num > maxNum) {
+      maxNum = num;
+      bestPadding = inv.DocNumber.length;
     }
   }
 
   const nextNum = maxNum > 0 ? maxNum + 1 : 1001;
-  return bestPrefix + String(nextNum).padStart(bestPadding, '0');
+  return String(nextNum).padStart(bestPadding, '0');
 }
 
 // ── Invoice creation ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
The brewery noticed all new invoices starting 5/29 came back with a \`PO 8198\`-style number instead of the expected \`1200\`-style. Traced it to \`getNextInvoiceNumber\` in qbo-service.js.

### Root cause

The function scanned the last 100 QBO invoices, captured the prefix and trailing digits of whichever had the highest trailing number, then constructed the next as \`prefix + (num + 1)\`. When somebody entered an invoice in QBO with a \`PO 8197\` DocNumber (manually or via import) and the trailing 8197 out-ranked the brewery's own sequence (~1199), every subsequent sync from the app started producing \`PO 8198\`, \`PO 8199\`, etc. QBO accepted those DocNumbers, so the app's local \`InvoiceNumber\` column captured the prefixed strings too — and the orders list rendered them as-is.

### Fix

Restrict the scan to purely-numeric DocNumbers (\`^\d+\$\`). Anything with a prefix or suffix is now ignored. Zero-padding behavior is preserved: the chosen \`bestPadding\` is the length of the highest pure-numeric DocNumber seen.

| Inputs in QBO | Old result | New result |
| --- | --- | --- |
| \`PO 8197\`, \`1199\`, \`1198\` | \`PO 8198\` | \`1200\` |
| \`1199\`, \`1200\`, \`1198\` | \`1201\` | \`1201\` (no change) |
| \`001199\`, \`001200\` | \`001201\` | \`001201\` (no change) |
| only prefixed entries | \`<prefix>{n+1}\` | \`1001\` (seed) |
| \`QBO-X\`, \`1500\`, \`PO 9999\` | \`PO 10000\` | \`1501\` |

## Note on existing data

This fix prevents new occurrences. The five-ish orders already saved as \`PO 8198\` etc. have those values stored in \`ORDERS.InvoiceNumber\` locally and in QBO. If desired they can be hand-edited in the app and the existing resync flow (#383) will push the corrected DocNumber to QBO — or just left in place.

## Test plan
- [ ] Pure-numeric history → next invoice number is max+1 (unchanged)
- [ ] After this deploy, sync a new order on production → InvoiceNumber is a pure numeric, no "PO " prefix
- [ ] Zero-padded numbering convention → preserved
- [ ] Empty QBO (no invoices yet) → starts at 1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)