### PR TITLE
Reports: add Taxable Only filter (closes #436)

### DIFF
--- a/public/js/reports.js
+++ b/public/js/reports.js
@@ -5,6 +5,7 @@
 let _reportsPreset = 'this-month';
 let _reportsStart = '';
 let _reportsEnd = '';
+let _reportsTaxableOnly = false;
 let _reportsData = null;
 let _reportCharts = {};
 
@@ -32,6 +33,7 @@ async function loadReports() {
   try {
     const params = new URLSearchParams({ start: _reportsStart, end: _reportsEnd });
     if (state.location) params.set('location', state.location);
+    if (_reportsTaxableOnly) params.set('taxableOnly', '1');
     _reportsData = await api.get('/api/reports?' + params.toString());
     renderReports();
   } catch (err) {
@@ -65,7 +67,7 @@ function renderReports() {
     <div class="view-header">
       <div>
         <h2>Reports</h2>
-        <div class="subtitle">${esc(formatDate(_reportsStart))} — ${esc(formatDate(_reportsEnd))}</div>
+        <div class="subtitle">${esc(formatDate(_reportsStart))} — ${esc(formatDate(_reportsEnd))}${_reportsTaxableOnly ? ' · <strong>Taxable Only</strong>' : ''}</div>
       </div>
       <div class="view-header-actions">
         <button class="btn btn-secondary" onclick="_reportsExportCsv()">Export CSV</button>
@@ -77,6 +79,10 @@ function renderReports() {
         ${presetOptions.map(([v, l]) => `<option value="${v}" ${v === _reportsPreset ? 'selected' : ''}>${l}</option>`).join('')}
       </select>
       ${customInputs}
+      <select id="reports-taxable" onchange="_reportsTaxableChange(this.value)" title="Filter to orders that had tax applied">
+        <option value="all" ${!_reportsTaxableOnly ? 'selected' : ''}>All Sales</option>
+        <option value="taxable" ${_reportsTaxableOnly ? 'selected' : ''}>Taxable Only</option>
+      </select>
     </div>
 
     <div class="stats-grid">
@@ -144,6 +150,11 @@ function _reportsCustomDate() {
     _reportsEnd = e;
     loadReports();
   }
+}
+
+function _reportsTaxableChange(value) {
+  _reportsTaxableOnly = value === 'taxable';
+  loadReports();
 }
 
 // ── Chart colors ────────────────────────────────────────────────

--- a/routes/reports.js
+++ b/routes/reports.js
@@ -21,6 +21,7 @@ function bucketKey(dateStr, granularity) {
 router.get('/', async (req, res) => {
   try {
     const { start, end, location } = req.query;
+    const taxableOnly = req.query.taxableOnly === '1' || req.query.taxableOnly === 'true';
     if (!start || !end) return res.status(400).json({ error: 'start and end query params required' });
 
     let [orders, orderItems, stockMovements, accounts, inventory, staff, products] = await Promise.all([
@@ -50,7 +51,13 @@ router.get('/', async (req, res) => {
       const d = (o.OrderDate || '').substring(0, 10);
       return d >= start && d <= end;
     });
-    const salesOrders = dateFilteredOrders.filter(o => o.Status !== 'Cancelled' && o.Status !== 'Pre-Sale' && o.Status !== 'Draft');
+    let salesOrders = dateFilteredOrders.filter(o => o.Status !== 'Cancelled' && o.Status !== 'Pre-Sale' && o.Status !== 'Draft');
+    // taxableOnly: state agencies require gross-sales reporting for taxable
+    // sales only; this narrows to orders that actually had tax applied so
+    // the brewery can pull both tax collected and the matching subtotal.
+    if (taxableOnly) {
+      salesOrders = salesOrders.filter(o => parseFloat(o.TaxAmount || 0) > 0);
+    }
 
     // Build sets for quick lookups
     const salesOrderIds = new Set(salesOrders.map(o => o.ID));


### PR DESCRIPTION
## Summary
Closes #436. State agencies require gross-sales reporting for taxable sales — the brewery needs to see both the tax collected and the subtotal the tax came from. Adds a Taxable Only filter to the Reports screen.

## Changes
- **\`routes/reports.js\`**: accepts \`taxableOnly=1\` query param. When present, narrows \`salesOrders\` to those with \`TaxAmount > 0\`. Top Products / Account Activity / Gallonage / Sales by Rep / Sales Summary all derive from \`salesOrders\` or \`salesOrderIds\`, so they auto-narrow with no further plumbing.
- **\`public/js/reports.js\`**: new "All Sales" / "Taxable Only" dropdown in the filter bar. Module-level flag persists across re-renders. Subtitle adds a "Taxable Only" indicator when active.

## Test plan
- [ ] Default ("All Sales") → numbers match what's currently shown (no regression)
- [ ] Switch to "Taxable Only" → Orders / Total Revenue / Paid Revenue / Awaiting Payment all shrink to just the taxable subset
- [ ] Tax Collected stat → matches the sum of \`TaxAmount\` for the taxable subset (which is also what the brewery files with the state)
- [ ] Subtitle reads "... · **Taxable Only**" when active
- [ ] Top Products / Account Activity / Sales by Rep tables reflect only taxable orders
- [ ] Export CSV — exports the currently-filtered data set
- [ ] Switch back to "All Sales" → numbers expand again

🤖 Generated with [Claude Code](https://claude.com/claude-code)