### PR TITLE
Friendly errors on non-JSON server responses + nginx upload-size note

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -178,6 +178,12 @@ server {
     listen 80;
     server_name app.yourbrewery.com;
 
+    # The app accepts uploads (PDF invoice imports, email attachments) up to
+    # 25 MB. nginx's default cap is 1 MB and rejects larger requests with
+    # an HTML 413 page before they reach the app — set the cap a bit above
+    # the app's own limit to leave headroom for multipart overhead.
+    client_max_body_size 30M;
+
     location / {
         proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;

--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -1674,8 +1674,19 @@ async function _postEmailFormData(path, fields) {
     headers: { 'X-Requested-With': 'XMLHttpRequest' },
     body: fd,
   });
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+  // Read raw text first so a non-JSON response (e.g. an nginx 413 HTML page
+  // when the upload exceeds client_max_body_size) can be translated into
+  // something readable instead of "Unexpected token '<'".
+  const text = await res.text();
+  let data;
+  try { data = text ? JSON.parse(text) : {}; } catch { data = null; }
+  if (data && data.error && !res.ok) throw new Error(data.error);
+  if (!res.ok) {
+    if (res.status === 413) {
+      throw new Error(`Attachments rejected — upload too large for the server (HTTP 413). Try smaller files.`);
+    }
+    throw new Error(`Server error (HTTP ${res.status}). Check your connection and try again.`);
+  }
   return data;
 }
 

--- a/public/js/core.js
+++ b/public/js/core.js
@@ -290,8 +290,17 @@ const api = {
     const opts = { method, headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' } };
     if (body) opts.body = JSON.stringify(body);
     const res = await fetch(BASE_PATH + path, opts);
-    const data = await res.json();
-    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+    // Read as text first so a non-JSON response (e.g. an nginx 413/502 HTML
+    // page or a proxy timeout) becomes a readable error instead of
+    // "Unexpected token '<' is not valid JSON".
+    const text = await res.text();
+    let data;
+    try { data = text ? JSON.parse(text) : {}; } catch { data = null; }
+    if (!res.ok) {
+      if (data && data.error) throw new Error(data.error);
+      if (res.status === 413) throw new Error('Upload too large for the server (HTTP 413).');
+      throw new Error(`Server error (HTTP ${res.status}). Check your connection and try again.`);
+    }
     return data;
   },
   get:    (p)    => api.req('GET', p),


### PR DESCRIPTION
## Summary
Follow-up to #434. A 1.1 MB attachment upload failed in production with the cryptic \`Failed to send email: Unexpected token '<', \"<html><h\"... is not valid JSON\`. Root cause was nginx's default \`client_max_body_size\` of 1 MB rejecting the request with an HTML 413 page before it ever reached the app.

The actual fix is the server-side nginx bump (already applied to the droplet). This PR makes sure neither problem recurs invisibly:

## Changes

**DEPLOYMENT.md** — adds \`client_max_body_size 30M;\` to the documented nginx server block, with a comment explaining why (PDF imports, email attachments, invoice resends all push >1 MB). 30 MB leaves headroom above the app's own 25 MB cap for multipart overhead.

**Client error handling** — both the FormData uploader (\`_postEmailFormData\`) and the global \`api.req\` helper now read the response as text first, then attempt JSON.parse. On non-JSON responses:
- 413 → "Upload too large for the server (HTTP 413)" / "Attachments rejected — upload too large for the server (HTTP 413). Try smaller files."
- Other non-2xx → "Server error (HTTP NNN). Check your connection and try again."

No more \`Unexpected token '<'\` toasts anywhere in the app.

## Test plan
- [ ] Send a small email → still works (toast: "Email sent successfully")
- [ ] Send an email with an attachment that fits — works
- [ ] Send an email with an attachment >25 MB → friendly "too large" toast (not raw JSON error)
- [ ] Any other API call returning HTML (proxy timeout, gateway error) → friendly toast with status code
- [ ] Fresh nginx config from DEPLOYMENT.md accepts a 5 MB upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)