### PR TITLE
Support merging pre-sales for the same account (closes #449)

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -886,7 +886,7 @@ function renderProfileOrders() {
           <td class="td-actions">
             <button class="btn btn-ghost btn-sm mobile-actions-toggle" onclick="toggleMobileActions(event)">&#8230;</button>
             <div class="mobile-actions-menu">
-            ${isPreSale ? `<button class="btn btn-ghost btn-sm" onclick="profileEditPreSale('${esc(s.ID)}')">Edit</button><button class="btn btn-ghost btn-sm text-success" onclick="profileConvertPreSale('${esc(s.ID)}')">Convert</button><button class="btn btn-ghost btn-sm text-danger" onclick="profileCancelPreSale('${esc(s.ID)}')">Cancel</button>`
+            ${isPreSale ? `<button class="btn btn-ghost btn-sm" onclick="profileEditPreSale('${esc(s.ID)}')">Edit</button><button class="btn btn-ghost btn-sm text-success" onclick="profileConvertPreSale('${esc(s.ID)}')">Convert</button>${_presaleHasMergePeers(s) ? `<button class="btn btn-ghost btn-sm" onclick="openMergePresales('${esc(s.ID)}')">Merge</button>` : ''}<button class="btn btn-ghost btn-sm text-danger" onclick="profileCancelPreSale('${esc(s.ID)}')">Cancel</button>`
             : `${s.Status === 'Pending' ? `<button class="btn btn-ghost btn-sm text-success" onclick="profileMarkOrderPaid('${esc(s.ID)}')">Mark Paid</button>` : ''}
             <button class="btn btn-ghost btn-sm" onclick="profileEditOrder('${esc(s.ID)}')">${s.Status === 'Paid' ? 'View' : 'Edit'}</button>
             <button class="btn btn-ghost btn-sm text-danger" onclick="profileDeleteOrder('${esc(s.ID)}')">Del</button>`}

--- a/public/js/orders.js
+++ b/public/js/orders.js
@@ -1478,7 +1478,7 @@ function renderOrders() {
                 <td class="td-actions">
                   <button class="btn btn-ghost btn-sm mobile-actions-toggle" onclick="toggleMobileActions(event)">&#8230;</button>
                   <div class="mobile-actions-menu">
-                  ${isPreSale ? `<button class="btn btn-ghost btn-sm" onclick="openEditPreSale('${esc(s.ID)}')">Edit</button><button class="btn btn-ghost btn-sm text-success" onclick="convertPreSale('${esc(s.ID)}')">Convert</button><button class="btn btn-ghost btn-sm text-danger" onclick="cancelPreSale('${esc(s.ID)}')">Cancel</button>`
+                  ${isPreSale ? `<button class="btn btn-ghost btn-sm" onclick="openEditPreSale('${esc(s.ID)}')">Edit</button><button class="btn btn-ghost btn-sm text-success" onclick="convertPreSale('${esc(s.ID)}')">Convert</button>${_presaleHasMergePeers(s) ? `<button class="btn btn-ghost btn-sm" onclick="openMergePresales('${esc(s.ID)}')">Merge</button>` : ''}<button class="btn btn-ghost btn-sm text-danger" onclick="cancelPreSale('${esc(s.ID)}')">Cancel</button>`
                   : `${s.Status === 'Pending' || s.Status === 'Draft' ? `<button class="btn btn-ghost btn-sm text-success" onclick="markOrderPaid('${esc(s.ID)}')">Paid</button>` : ''}
                   <button class="btn btn-ghost btn-sm" onclick="openEditOrder('${esc(s.ID)}')">${s.Status === 'Paid' ? 'View' : 'Edit'}</button>
                   <button class="btn btn-ghost btn-sm text-danger" onclick="deleteOrder('${esc(s.ID)}')">Del</button>
@@ -1965,6 +1965,117 @@ async function cancelPreSale(id) {
     if (state.view === 'account-profile') loadAccountProfile(state.accountProfileId);
     else loadOrders();
   });
+}
+
+// True when this pre-sale has at least one other pre-sale peer for the same
+// account — used to decide whether to show the Merge action.
+function _presaleHasMergePeers(presale) {
+  if (!presale || presale.Status !== 'Pre-Sale' || !presale.AccountID) return false;
+  const source = _profilePresaleSource() || _ordersCache;
+  return source.some(o =>
+    o.ID !== presale.ID
+    && o.Status === 'Pre-Sale'
+    && o.AccountID === presale.AccountID
+  );
+}
+
+// When rendering from the account profile, the pre-sales list lives in
+// _profileOrdersCache (accounts.js). Try that first, then fall back to the
+// main orders cache. Both are set on the page they belong to.
+function _profilePresaleSource() {
+  if (typeof _profileOrdersCache !== 'undefined' && Array.isArray(_profileOrdersCache) && _profileOrdersCache.length) {
+    return _profileOrdersCache;
+  }
+  return null;
+}
+
+// Merge two or more of an account's pre-sales into one. Opens a modal with
+// the target row highlighted and every other pre-sale for the account
+// listed with a checkbox. On confirm, calls POST /api/orders/:id/merge-presales
+// which combines line items, sums matching InventoryID+PriceTier lines,
+// rewrites RequestedProducts, appends notes, and deletes the source rows.
+async function openMergePresales(targetId) {
+  const source = _profilePresaleSource() || _ordersCache;
+  const target = source.find(o => o.ID === targetId);
+  if (!target) return;
+  const peers = source.filter(o =>
+    o.ID !== targetId
+    && o.Status === 'Pre-Sale'
+    && o.AccountID === target.AccountID
+  );
+  if (peers.length === 0) { toast('No other pre-sales to merge for this account', 'error'); return; }
+
+  const summarize = (o) => {
+    const parts = [];
+    if (o.DeliveryDate) parts.push(`Expected ${formatDate(o.DeliveryDate)}`);
+    if (o.OrderAmount && parseFloat(o.OrderAmount) > 0) parts.push(fmtMoney(o.OrderAmount));
+    const rp = (o.RequestedProducts || '').trim();
+    if (rp) parts.push(rp.length > 80 ? rp.slice(0, 80) + '…' : rp);
+    return parts.join(' · ');
+  };
+
+  const peerRows = peers.map(p => `
+    <label class="dropdown-multi-item" style="display:flex;gap:10px;align-items:flex-start;padding:8px 4px;border-bottom:1px solid var(--border-light);cursor:pointer">
+      <input type="checkbox" class="merge-presale-src" data-id="${esc(p.ID)}" data-staff="${esc(p.StaffID || '')}" data-location="${esc(p.Location || '')}" data-date="${esc(p.DeliveryDate || '')}" style="margin-top:3px" />
+      <div style="flex:1;min-width:0">
+        <div class="fw-600">${esc(summarize(p)) || 'Pre-sale ' + esc(p.ID.slice(0, 8))}</div>
+      </div>
+    </label>`).join('');
+
+  modal.open('Merge Pre-Sales', `
+    <p class="text-sm text-muted" style="margin-bottom:12px">
+      Combine other pre-sales for <strong>${esc(target.AccountName || 'this account')}</strong> into the one you started from.
+      Line items with the same product and price tier will be summed; other lines are appended. The source pre-sales are deleted after merging.
+    </p>
+    <div class="form-group">
+      <label>Keep this pre-sale (target)</label>
+      <div class="text-sm" style="padding:8px 10px;background:#f7f7f8;border-radius:6px">
+        ${esc(summarize(target)) || 'Pre-sale ' + esc(target.ID.slice(0, 8))}
+      </div>
+    </div>
+    <div class="form-group">
+      <label>Merge these into it</label>
+      <div style="max-height:280px;overflow-y:auto;border:1px solid var(--border);border-radius:6px;padding:4px 10px">
+        ${peerRows}
+      </div>
+    </div>
+    <div id="merge-presale-warning" class="text-sm" style="margin-top:8px"></div>`,
+    async () => {
+      const checked = Array.from(document.querySelectorAll('.merge-presale-src:checked'));
+      if (checked.length === 0) { toast('Select at least one pre-sale to merge', 'error'); return; }
+      const sourceIds = checked.map(cb => cb.dataset.id);
+      try {
+        await api.post(`/api/orders/${encodeURIComponent(targetId)}/merge-presales`, { sourceIds });
+        modal.close();
+        toast(`Merged ${sourceIds.length} pre-sale${sourceIds.length !== 1 ? 's' : ''}`);
+        if (state.view === 'account-profile') loadAccountProfile(state.accountProfileId);
+        else loadOrders();
+      } catch (err) {
+        toast('Merge failed: ' + (err.message || 'unknown error'), 'error');
+      }
+    }, 'Merge');
+
+  // After render, wire the checkboxes to surface a warning when any selected
+  // source's StaffID/Location/DeliveryDate differs from the target's — the
+  // merge will keep the target's values, so the user should sanity-check.
+  const targetStaff = target.StaffID || '';
+  const targetLoc = target.Location || '';
+  const targetDate = target.DeliveryDate || '';
+  const warnEl = document.getElementById('merge-presale-warning');
+  const refreshWarn = () => {
+    const checked = Array.from(document.querySelectorAll('.merge-presale-src:checked'));
+    const diffs = new Set();
+    for (const cb of checked) {
+      if ((cb.dataset.staff || '') !== targetStaff) diffs.add('sales rep');
+      if ((cb.dataset.location || '') !== targetLoc) diffs.add('location');
+      if ((cb.dataset.date || '') !== targetDate) diffs.add('expected date');
+    }
+    if (diffs.size === 0) { warnEl.innerHTML = ''; return; }
+    warnEl.innerHTML = `<div style="padding:8px 10px;background:#fff3e0;border:1px solid #ffe0b2;border-radius:6px;color:#c46900">
+      <strong>Heads up:</strong> the target keeps its own ${[...diffs].join(', ')}. Selected pre-sales with different values won't preserve those fields.
+    </div>`;
+  };
+  document.querySelectorAll('.merge-presale-src').forEach(cb => cb.addEventListener('change', refreshWarn));
 }
 
 async function openPaymentModal(id, onComplete) {

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -138,6 +138,143 @@ router.put('/:id', async (req, res) => {
   }
 });
 
+/**
+ * POST /api/orders/:id/merge-presales
+ * Merge one or more pre-sale orders into the target pre-sale. All ORDER_ITEMS
+ * from the sources are moved onto the target, deduplicating lines that share
+ * InventoryID + PriceTier by summing their quantities. Notes are appended
+ * with a separator. Source rows are deleted.
+ *
+ * Guards: target and all sources must exist, have Status='Pre-Sale', and
+ * share the same AccountID.
+ *
+ * @body {{ sourceIds: string[] }}
+ * @returns {{ success: true, target: object, mergedSourceIds: string[] }}
+ */
+router.post('/:id/merge-presales', async (req, res) => {
+  try {
+    const targetId = req.params.id;
+    const { sourceIds } = req.body || {};
+    if (!Array.isArray(sourceIds) || sourceIds.length === 0) {
+      return res.status(400).json({ error: 'sourceIds must be a non-empty array' });
+    }
+    if (sourceIds.includes(targetId)) {
+      return res.status(400).json({ error: 'sourceIds cannot include the target order' });
+    }
+
+    const orders = await getAllRows('ORDERS');
+    const target = orders.find(o => o.ID === targetId);
+    if (!target) return res.status(404).json({ error: 'Target order not found' });
+    if (target.Status !== 'Pre-Sale') return res.status(400).json({ error: 'Target is not a pre-sale' });
+
+    const sources = [];
+    for (const sid of sourceIds) {
+      const s = orders.find(o => o.ID === sid);
+      if (!s) return res.status(404).json({ error: `Source ${sid} not found` });
+      if (s.Status !== 'Pre-Sale') return res.status(400).json({ error: `Source ${sid} is not a pre-sale` });
+      if (s.AccountID !== target.AccountID) return res.status(400).json({ error: 'All pre-sales must belong to the same account' });
+      sources.push(s);
+    }
+
+    const allItems = await getAllRows('ORDER_ITEMS');
+    const targetItems = allItems.filter(i => i.OrderID === targetId);
+
+    // Build a dedupe key so the same InventoryID + PriceTier (or, for custom
+    // items with no InventoryID, ProductName + Format) collapse into one row
+    // rather than showing two lines of the same beer with different qty.
+    const keyFor = (it) => it.InventoryID
+      ? `inv:${it.InventoryID}|${it.PriceTier || ''}`
+      : `custom:${(it.ProductName || '').toLowerCase().trim()}|${(it.Format || '').toLowerCase().trim()}|${it.PriceTier || ''}`;
+
+    const byKey = new Map();
+    for (const it of targetItems) byKey.set(keyFor(it), { ...it });
+
+    for (const src of sources) {
+      const srcItems = allItems.filter(i => i.OrderID === src.ID);
+      for (const it of srcItems) {
+        // Skip Account Credit rows — they're payment plumbing, not products,
+        // and don't belong on merged pre-sales.
+        if (it.ProductName === 'Account Credit') continue;
+        const k = keyFor(it);
+        if (byKey.has(k)) {
+          const existing = byKey.get(k);
+          const combinedQty = (parseInt(existing.Quantity) || 0) + (parseInt(it.Quantity) || 0);
+          const unitPrice = parseFloat(existing.UnitPrice || it.UnitPrice || 0);
+          existing.Quantity  = String(combinedQty);
+          existing.LineTotal = (combinedQty * unitPrice).toFixed(2);
+        } else {
+          byKey.set(k, { ...it });
+        }
+      }
+    }
+
+    // Replace target's ORDER_ITEMS wholesale with the merged set, and drop
+    // all source ORDER_ITEMS.
+    for (const it of targetItems) await deleteRow('ORDER_ITEMS', it.ID);
+    for (const src of sources) {
+      const srcItems = allItems.filter(i => i.OrderID === src.ID);
+      for (const it of srcItems) await deleteRow('ORDER_ITEMS', it.ID);
+    }
+    const now = new Date().toISOString();
+    const mergedItems = [];
+    for (const it of byKey.values()) {
+      const row = {
+        ID: uuidv4(),
+        OrderID: targetId,
+        InventoryID: it.InventoryID || '',
+        ProductName: it.ProductName || '',
+        Format: it.Format || '',
+        PriceTier: it.PriceTier || '',
+        Quantity: String(it.Quantity || '0'),
+        UnitPrice: String(it.UnitPrice || '0'),
+        LineTotal: String(it.LineTotal || '0'),
+        Taxable: it.Taxable || '',
+        EndCustomerAccountID: it.EndCustomerAccountID || '',
+        EndCustomerName: it.EndCustomerName || '',
+        CreatedAt: now,
+      };
+      await addRow('ORDER_ITEMS', row);
+      mergedItems.push(row);
+    }
+
+    // Recompute the target order's summary fields from the merged items.
+    const newOrderAmount = mergedItems
+      .reduce((sum, it) => sum + (parseFloat(it.LineTotal) || 0), 0)
+      .toFixed(2);
+    const requestedText = mergedItems
+      .map(it => {
+        const qty = parseInt(it.Quantity) || 0;
+        if (qty <= 0) return '';
+        let label = it.Format ? `${it.ProductName} (${it.Format})` : it.ProductName;
+        if (it.PriceTier) label += ` [${it.PriceTier}]`;
+        return `${qty}x ${label}`;
+      })
+      .filter(Boolean)
+      .join(', ');
+
+    // Append source notes with a separator so nothing is silently lost.
+    const noteParts = [target.Notes || ''].filter(Boolean);
+    for (const src of sources) {
+      if (src.Notes) noteParts.push(`--- Merged from pre-sale ${src.ID.slice(0, 8)}:\n${src.Notes}`);
+    }
+
+    await updateRow('ORDERS', targetId, {
+      OrderAmount: newOrderAmount,
+      RequestedProducts: requestedText,
+      Notes: noteParts.join('\n'),
+    });
+
+    // Delete source orders.
+    for (const src of sources) await deleteRow('ORDERS', src.ID);
+
+    const updatedTarget = getRow('ORDERS', targetId);
+    res.json({ success: true, target: updatedTarget, mergedSourceIds: sources.map(s => s.ID) });
+  } catch (err) {
+    console.error(`[orders] merge-presales: ${err.message}`);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 router.delete('/:id', async (req, res) => {
   try {
     const id = req.params.id;


### PR DESCRIPTION
## Summary
Closes #449. Pre-sales for a single account often accumulate (different beers coming back in stock at different times). When two or more are actually going to ship together, there was no way to combine them — each stayed a separate pre-sale that had to be converted independently.

Add a Merge action to the pre-sale row menu (both the orders list and the account profile Order History) that combines the account's other pre-sales into the one you started from.

## Backend
- \`POST /api/orders/:id/merge-presales\` with body \`{ sourceIds: string[] }\`
- Combines \`ORDER_ITEMS\` from all sources onto the target
  - Lines with the same \`InventoryID + PriceTier\` are summed into one row
  - Custom items are deduped by \`ProductName + Format + PriceTier\` (case-insensitive)
  - Account Credit rows are skipped (payment plumbing, not products)
- Recomputes the target's \`OrderAmount\` and \`RequestedProducts\`
- Appends each source's Notes to the target with a separator so nothing is lost
- Deletes source \`ORDER_ITEMS\` and \`ORDERS\` rows
- Guards: target and all sources must exist, all \`Status='Pre-Sale'\`, all share \`AccountID\`, target ID not in \`sourceIds\`

## Client
- Merge action only appears when the account has ≥2 pre-sales (no clutter otherwise)
- Modal shows the target row highlighted + checkbox list of peer pre-sales with a compact summary
- Warns when any selected source's \`StaffID\` / \`Location\` / \`DeliveryDate\` differs from the target's — those fields aren't merged, the target's are kept
- Reloads current view on success

## Test plan
- [ ] Account with a single pre-sale → no Merge button in the row menu
- [ ] Account with 2+ pre-sales → Merge appears; opens modal with the other pre-sales listed
- [ ] Merge two pre-sales that share a product+format → merged pre-sale shows the combined quantity in one line
- [ ] Merge two pre-sales with disjoint products → merged pre-sale has both line items
- [ ] After merge: \`OrderAmount\` matches sum of merged line items; \`RequestedProducts\` text summary regenerated from the merged items
- [ ] Notes from source pre-sales appear in target Notes with a separator
- [ ] Source pre-sales are deleted (gone from orders list, allocations, etc.)
- [ ] Merge from the account profile Order History → same flow, same result
- [ ] Selected source with different Delivery Date → yellow warning banner appears
- [ ] Attempt to merge a pre-sale from a different account (via API) → 400
- [ ] Attempt to merge a converted-to-Pending order → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)