### PR TITLE
Sink undated completed todos + display 'Done (date unknown)'

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -826,7 +826,7 @@ function renderProfileTodos() {
     : pg.rows.map(t => `<tr class="${t.Completed === 'true' ? 'row-completed' : ''}">
         <td class="fw-600"><span class="td-link" onclick="profileEditTodo('${esc(t.ID)}')">${esc(t.Title)}</span>${t.Recurrence && t.Recurrence !== 'none' ? ' <span class="badge badge-recurrence" title="Recurring">↻</span>' : ''}</td>
         <td class="mobile-hide">${typeBadge(t.Type) || '—'}</td>
-        <td>${urgencyBadge(t.DueDate, t.Completed)}${t.Completed === 'true' && t.CompletedAt ? `<br><span class="text-muted text-sm">Done ${formatDate(t.CompletedAt)}</span>` : ''}</td>
+        <td>${urgencyBadge(t.DueDate, t.Completed)}${t.Completed === 'true' ? `<br><span class="text-muted text-sm">${t.CompletedAt ? 'Done ' + formatDate(t.CompletedAt) : 'Done (date unknown)'}</span>` : ''}</td>
         <td class="mobile-hide">${priorityBadge(t.Priority)}</td>
         <td class="mobile-hide text-sm text-muted">${esc(t.Notes) || '—'}</td>
         <td class="td-actions">

--- a/public/js/todos.js
+++ b/public/js/todos.js
@@ -180,7 +180,7 @@ function renderTodos() {
           ${pg.total === 0 ? `<tr><td colspan="9" class="empty-state">No todos found.</td></tr>` :
             pg.rows.map(r => `<tr>
               <td><input type="checkbox" class="todo-row-checkbox" data-id="${esc(r.ID)}" ${_todoSelection.has(r.ID) ? 'checked' : ''} onchange="toggleTodoSelection('${esc(r.ID)}', this.checked)" /></td>
-              <td>${formatDate(r.DueDate)}${r.Completed === 'true' && r.CompletedAt ? `<br><span class="text-muted text-sm">Done ${formatDate(r.CompletedAt)}</span>` : ''}</td>
+              <td>${formatDate(r.DueDate)}${r.Completed === 'true' ? `<br><span class="text-muted text-sm">${r.CompletedAt ? 'Done ' + formatDate(r.CompletedAt) : 'Done (date unknown)'}</span>` : ''}</td>
               <td class="mobile-hide">${urgencyBadge(r.DueDate, r.Completed)}</td>
               <td class="fw-600"><span class="td-link" onclick="openEditTodo('${esc(r.ID)}')">${esc(r.Title)}</span>${r.Recurrence && r.Recurrence !== 'none' ? ` <span class="badge badge-recurrence" title="${esc(RECURRENCE_OPTIONS.find(o => o.value === r.Recurrence)?.label || r.Recurrence)}">↻</span>` : ''}</td>
               <td class="mobile-hide text-sm">${r.AccountID ? `<span class="td-link" onclick="loadAccountProfile('${esc(r.AccountID)}')">${esc(r.AccountName)}</span>` : '—'}</td>

--- a/routes/reminders.js
+++ b/routes/reminders.js
@@ -36,20 +36,26 @@ router.get('/', async (req, res) => {
     // Sort: open todos first (by due date ASC — next up at the top), then
     // completed todos (by CompletedAt DESC — most recently done at the top
     // so users can quickly see "when did I last do this?", especially for
-    // recurring todos). Legacy completed rows without CompletedAt fall back
-    // to DueDate so they sort in a stable, predictable order at the bottom.
+    // recurring todos). Completed rows without a CompletedAt value (legacy
+    // data from before #414) sink to the bottom of the completed group —
+    // we know they're older but we don't know when, so we shouldn't claim
+    // they're newest just because their empty string sorts high.
     items.sort((a, b) => {
       const aDone = a.Completed === 'true' ? 1 : 0;
       const bDone = b.Completed === 'true' ? 1 : 0;
       if (aDone !== bDone) return aDone - bDone;
       if (aDone === 0) {
-        // Both open
+        // Both open: due soonest first.
         return (a.DueDate || '').localeCompare(b.DueDate || '');
       }
-      // Both completed: newest completion first.
-      const aKey = a.CompletedAt || a.DueDate || '';
-      const bKey = b.CompletedAt || b.DueDate || '';
-      return bKey.localeCompare(aKey);
+      // Both completed.
+      const aHas = !!a.CompletedAt;
+      const bHas = !!b.CompletedAt;
+      if (aHas !== bHas) return aHas ? -1 : 1;  // dated rows first
+      if (aHas) return b.CompletedAt.localeCompare(a.CompletedAt);  // newest first
+      // Neither has CompletedAt — keep a stable fallback by DueDate desc
+      // so two undated rows don't shuffle randomly between requests.
+      return (b.DueDate || '').localeCompare(a.DueDate || '');
     });
     res.json(items);
   } catch (err) {


### PR DESCRIPTION
## Summary
Follow-up to #438. Two related fixes for the legacy-row edge case:

### 1. Always show completion status
On both the main Todos page and the account-profile Todos section, the "Done MM/DD/YYYY" subtitle only rendered when \`CompletedAt\` was populated. Rows completed before #414 added that column had no \`CompletedAt\` and showed only a bare "Done" badge — easy to mistake for a broken feature. Now those rows explicitly read "Done (date unknown)".

### 2. Sink undated rows below dated ones
PR #438 fell back to \`DueDate\` when \`CompletedAt\` was missing, which let legacy rows masquerade as recently-completed (their DueDate could outrank a real recent CompletedAt depending on data). Result: old "Done (date unknown)" rows appeared above newly-completed ones — see the screenshot the user shared.

Split the completed group explicitly:
- Dated rows first, newest first (\`Done 06/29/2026\` at the top)
- Then undated rows, with \`DueDate\` desc as a stable fallback so they don't reshuffle

## Base
This PR is stacked on \`fix/todo-sort-by-completion-date\` (PR #438) — merge that first, then this rebases onto main automatically.

## Test plan
- [ ] Account with mix of dated + undated completions → dated rows appear before undated ones
- [ ] Dated completions sort newest-first among themselves
- [ ] Undated completions sort DueDate-desc as a stable fallback (no shuffling between requests)
- [ ] Account profile Todos table shows "Done MM/DD/YYYY" on dated rows and "Done (date unknown)" on undated rows
- [ ] Main Todos page matches the same rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)