### PR TITLE
Add attachment support to single + bulk email (closes #433)

### DIFF
--- a/db.js
+++ b/db.js
@@ -48,7 +48,7 @@ const HEADERS = {
   // happened, KegTrackingID points back to the outbound KEG_TRACKING row.
   KEG_RETURNS:     ['ID', 'AccountID', 'AccountName', 'OrderID', 'KegTrackingID', 'ProductName', 'Format', 'Quantity', 'DepositPerUnit', 'DepositRefunded', 'ReturnedDate', 'Notes', 'CreatedAt'],
   TAP_HANDLES:     ['ID', 'AccountID', 'AccountName', 'Quantity', 'DeployedDate', 'CollectedDate', 'CollectedQuantity', 'Notes', 'CreatedAt'],
-  EMAIL_LOG:       ['ID', 'SenderName', 'SenderEmail', 'Recipients', 'Subject', 'Body', 'Type', 'AccountIDs', 'Status', 'Error', 'CreatedAt'],
+  EMAIL_LOG:       ['ID', 'SenderName', 'SenderEmail', 'Recipients', 'Subject', 'Body', 'Type', 'AccountIDs', 'Attachments', 'Status', 'Error', 'CreatedAt'],
   ORDER_ITEMS:     ['ID', 'OrderID', 'InventoryID', 'ProductName', 'Format', 'PriceTier', 'Quantity', 'UnitPrice', 'LineTotal', 'Taxable', 'EndCustomerAccountID', 'EndCustomerName', 'CreatedAt'],
   NOTIFICATIONS:   ['ID', 'Type', 'Channel', 'RecipientStaffID', 'RecipientName', 'RecipientEmail', 'SenderName', 'SenderEmail', 'EntityType', 'EntityID', 'EntityName', 'Message', 'Status', 'Error', 'CreatedAt'],
   ACCOUNT_CREDITS: ['ID', 'AccountID', 'AccountName', 'Type', 'Amount', 'OrderID', 'Reason', 'Notes', 'CreatedAt'],

--- a/email-service.js
+++ b/email-service.js
@@ -30,25 +30,80 @@ function sanitizeHeader(value) {
   return String(value).replace(/[\r\n]/g, '');
 }
 
+// RFC 2047 encoded-word for filenames containing non-ASCII characters.
+// Gmail accepts UTF-8 in raw form for most filenames, but encoded-word is the
+// portable choice for cross-client display.
+function encodeMimeFilename(name) {
+  if (/^[\x20-\x7e]+$/.test(name)) return name;
+  return `=?UTF-8?B?${Buffer.from(name, 'utf8').toString('base64')}?=`;
+}
+
+// Wrap base64 content at 76 chars per line per RFC 5322 / 2045.
+function wrapBase64(b64) {
+  return b64.replace(/.{1,76}/g, '$&\r\n').trimEnd();
+}
+
 /**
- * Build a base64url-encoded RFC 2822 email message.
+ * Build a base64url-encoded RFC 2822 email message. When `attachments` is
+ * provided (array of { filename, content: Buffer, mimeType }), the message is
+ * built as multipart/mixed with a text/plain body part followed by one
+ * base64-encoded part per attachment. Without attachments, the message keeps
+ * the historical single-part text/plain shape (no behavior change).
  */
-function buildRawMessage({ from, to, cc, bcc, replyTo, subject, body }) {
-  const lines = [
+function buildRawMessage({ from, to, cc, bcc, replyTo, subject, body, attachments }) {
+  const headers = [
     `From: ${sanitizeHeader(from)}`,
     `To: ${sanitizeHeader(to)}`,
   ];
-  if (cc) lines.push(`Cc: ${sanitizeHeader(cc)}`);
-  if (bcc) lines.push(`Bcc: ${sanitizeHeader(bcc)}`);
-  if (replyTo) lines.push(`Reply-To: ${sanitizeHeader(replyTo)}`);
-  lines.push(
-    `Subject: ${sanitizeHeader(subject)}`,
-    'MIME-Version: 1.0',
-    'Content-Type: text/plain; charset=UTF-8',
-    '',
-    body,
-  );
-  const message = lines.join('\r\n');
+  if (cc) headers.push(`Cc: ${sanitizeHeader(cc)}`);
+  if (bcc) headers.push(`Bcc: ${sanitizeHeader(bcc)}`);
+  if (replyTo) headers.push(`Reply-To: ${sanitizeHeader(replyTo)}`);
+  headers.push(`Subject: ${sanitizeHeader(subject)}`);
+  headers.push('MIME-Version: 1.0');
+
+  const hasAttachments = Array.isArray(attachments) && attachments.length > 0;
+
+  let message;
+  if (!hasAttachments) {
+    message = [
+      ...headers,
+      'Content-Type: text/plain; charset=UTF-8',
+      '',
+      body,
+    ].join('\r\n');
+  } else {
+    const boundary = `=_shbdist_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+    const parts = [
+      `Content-Type: text/plain; charset=UTF-8`,
+      `Content-Transfer-Encoding: 7bit`,
+      '',
+      body,
+    ].join('\r\n');
+
+    const attachmentParts = attachments.map(att => {
+      const safeName = encodeMimeFilename(att.filename || 'attachment');
+      const mime = att.mimeType || 'application/octet-stream';
+      const b64 = wrapBase64(Buffer.from(att.content).toString('base64'));
+      return [
+        `Content-Type: ${mime}; name="${safeName}"`,
+        `Content-Disposition: attachment; filename="${safeName}"`,
+        `Content-Transfer-Encoding: base64`,
+        '',
+        b64,
+      ].join('\r\n');
+    });
+
+    message = [
+      ...headers,
+      `Content-Type: multipart/mixed; boundary="${boundary}"`,
+      '',
+      `--${boundary}`,
+      parts,
+      ...attachmentParts.flatMap(p => [`--${boundary}`, p]),
+      `--${boundary}--`,
+      '',
+    ].join('\r\n');
+  }
   return Buffer.from(message).toString('base64url');
 }
 
@@ -63,7 +118,7 @@ function buildRawMessage({ from, to, cc, bcc, replyTo, subject, body }) {
  * @param {string} opts.body         - Plain-text body
  * @returns {Promise<object>}        - Gmail API response
  */
-async function sendEmail({ user, to, cc, bcc, replyTo, subject, body, fromEmail }) {
+async function sendEmail({ user, to, cc, bcc, replyTo, subject, body, fromEmail, attachments }) {
   if (!isEmailConfigured()) {
     throw new Error('Email is not configured. Google OAuth credentials are missing.');
   }
@@ -93,6 +148,7 @@ async function sendEmail({ user, to, cc, bcc, replyTo, subject, body, fromEmail 
     replyTo,
     subject,
     body,
+    attachments,
   });
 
   const result = await gmail.users.messages.send({

--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -1568,6 +1568,130 @@ function _emailBodyPreviewHtml(body) {
   return `<div style="white-space:pre-wrap;background:#f7f7f8;border:1px solid #e0e0e0;border-radius:6px;padding:10px 12px;max-height:240px;overflow-y:auto;font-size:13px">${esc(body)}</div>`;
 }
 
+// Hard limits should match the server (routes/email.js). Gmail's per-message
+// cap is 25 MB; we leave headroom for base64 inflation + MIME overhead.
+const EMAIL_ATTACH_MAX_FILE_BYTES = 20 * 1024 * 1024;
+const EMAIL_ATTACH_MAX_TOTAL_BYTES = 25 * 1024 * 1024;
+const EMAIL_ATTACH_MAX_FILES = 10;
+
+function _fmtBytes(n) {
+  if (n < 1024) return n + ' B';
+  if (n < 1024 * 1024) return (n / 1024).toFixed(0) + ' KB';
+  return (n / (1024 * 1024)).toFixed(1) + ' MB';
+}
+
+// Attachment input + chosen-file list. The <input type="file"> doesn't allow
+// per-file removal from a FileList, so we wrap it: each "add files" click
+// appends to a separate `_emailAttachments` array stored on a per-modal
+// element (since modal markup is replaced on each open).
+function _attachmentFieldHtml() {
+  return `
+    <div class="form-group" id="f-email-attachments-wrap">
+      <label>Attachments</label>
+      <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+        <input type="file" id="f-email-attachments" multiple
+          onchange="_addEmailAttachments(this)" style="flex:1;min-width:200px" />
+        <span class="text-sm text-muted" id="f-email-attach-summary"></span>
+      </div>
+      <ul id="f-email-attach-list" style="list-style:none;padding:0;margin:6px 0 0;font-size:13px"></ul>
+      <p class="text-sm text-muted" style="margin-top:4px">Up to ${EMAIL_ATTACH_MAX_FILES} files, ${_fmtBytes(EMAIL_ATTACH_MAX_TOTAL_BYTES)} total. Attachments don't persist if you go back to edit.</p>
+    </div>`;
+}
+
+// In-memory store of File objects added so far. Cleared on modal open.
+let _emailAttachmentsBuffer = [];
+
+function _resetEmailAttachments() { _emailAttachmentsBuffer = []; }
+
+function _addEmailAttachments(input) {
+  const files = Array.from(input.files || []);
+  // Each picked file gets validated against the per-file cap; the chooser is
+  // additive (subsequent picks append), so we re-check totals every time.
+  for (const f of files) {
+    if (f.size > EMAIL_ATTACH_MAX_FILE_BYTES) {
+      toast(`"${f.name}" exceeds ${_fmtBytes(EMAIL_ATTACH_MAX_FILE_BYTES)} limit`, 'error');
+      continue;
+    }
+    if (_emailAttachmentsBuffer.length >= EMAIL_ATTACH_MAX_FILES) {
+      toast(`Max ${EMAIL_ATTACH_MAX_FILES} attachments`, 'error');
+      break;
+    }
+    _emailAttachmentsBuffer.push(f);
+  }
+  const total = _emailAttachmentsBuffer.reduce((s, f) => s + f.size, 0);
+  if (total > EMAIL_ATTACH_MAX_TOTAL_BYTES) {
+    // Pop until under limit.
+    while (_emailAttachmentsBuffer.length > 0
+        && _emailAttachmentsBuffer.reduce((s, f) => s + f.size, 0) > EMAIL_ATTACH_MAX_TOTAL_BYTES) {
+      const popped = _emailAttachmentsBuffer.pop();
+      toast(`"${popped.name}" not added — would exceed ${_fmtBytes(EMAIL_ATTACH_MAX_TOTAL_BYTES)} total`, 'error');
+    }
+  }
+  input.value = '';  // Reset so the same filename can be picked again later.
+  _renderEmailAttachments();
+}
+
+function _removeEmailAttachment(index) {
+  _emailAttachmentsBuffer.splice(index, 1);
+  _renderEmailAttachments();
+}
+
+function _renderEmailAttachments() {
+  const list = document.getElementById('f-email-attach-list');
+  const sum  = document.getElementById('f-email-attach-summary');
+  if (!list || !sum) return;
+  if (_emailAttachmentsBuffer.length === 0) {
+    list.innerHTML = '';
+    sum.textContent = '';
+    return;
+  }
+  const totalBytes = _emailAttachmentsBuffer.reduce((s, f) => s + f.size, 0);
+  sum.textContent = `${_emailAttachmentsBuffer.length} file${_emailAttachmentsBuffer.length !== 1 ? 's' : ''}, ${_fmtBytes(totalBytes)}`;
+  list.innerHTML = _emailAttachmentsBuffer.map((f, i) =>
+    `<li style="display:flex;align-items:center;gap:8px;padding:4px 0">
+      <span style="flex:1">${esc(f.name)}</span>
+      <span class="text-muted text-sm">${_fmtBytes(f.size)}</span>
+      <button type="button" class="btn btn-ghost btn-sm text-danger" onclick="_removeEmailAttachment(${i})">Remove</button>
+    </li>`).join('');
+}
+
+// Build a FormData body with text fields + the in-memory attachment files,
+// then POST without setting Content-Type (lets the browser set the
+// multipart boundary). Returns the parsed JSON or throws.
+async function _postEmailFormData(path, fields) {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) {
+    if (v === undefined || v === null) continue;
+    if (Array.isArray(v) || (typeof v === 'object' && !(v instanceof File) && !(v instanceof Blob))) {
+      fd.append(k, JSON.stringify(v));
+    } else {
+      fd.append(k, v);
+    }
+  }
+  for (const f of _emailAttachmentsBuffer) fd.append('attachments', f);
+  const res = await fetch(BASE_PATH + path, {
+    method: 'POST',
+    headers: { 'X-Requested-With': 'XMLHttpRequest' },
+    body: fd,
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+  return data;
+}
+
+function _attachmentSummaryHtml() {
+  if (_emailAttachmentsBuffer.length === 0) return '';
+  const totalBytes = _emailAttachmentsBuffer.reduce((s, f) => s + f.size, 0);
+  return `
+    <div class="form-group">
+      <label>Attachments</label>
+      <ul class="text-sm" style="list-style:none;padding:0;margin:0;color:var(--text-secondary)">
+        ${_emailAttachmentsBuffer.map(f => `<li>${esc(f.name)} <span class="text-muted">— ${_fmtBytes(f.size)}</span></li>`).join('')}
+      </ul>
+      <p class="text-sm text-muted" style="margin-top:4px">${_emailAttachmentsBuffer.length} file${_emailAttachmentsBuffer.length !== 1 ? 's' : ''}, ${_fmtBytes(totalBytes)} total</p>
+    </div>`;
+}
+
 function openEmailCompose(accountId, draft) {
   const acct = state.accounts.find(a => a.ID === accountId);
   if (!acct) return;
@@ -1590,6 +1714,10 @@ function openEmailCompose(accountId, draft) {
   const initialBody    = draft?.body    || '';
   const initialFrom    = draft?.fromEmail || '';
 
+  // Reset the attachment buffer when opening from scratch (no draft), but
+  // keep existing files if reopening via "Back to Edit" (draft truthy).
+  if (!draft) _resetEmailAttachments();
+
   const formHtml = `
     <div class="form-group">
       <label>To${ccEmails.length > 0 ? ' / Cc' : ''}</label>
@@ -1607,7 +1735,8 @@ function openEmailCompose(accountId, draft) {
     <div class="form-group">
       <label>Message <span class="required">*</span></label>
       <textarea class="form-control" id="f-email-body" rows="8" placeholder="Type your message...">${esc(initialBody)}</textarea>
-    </div>`;
+    </div>
+    ${_attachmentFieldHtml()}`;
 
   modal.open('Send Email', formHtml, () => {
     const subject   = val('f-email-subject');
@@ -1635,11 +1764,12 @@ function openEmailCompose(accountId, draft) {
       <div class="form-group">
         <label>Message</label>
         ${_emailBodyPreviewHtml(body)}
-      </div>`;
+      </div>
+      ${_attachmentSummaryHtml()}`;
 
     modal.open('Confirm Send', confirmHtml, async () => {
       try {
-        await api.post('/api/email/send', {
+        await _postEmailFormData('/api/email/send', {
           to:          primaryEmail,
           cc:          ccEmails.length > 0 ? ccEmails : undefined,
           subject,
@@ -1649,6 +1779,7 @@ function openEmailCompose(accountId, draft) {
           accountName: acct.Name,
         });
         modal.close();
+        _resetEmailAttachments();
         toast('Email sent successfully');
         if (state.view === 'account-profile') loadAccountProfile(state.accountProfileId);
       } catch (err) {
@@ -1669,6 +1800,8 @@ function openEmailCompose(accountId, draft) {
       };
     }
   }, 'Send');
+  // Render any already-staged attachments (e.g. survived Back-to-Edit).
+  _renderEmailAttachments();
 }
 
 function openBulkEmail(draft) {
@@ -1710,6 +1843,9 @@ function openBulkEmail(draft) {
   const initialBody    = draft?.body    || '';
   const initialFrom    = draft?.fromEmail || '';
 
+  // Reset the attachment buffer when opening from scratch (no draft).
+  if (!draft) _resetEmailAttachments();
+
   const formHtml = `
     ${warningHtml}
     <div class="form-group">
@@ -1730,7 +1866,8 @@ function openBulkEmail(draft) {
     <div class="form-group">
       <label>Message <span class="required">*</span></label>
       <textarea class="form-control" id="f-email-body" rows="8" placeholder="Type your message...">${esc(initialBody)}</textarea>
-    </div>`;
+    </div>
+    ${_attachmentFieldHtml()}`;
 
   modal.open('Send Bulk Email', formHtml, () => {
     const subject   = val('f-email-subject');
@@ -1762,7 +1899,8 @@ function openBulkEmail(draft) {
       <div class="form-group">
         <label>Message</label>
         ${_emailBodyPreviewHtml(body)}
-      </div>`;
+      </div>
+      ${_attachmentSummaryHtml()}`;
 
     const recipients = withEmail.map(a => ({
       email:            a.Email,
@@ -1773,8 +1911,9 @@ function openBulkEmail(draft) {
 
     modal.open('Confirm Send', confirmHtml, async () => {
       try {
-        const result = await api.post('/api/email/bulk', { recipients, subject, body, fromEmail });
+        const result = await _postEmailFormData('/api/email/bulk', { recipients, subject, body, fromEmail });
         modal.close();
+        _resetEmailAttachments();
         toast(`Email sent to ${result.sent} address${result.sent !== 1 ? 'es' : ''}`);
         document.querySelectorAll('.acct-select:checked').forEach(cb => { cb.checked = false; });
         updateBulkEmailBar();
@@ -1791,6 +1930,8 @@ function openBulkEmail(draft) {
       };
     }
   }, 'Send');
+  // Render any already-staged attachments (e.g. survived Back-to-Edit).
+  _renderEmailAttachments();
 }
 
 // ── Merge Account ─────────────────────────────────────────────────

--- a/routes/email.js
+++ b/routes/email.js
@@ -1,11 +1,43 @@
 'use strict';
 
 const express = require('express');
+const multer = require('multer');
 const { v4: uuidv4 } = require('uuid');
 const { addRow, updateRow, getAllRows } = require('../db');
 const { isEmailConfigured, sendEmail } = require('../email-service');
 
 const router = express.Router();
+
+// Gmail's per-message hard limit is 25 MB. Cap each file at 20 MB and the
+// whole request at 25 MB to leave headroom for base64 inflation (~33%) and
+// MIME overhead. Files live in memory; nothing is persisted to disk.
+const MAX_FILE_BYTES = 20 * 1024 * 1024;
+const MAX_REQUEST_BYTES = 25 * 1024 * 1024;
+const emailUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_FILE_BYTES, files: 10, fieldSize: 1024 * 1024 },
+}).array('attachments', 10);
+
+// Wrap multer in a middleware that surfaces friendly errors and rejects
+// total payloads exceeding MAX_REQUEST_BYTES (multer's `fileSize` is per
+// file; we want a combined cap so a user can't attach 5×20MB).
+function uploadAttachments(req, res, next) {
+  emailUpload(req, res, (err) => {
+    if (err) {
+      const msg = err.code === 'LIMIT_FILE_SIZE'
+        ? 'Attachment exceeds 20 MB limit'
+        : err.code === 'LIMIT_FILE_COUNT'
+        ? 'Too many attachments (max 10)'
+        : err.message;
+      return res.status(400).json({ error: msg });
+    }
+    const totalBytes = (req.files || []).reduce((s, f) => s + f.size, 0);
+    if (totalBytes > MAX_REQUEST_BYTES) {
+      return res.status(400).json({ error: 'Attachments exceed 25 MB total' });
+    }
+    next();
+  });
+}
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -71,8 +103,30 @@ router.get('/status', (req, res) => {
   res.json({ configured: isEmailConfigured() });
 });
 
-// POST /api/email/send — Send individual email to one account
-router.post('/send', async (req, res) => {
+// Decode an array field that may arrive as either a JSON string (multipart
+// form-data) or an already-parsed array (legacy application/json caller).
+function parseMaybeJsonArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.filter(Boolean);
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter(Boolean) : [];
+  } catch { return []; }
+}
+
+// Convert Multer file rows into the shape sendEmail expects.
+function mapAttachments(files) {
+  return (files || []).map(f => ({
+    filename: f.originalname,
+    mimeType: f.mimetype,
+    content:  f.buffer,
+  }));
+}
+
+// POST /api/email/send — Send individual email to one account.
+// Accepts multipart/form-data for attachments; legacy JSON callers without
+// files still work because multer just leaves req.body as the form fields.
+router.post('/send', uploadAttachments, async (req, res) => {
   try {
     if (!isEmailConfigured()) {
       return res.status(503).json({ error: 'Email is not configured. Google OAuth credentials are missing.' });
@@ -88,13 +142,14 @@ router.post('/send', async (req, res) => {
     const validatedFrom = validateFromEmail(req.user.email, fromEmail);
     const senderName  = req.user.name  || 'Brewery Team';
     const senderEmail = validatedFrom;
-    const ccEmails = Array.isArray(cc) ? cc.filter(Boolean) : [];
+    const ccEmails = parseMaybeJsonArray(cc);
+    const attachments = mapAttachments(req.files);
 
     let status = 'sent';
     let error  = '';
 
     try {
-      await sendEmail({ user: req.user, to, cc: ccEmails.length > 0 ? ccEmails : undefined, replyTo: getReplyToAddress(req.user), subject, body, fromEmail: validatedFrom });
+      await sendEmail({ user: req.user, to, cc: ccEmails.length > 0 ? ccEmails : undefined, replyTo: getReplyToAddress(req.user), subject, body, fromEmail: validatedFrom, attachments });
     } catch (err) {
       status = 'failed';
       error  = err.message;
@@ -111,6 +166,7 @@ router.post('/send', async (req, res) => {
       Body:        body,
       Type:        'individual',
       AccountIDs:  accountId || '',
+      Attachments: attachments.map(a => a.filename).join(', '),
       Status:      status,
       Error:       error,
       CreatedAt:   new Date().toISOString(),
@@ -133,17 +189,19 @@ router.post('/send', async (req, res) => {
   }
 });
 
-// POST /api/email/bulk — Send bulk email to multiple accounts via BCC
-router.post('/bulk', async (req, res) => {
+// POST /api/email/bulk — Send bulk email to multiple accounts via BCC.
+// Accepts multipart/form-data; `recipients` is sent as a JSON string field.
+router.post('/bulk', uploadAttachments, async (req, res) => {
   try {
     if (!isEmailConfigured()) {
       return res.status(503).json({ error: 'Email is not configured. Google OAuth credentials are missing.' });
     }
 
-    const { recipients, subject, body, fromEmail } = req.body;
+    const { subject, body, fromEmail } = req.body;
+    const recipients = parseMaybeJsonArray(req.body.recipients);
     // recipients: [{ email, additionalEmails, accountId, accountName }, ...]
 
-    if (!recipients || !Array.isArray(recipients) || recipients.length === 0) {
+    if (!recipients || recipients.length === 0) {
       return res.status(400).json({ error: 'At least one recipient is required' });
     }
     if (!subject) return res.status(400).json({ error: 'Subject is required' });
@@ -167,12 +225,13 @@ router.post('/bulk', async (req, res) => {
 
     const senderName  = req.user.name  || 'Brewery Team';
     const senderEmail = validatedFrom;
+    const attachments = mapAttachments(req.files);
 
     let status = 'sent';
     let error  = '';
 
     try {
-      await sendEmail({ user: req.user, bcc: bccEmails, replyTo: getReplyToAddress(req.user), subject, body, fromEmail: validatedFrom });
+      await sendEmail({ user: req.user, bcc: bccEmails, replyTo: getReplyToAddress(req.user), subject, body, fromEmail: validatedFrom, attachments });
     } catch (err) {
       status = 'failed';
       error  = err.message;
@@ -188,6 +247,7 @@ router.post('/bulk', async (req, res) => {
       Body:        body,
       Type:        'bulk',
       AccountIDs:  recipients.map(r => r.accountId).join(', '),
+      Attachments: attachments.map(a => a.filename).join(', '),
       Status:      status,
       Error:       error,
       CreatedAt:   new Date().toISOString(),


### PR DESCRIPTION
## Summary
Closes #433. Both the single-account Email modal and the bulk **Email Selected** modal now accept up to 10 file attachments (20 MB per file, 25 MB total) that travel through Gmail as proper multipart/mixed messages.

## Server
- \`email-service.buildRawMessage\` now emits \`multipart/mixed\` when an \`attachments\` array is provided, with each file as a base64-encoded part. No-attachment sends keep the existing single-part shape, so other callers (e.g. QBO invoice sends) are unchanged.
- \`routes/email\` accepts \`multipart/form-data\` via a multer middleware with per-file (20 MB) and per-request (25 MB) caps. Files live in memory and are discarded after the Gmail API call — nothing persisted to disk. \`recipients\` / \`cc\` arrive as JSON strings under multipart and are parsed defensively (also still works if called with JSON for any future caller).
- \`EMAIL_LOG\` gains an \`Attachments\` column listing filenames sent (auto-migrates on boot).

## Client
- Shared file picker + chosen-file list (filename + size + Remove) in both modals.
- Validation matches the server caps: 20 MB per file, 25 MB total, 10 files max. Friendly toasts when over.
- Submit goes through a new \`_postEmailFormData\` helper that builds a FormData and POSTs without setting Content-Type (browser supplies the multipart boundary).
- The existing confirm-before-send step from #391 now shows an Attachments summary.
- Files survive **Back to Edit** (preserved in module buffer). Reset on fresh open and after a successful send.

## Out of scope
- Attachment previews / thumbnails.
- Persisting attachments after send (history shows filenames only).
- Drag-and-drop. Standard file picker only for v1.

## Test plan
- [ ] Single-send with no attachment → behaves exactly as before (plain text/plain email)
- [ ] Single-send with a PDF → recipient gets the email with the PDF attached, opens correctly
- [ ] Bulk send to 3+ accounts with a PDF → all recipients receive the attachment (BCC)
- [ ] Attach a 25 MB file → friendly client-side error before upload
- [ ] Attach 10 files then try an 11th → blocked
- [ ] Attach a file with a non-ASCII filename → arrives with the right name
- [ ] Confirm step shows the attachments list
- [ ] Back to Edit preserves attachments
- [ ] Successful send clears the attachment buffer; opening the modal again starts empty
- [ ] EMAIL_LOG row records the filenames in the Attachments column
- [ ] QBO invoice send (existing flow) unaffected (no attachment param passed = single-part email)

🤖 Generated with [Claude Code](https://claude.com/claude-code)