### PR TITLE
Don't close modal on backdrop click (closes #443)

### DIFF
--- a/public/js/core.js
+++ b/public/js/core.js
@@ -396,9 +396,9 @@ const modal = {
 
 document.getElementById('modal-close-btn').addEventListener('click', modal.close);
 document.getElementById('modal-cancel-btn').addEventListener('click', modal.close);
-document.getElementById('modal-overlay').addEventListener('click', e => {
-  if (e.target === document.getElementById('modal-overlay')) modal.close();
-});
+// Intentionally no click-outside-to-close handler: on wider modals like the
+// email composer, an accidental click on the darkened backdrop would discard
+// the in-progress message. Users still close via the X, Cancel, or Escape.
 document.addEventListener('keydown', e => {
   if (e.key === 'Escape' && !document.getElementById('modal-overlay').classList.contains('hidden')) modal.close();
 });


### PR DESCRIPTION
## Summary
Closes #443. Accidental clicks outside a modal — especially on wider modals like the email composer — discarded in-progress work. Every modal in the app is task-oriented (compose email, edit order, confirm delivery, etc.), so a stray backdrop click never means "throw this away."

## Fix
Drop the overlay click handler entirely. Users still close intentionally via:
- The X in the modal header
- The Cancel button in the footer
- The Escape key

No new state, no CSS changes.

## Test plan
- [ ] Open Send Bulk Email, type a message, click on the darkened area outside the modal → modal stays open, message preserved
- [ ] Same modal, click the X → closes
- [ ] Same modal, click Cancel → closes
- [ ] Same modal, press Escape → closes
- [ ] Regression: order edit modal, confirm delivery modal, add-todo modal — all still behave the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)