### PR TITLE
Allow linking todos to inactive accounts (closes #445)

### DIFF
--- a/public/js/core.js
+++ b/public/js/core.js
@@ -444,21 +444,32 @@ document.addEventListener('click', () => {
   document.querySelectorAll('.mobile-actions-menu.open').forEach(m => m.classList.remove('open'));
 });
 
-function accountOptions(selectedId = '', location = '') {
-  const active = state.accounts
-    .filter(a => a.Status !== 'Inactive')
-    .sort((a, b) => a.Name.localeCompare(b.Name));
-  if (!location) {
-    return active
-      .map(a => `<option value="${esc(a.ID)}" ${a.ID === selectedId ? 'selected' : ''}>${esc(a.Name)}</option>`)
-      .join('');
-  }
-  const serviced = active.filter(a => a.ServicedBy === location || !a.ServicedBy);
-  const other = active.filter(a => a.ServicedBy && a.ServicedBy !== location);
+// Render <option>s for a select of accounts.
+// - selectedId: preselect this ID
+// - location: when provided, splits active accounts into Serviced-here /
+//   Other optgroups.
+// - opts.includeInactive: when true, appends an "Inactive Accounts" optgroup
+//   after the active options. Off by default — most callers (order form,
+//   outreach, kegs, etc.) shouldn't allow assigning to closed accounts.
+function accountOptions(selectedId = '', location = '', opts = {}) {
+  const includeInactive = !!opts.includeInactive;
+  const sorted = state.accounts.slice().sort((a, b) => a.Name.localeCompare(b.Name));
+  const active   = sorted.filter(a => a.Status !== 'Inactive');
+  const inactive = sorted.filter(a => a.Status === 'Inactive');
   const optHtml = list => list.map(a => `<option value="${esc(a.ID)}" ${a.ID === selectedId ? 'selected' : ''}>${esc(a.Name)}</option>`).join('');
+
   let html = '';
-  if (serviced.length) html += `<optgroup label="Serviced by ${esc(location)}">${optHtml(serviced)}</optgroup>`;
-  if (other.length) html += `<optgroup label="Other accounts">${optHtml(other)}</optgroup>`;
+  if (!location) {
+    html += optHtml(active);
+  } else {
+    const serviced = active.filter(a => a.ServicedBy === location || !a.ServicedBy);
+    const other    = active.filter(a => a.ServicedBy && a.ServicedBy !== location);
+    if (serviced.length) html += `<optgroup label="Serviced by ${esc(location)}">${optHtml(serviced)}</optgroup>`;
+    if (other.length)    html += `<optgroup label="Other accounts">${optHtml(other)}</optgroup>`;
+  }
+  if (includeInactive && inactive.length) {
+    html += `<optgroup label="Inactive Accounts">${optHtml(inactive)}</optgroup>`;
+  }
   return html;
 }
 

--- a/public/js/todos.js
+++ b/public/js/todos.js
@@ -41,7 +41,7 @@ function todoForm(todo = {}) {
         <label>Linked Account (optional)</label>
         <select class="form-control" id="f-account">
           <option value="">-- None --</option>
-          ${accountOptions(todo.AccountID)}
+          ${accountOptions(todo.AccountID, '', { includeInactive: true })}
         </select>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Closes #445. The account dropdown in the todo form omitted Inactive accounts, so a follow-up like "Check in with Rusty Tap" couldn't be created after that account had been marked Inactive — which is exactly when that kind of todo is most useful.

## Fix
- \`accountOptions()\` gains an \`opts.includeInactive\` flag. When true, an "Inactive Accounts" optgroup is appended after the active options (matching the visual split used elsewhere in the app, e.g. In Stock / Out of Stock on the order product picker).
- Off by default so the order form, outreach, kegs, tap handles, etc. all keep hiding closed accounts — linking one from those flows doesn't make sense.
- Turn it on for the todo form.

## Test plan
- [ ] Mark an account Inactive → open Add Todo → dropdown shows an "Inactive Accounts" group at the bottom, active accounts unchanged at the top
- [ ] Save a todo linked to an inactive account → row persists with the correct AccountName; account profile still shows the todo
- [ ] Order form / Outreach / Add Kegs → inactive accounts still hidden (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)