### PR TITLE
Sink undated completed todos + mirror sort on account profile

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -456,13 +456,22 @@ async function loadAccountProfile(accountId) {
   const acctOutreach = outreach
     .filter(o => o.AccountID === accountId)
     .sort((a, b) => (b.Date || '').localeCompare(a.Date || ''));
+  // Mirrors routes/reminders.js sort: open todos first (due-soonest first),
+  // then completed with CompletedAt DESC, then any legacy completed rows
+  // without CompletedAt at the bottom (sorted by DueDate desc as a stable
+  // fallback).
   const acctTodos = todos
     .filter(t => t.AccountID === accountId)
     .sort((a, b) => {
       const aDone = a.Completed === 'true' ? 1 : 0;
       const bDone = b.Completed === 'true' ? 1 : 0;
       if (aDone !== bDone) return aDone - bDone;
-      return (a.DueDate || '').localeCompare(b.DueDate || '');
+      if (aDone === 0) return (a.DueDate || '').localeCompare(b.DueDate || '');
+      const aHas = !!a.CompletedAt;
+      const bHas = !!b.CompletedAt;
+      if (aHas !== bHas) return aHas ? -1 : 1;
+      if (aHas) return b.CompletedAt.localeCompare(a.CompletedAt);
+      return (b.DueDate || '').localeCompare(a.DueDate || '');
     });
   const acctOrders = orders
     .filter(s => s.AccountID === accountId)

--- a/routes/reminders.js
+++ b/routes/reminders.js
@@ -36,20 +36,26 @@ router.get('/', async (req, res) => {
     // Sort: open todos first (by due date ASC — next up at the top), then
     // completed todos (by CompletedAt DESC — most recently done at the top
     // so users can quickly see "when did I last do this?", especially for
-    // recurring todos). Legacy completed rows without CompletedAt fall back
-    // to DueDate so they sort in a stable, predictable order at the bottom.
+    // recurring todos). Completed rows without a CompletedAt value (legacy
+    // data from before #414) sink to the bottom of the completed group —
+    // we know they're older but we don't know when, so we shouldn't claim
+    // they're newest just because their empty string sorts high.
     items.sort((a, b) => {
       const aDone = a.Completed === 'true' ? 1 : 0;
       const bDone = b.Completed === 'true' ? 1 : 0;
       if (aDone !== bDone) return aDone - bDone;
       if (aDone === 0) {
-        // Both open
+        // Both open: due soonest first.
         return (a.DueDate || '').localeCompare(b.DueDate || '');
       }
-      // Both completed: newest completion first.
-      const aKey = a.CompletedAt || a.DueDate || '';
-      const bKey = b.CompletedAt || b.DueDate || '';
-      return bKey.localeCompare(aKey);
+      // Both completed.
+      const aHas = !!a.CompletedAt;
+      const bHas = !!b.CompletedAt;
+      if (aHas !== bHas) return aHas ? -1 : 1;  // dated rows first
+      if (aHas) return b.CompletedAt.localeCompare(a.CompletedAt);  // newest first
+      // Neither has CompletedAt — keep a stable fallback by DueDate desc
+      // so two undated rows don't shuffle randomly between requests.
+      return (b.DueDate || '').localeCompare(a.DueDate || '');
     });
     res.json(items);
   } catch (err) {


### PR DESCRIPTION
## Summary
Re-applies two fixes from the earlier #439 branch that didn't end up in main (PR #439 was based on the #438 branch rather than main, so when #438 merged it only brought the sort + display commits — the "sink undated" sort tweak and the account-profile mirror were left behind).

### 1. Sink undated completed todos below dated ones
The earlier sort fell back to \`DueDate\` when \`CompletedAt\` was missing, which let legacy "Done (date unknown)" rows masquerade as recently-completed and appear above newly-completed ones. Split the completed group explicitly:
- Dated rows first, newest first (\`Done 06/29/2026\` at the top)
- Then undated rows, with \`DueDate\` desc as a stable fallback so they don't shuffle

### 2. Mirror the same sort on the account profile
The account profile builds its own filtered \`acctTodos\` array client-side and was still using the old "completed-by-DueDate-asc" logic, bypassing the server's sort. Mirror the same two-key sort there so both pages match.

## Test plan
- [ ] Account with mix of dated + undated completions → dated rows appear before undated ones
- [ ] Dated completions sort newest-first
- [ ] Undated rows sort \`DueDate\` desc as a stable fallback
- [ ] Main Todos page and account-profile Todos table show identical order

🤖 Generated with [Claude Code](https://claude.com/claude-code)