### PR TITLE
Add PO Number field on orders (closes #431)

### DIFF
--- a/db.js
+++ b/db.js
@@ -39,7 +39,7 @@ const HEADERS = {
   OUTREACH:  ['ID', 'AccountID', 'AccountName', 'Date', 'Method', 'Notes', 'FollowUpDate', 'FollowUpStatus', 'CreatedAt'],
   REMINDERS: ['ID', 'Type', 'AccountID', 'AccountName', 'Title', 'DueDate', 'Priority', 'Notes', 'Completed', 'CompletedAt', 'StaffID', 'StaffName', 'Recurrence', 'RecurrenceParentID', 'CreatedAt'],
   STAFF:     ['ID', 'Name', 'Email', 'Phone', 'Role', 'Active', 'Notes', 'CreatedAt', 'Locations'],
-  ORDERS:          ['ID', 'AccountID', 'AccountName', 'Location', 'StaffID', 'StaffName', 'OrderDate', 'DeliveryDate', 'InvoiceNumber', 'OrderAmount', 'TaxAmount', 'DepositAmount', 'Notes', 'RequestedProducts', 'Status', 'Delivered', 'PaymentMethod', 'PaymentReference', 'PaymentDate', 'QboPaymentId', 'QboInvoiceId', 'QboSyncStatus', 'QboSyncError', 'InvoicePdf', 'CreatedAt'],
+  ORDERS:          ['ID', 'AccountID', 'AccountName', 'Location', 'StaffID', 'StaffName', 'OrderDate', 'DeliveryDate', 'InvoiceNumber', 'PONumber', 'OrderAmount', 'TaxAmount', 'DepositAmount', 'Notes', 'RequestedProducts', 'Status', 'Delivered', 'PaymentMethod', 'PaymentReference', 'PaymentDate', 'QboPaymentId', 'QboInvoiceId', 'QboSyncStatus', 'QboSyncError', 'InvoicePdf', 'CreatedAt'],
   STOCK_MOVEMENTS: ['ID', 'InventoryID', 'InventoryName', 'OrderID', 'Type', 'Quantity', 'Notes', 'Date', 'CreatedAt'],
   SETTINGS:        ['ID', 'Key', 'Value', 'UpdatedAt'],
   KEG_TRACKING:    ['ID', 'AccountID', 'AccountName', 'OrderID', 'InventoryID', 'ProductName', 'Format', 'Quantity', 'DepositPerUnit', 'DepositTotal', 'DepositRefunded', 'DeliveredDate', 'ReturnedDate', 'ReturnedQuantity', 'Notes', 'CreatedAt'],

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -191,9 +191,15 @@ function orderForm(order = {}, presetAccountId = '', readOnly = false) {
         <p id="order-billing-term-hint" class="text-sm text-muted" style="margin-top:4px;min-height:18px"></p>
       </div>
     </div>
-    <div class="form-group">
-      <label>Invoice Number</label>
-      <input class="form-control" id="f-invoice" value="${esc(order.InvoiceNumber)}" placeholder="e.g. INV-2024-001" />
+    <div class="form-row">
+      <div class="form-group">
+        <label>Invoice Number</label>
+        <input class="form-control" id="f-invoice" value="${esc(order.InvoiceNumber)}" placeholder="e.g. INV-2024-001" />
+      </div>
+      <div class="form-group">
+        <label>PO Number</label>
+        <input class="form-control" id="f-po" value="${esc(order.PONumber || '')}" placeholder="Customer PO #"${dis} />
+      </div>
     </div>
     <hr class="form-divider" />
     <div class="form-section-title">Products</div>
@@ -1419,7 +1425,7 @@ function renderOrders() {
               return `<tr>
                 <td>${formatDate(s.OrderDate)}</td>
                 <td class="fw-600"><span class="td-link" onclick="loadAccountProfile('${esc(s.AccountID)}')">${esc(s.AccountName)}</span>${formatEndCustomers(s.ID)}${formatProductsSummary(s.RequestedProducts)}</td>
-                <td class="mobile-hide text-sm">${esc(s.InvoiceNumber) || '—'}${(_orderItemSummary[s.ID]?.count) ? ` <span class="badge badge-items" title="${_orderItemSummary[s.ID].count} line item${_orderItemSummary[s.ID].count > 1 ? 's' : ''}">${_orderItemSummary[s.ID].count} items</span>` : ''}${qboSyncBadge(s)}</td>
+                <td class="mobile-hide text-sm">${esc(s.InvoiceNumber) || '—'}${s.PONumber ? `<br><span class="text-muted text-sm">PO: ${esc(s.PONumber)}</span>` : ''}${(_orderItemSummary[s.ID]?.count) ? ` <span class="badge badge-items" title="${_orderItemSummary[s.ID].count} line item${_orderItemSummary[s.ID].count > 1 ? 's' : ''}">${_orderItemSummary[s.ID].count} items</span>` : ''}${qboSyncBadge(s)}</td>
                 <td class="mobile-hide">${isPreSale && !parseFloat(s.OrderAmount) ? '<span class="text-muted">—</span>' : fmtMoney(s.OrderAmount)}${s.DepositAmount && parseFloat(s.DepositAmount) > 0 ? `<br><span class="text-muted text-sm">+${fmtMoney(s.DepositAmount)} deposit</span>` : ''}</td>
                 <td class="mobile-hide">${s.TaxAmount && parseFloat(s.TaxAmount) > 0 ? fmtMoney(s.TaxAmount) : '—'}</td>
                 <td class="fw-600">${isPreSale && !parseFloat(s.OrderAmount) ? '<span class="text-muted">—</span>' : fmtMoney(total)}</td>
@@ -1487,7 +1493,7 @@ async function openAddOrder(presetAccountId = '') {
       Location: val('f-location') || state.location,
       StaffID: staffId, StaffName: staffName,
       OrderDate: orderDate, DeliveryDate: val('f-delivery-date'),
-      InvoiceNumber: val('f-invoice'), Status: newStatus,
+      InvoiceNumber: val('f-invoice'), PONumber: val('f-po'), Status: newStatus,
       OrderAmount: finalAmount, TaxAmount: val('f-tax'),
       DepositAmount: val('f-deposit-amount') || '0',
       Notes: val('f-notes'),
@@ -1564,6 +1570,7 @@ function orderMaterialSignature(order, items) {
     String(order.OrderAmount || ''),
     String(order.TaxAmount || ''),
     String(order.DepositAmount || ''),
+    order.PONumber || '',
     itemSig,
   ].join('::');
 }
@@ -1586,7 +1593,7 @@ async function openEditOrder(id) {
       </div>` : '';
     modal.open('View Order', deliveryBanner + orderForm(order, '', true), async () => {
       await api.put(`/api/orders/${id}`, {
-        InvoiceNumber: val('f-invoice'),
+        InvoiceNumber: val('f-invoice'), PONumber: val('f-po'),
         Notes: val('f-notes'),
       });
       modal.close();
@@ -1627,7 +1634,7 @@ async function openEditOrder(id) {
         Location: val('f-location') || state.location,
         StaffID: staffId, StaffName: staffName,
         OrderDate: val('f-order-date'), DeliveryDate: val('f-delivery-date'),
-        InvoiceNumber: val('f-invoice'), Status: newStatus,
+        InvoiceNumber: val('f-invoice'), PONumber: val('f-po'), Status: newStatus,
         OrderAmount: finalAmount, TaxAmount: val('f-tax'),
         DepositAmount: val('f-deposit-amount') || '0',
         Notes: val('f-notes'),
@@ -1683,7 +1690,8 @@ async function openEditOrder(id) {
           { AccountID: val('f-account') || order.AccountID,
             OrderAmount: finalAmount,
             TaxAmount: val('f-tax'),
-            DepositAmount: val('f-deposit-amount') || '0' },
+            DepositAmount: val('f-deposit-amount') || '0',
+            PONumber: val('f-po') },
           collectOrderItems(),
         );
         if (newSig !== origSig) {
@@ -1854,7 +1862,7 @@ async function convertPreSale(id) {
       Location: val('f-location') || state.location,
       StaffID: staffId, StaffName: staffName,
       OrderDate: orderDate, DeliveryDate: val('f-delivery-date'),
-      InvoiceNumber: val('f-invoice'), Status: 'Pending',
+      InvoiceNumber: val('f-invoice'), PONumber: val('f-po'), Status: 'Pending',
       OrderAmount: amount, TaxAmount: val('f-tax'),
       Notes: val('f-notes'),
       RequestedProducts: products || ps.RequestedProducts || '',

--- a/qbo-service.js
+++ b/qbo-service.js
@@ -954,6 +954,7 @@ async function _buildInvoiceBody(order, lineItems, account) {
     CustomerRef:  { value: customerId },
     Line:         lines,
     DocNumber:    docNumber,
+    PONumber:     order.PONumber ? String(order.PONumber).slice(0, 25) : undefined,
     TxnDate:      order.OrderDate ? order.OrderDate.split('T')[0] : undefined,
     DueDate:      _computeInvoiceDueDate(order, account),
     BillEmail:     billEmail ? { Address: billEmail } : undefined,

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -72,7 +72,7 @@ router.post('/', async (req, res) => {
   try {
     const {
       AccountID, AccountName, Location, StaffID, StaffName,
-      OrderDate, DeliveryDate, InvoiceNumber,
+      OrderDate, DeliveryDate, InvoiceNumber, PONumber,
       OrderAmount, TaxAmount, DepositAmount, Notes, RequestedProducts, Status, Delivered,
     } = req.body;
 
@@ -89,6 +89,7 @@ router.post('/', async (req, res) => {
       OrderDate: withTimestamp(OrderDate),
       DeliveryDate: DeliveryDate || '',
       InvoiceNumber: InvoiceNumber || '',
+      PONumber: PONumber || '',
       OrderAmount: OrderAmount || '0',
       TaxAmount:  TaxAmount  || '0',
       DepositAmount: DepositAmount || '0',


### PR DESCRIPTION
## Summary
Closes #431. Some customers require a PO number on their invoices for AP processing. Add a dedicated PONumber field on orders that flows through to the QBO invoice's top-level \`PONumber\` so it displays on the invoice the customer receives.

## Changes
- **Schema**: \`ORDERS\` gains \`PONumber\` (auto-migrates on boot).
- **Order form**: new input next to Invoice Number in the existing row. Disabled in read-only view mode for paid orders.
- **Routes**: \`POST\` + \`PUT /api/orders\` pass the field through. PDF-import path doesn't fill it (the user can edit later).
- **QBO**: \`_buildInvoiceBody\` sends \`PONumber\` on the invoice body. Both initial sync (\`createInvoice\`) and resync (\`updateInvoice\`) paths share the helper, so editing the PO on an unpaid synced order triggers a resync via \`orderMaterialSignature\` — which now includes \`PONumber\`.
- **Orders list**: shows "PO: <number>" as a small line under the invoice number when present.

Defensive truncation to QBO's documented 25-char max before send.

## Relationship to #430
PR #430 stops the app from accidentally generating "PO 8198"-style invoice numbers. This PR is the proper way to record a real customer-supplied PO — they're independent fields with different purposes.

## Test plan
- [ ] Edit a Pending order → enter "PO-12345" in PO Number → save → field persists, shows in orders list under invoice number
- [ ] Sync that order to QBO → open invoice in QBO → PO Number field shows "PO-12345"
- [ ] Edit the order, change PO to "PO-67890", save → resync fires (#383), QBO invoice now shows "PO-67890"
- [ ] Edit a paid order (view-only mode) → PO field is disabled; saving doesn't error
- [ ] Order without a PO → orders list shows just the invoice number (no "PO:" line, unchanged)
- [ ] Long PO string → truncated to 25 chars in QBO

🤖 Generated with [Claude Code](https://claude.com/claude-code)