### PR TITLE
Surface todo completion dates: sort + always show

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -826,7 +826,7 @@ function renderProfileTodos() {
     : pg.rows.map(t => `<tr class="${t.Completed === 'true' ? 'row-completed' : ''}">
         <td class="fw-600"><span class="td-link" onclick="profileEditTodo('${esc(t.ID)}')">${esc(t.Title)}</span>${t.Recurrence && t.Recurrence !== 'none' ? ' <span class="badge badge-recurrence" title="Recurring">↻</span>' : ''}</td>
         <td class="mobile-hide">${typeBadge(t.Type) || '—'}</td>
-        <td>${urgencyBadge(t.DueDate, t.Completed)}${t.Completed === 'true' && t.CompletedAt ? `<br><span class="text-muted text-sm">Done ${formatDate(t.CompletedAt)}</span>` : ''}</td>
+        <td>${urgencyBadge(t.DueDate, t.Completed)}${t.Completed === 'true' ? `<br><span class="text-muted text-sm">${t.CompletedAt ? 'Done ' + formatDate(t.CompletedAt) : 'Done (date unknown)'}</span>` : ''}</td>
         <td class="mobile-hide">${priorityBadge(t.Priority)}</td>
         <td class="mobile-hide text-sm text-muted">${esc(t.Notes) || '—'}</td>
         <td class="td-actions">

--- a/public/js/todos.js
+++ b/public/js/todos.js
@@ -180,7 +180,7 @@ function renderTodos() {
           ${pg.total === 0 ? `<tr><td colspan="9" class="empty-state">No todos found.</td></tr>` :
             pg.rows.map(r => `<tr>
               <td><input type="checkbox" class="todo-row-checkbox" data-id="${esc(r.ID)}" ${_todoSelection.has(r.ID) ? 'checked' : ''} onchange="toggleTodoSelection('${esc(r.ID)}', this.checked)" /></td>
-              <td>${formatDate(r.DueDate)}${r.Completed === 'true' && r.CompletedAt ? `<br><span class="text-muted text-sm">Done ${formatDate(r.CompletedAt)}</span>` : ''}</td>
+              <td>${formatDate(r.DueDate)}${r.Completed === 'true' ? `<br><span class="text-muted text-sm">${r.CompletedAt ? 'Done ' + formatDate(r.CompletedAt) : 'Done (date unknown)'}</span>` : ''}</td>
               <td class="mobile-hide">${urgencyBadge(r.DueDate, r.Completed)}</td>
               <td class="fw-600"><span class="td-link" onclick="openEditTodo('${esc(r.ID)}')">${esc(r.Title)}</span>${r.Recurrence && r.Recurrence !== 'none' ? ` <span class="badge badge-recurrence" title="${esc(RECURRENCE_OPTIONS.find(o => o.value === r.Recurrence)?.label || r.Recurrence)}">↻</span>` : ''}</td>
               <td class="mobile-hide text-sm">${r.AccountID ? `<span class="td-link" onclick="loadAccountProfile('${esc(r.AccountID)}')">${esc(r.AccountName)}</span>` : '—'}</td>

--- a/routes/reminders.js
+++ b/routes/reminders.js
@@ -33,12 +33,23 @@ router.get('/', async (req, res) => {
       items = items.filter(r => r.Completed === 'true');
     }
 
-    // Sort: open todos first, then by due date ascending
+    // Sort: open todos first (by due date ASC — next up at the top), then
+    // completed todos (by CompletedAt DESC — most recently done at the top
+    // so users can quickly see "when did I last do this?", especially for
+    // recurring todos). Legacy completed rows without CompletedAt fall back
+    // to DueDate so they sort in a stable, predictable order at the bottom.
     items.sort((a, b) => {
       const aDone = a.Completed === 'true' ? 1 : 0;
       const bDone = b.Completed === 'true' ? 1 : 0;
       if (aDone !== bDone) return aDone - bDone;
-      return (a.DueDate || '').localeCompare(b.DueDate || '');
+      if (aDone === 0) {
+        // Both open
+        return (a.DueDate || '').localeCompare(b.DueDate || '');
+      }
+      // Both completed: newest completion first.
+      const aKey = a.CompletedAt || a.DueDate || '';
+      const bKey = b.CompletedAt || b.DueDate || '';
+      return bKey.localeCompare(aKey);
     });
     res.json(items);
   } catch (err) {


### PR DESCRIPTION
## Summary
Two related improvements to make "when was this last done?" answerable from the Todos list — especially for recurring todos where multiple completed rows accumulate.

### 1. Sort completed todos by completion date desc
The server sorted done todos by \`DueDate ASC\`, which buried recently-completed work below long-finished historical rows — the opposite of useful. Now:
- **Open** todos sort by \`DueDate ASC\` (next up first, unchanged).
- **Completed** todos sort by \`CompletedAt DESC\` (most recent first). Rows without \`CompletedAt\` (legacy data pre-#414) fall back to \`DueDate\` so the order is stable.

### 2. Always show completion status in the UI
On the main Todos page and the account-profile Todos section, the "Done MM/DD/YYYY" subtitle only rendered when \`CompletedAt\` was populated. Legacy rows showed a bare "Done" badge with no date — easy to mistake for a broken feature. Now those rows explicitly say "Done (date unknown)". New completions still show the real date.

## Test plan
- [ ] Account with many recurring "Check in" completions → most recently done appears at the top of the completed group
- [ ] Open todos still show next-due first
- [ ] Newly-completed todos show \`Done MM/DD/YYYY\` subtitle (unchanged)
- [ ] Old completed todos with no CompletedAt now read \`Done (date unknown)\` instead of a blank
- [ ] Account profile Todos section matches the main Todos page rendering
- [ ] Bulk Mark Done from #387 → all newly-completed rows show today's date and sort to the top of the completed group

🤖 Generated with [Claude Code](https://claude.com/claude-code)