### PR TITLE
Exclude pre-sales from inventory allocations (closes #451)

### DIFF
--- a/routes/inventory.js
+++ b/routes/inventory.js
@@ -43,12 +43,16 @@ router.get('/', async (req, res) => {
     if (location) items = items.filter(i => i.Location === location);
     items = await enrichInventory(items);
 
-    // Compute allocated units from non-cancelled, undelivered orders
+    // Compute allocated units from non-cancelled, undelivered orders.
+    // Pre-sales are intentionally excluded (issue #451): they often sit on
+    // the books weeks out and shouldn't consume inventory available for
+    // current orders. Draft is included since it usually represents a
+    // near-term order still being finalized.
     const orders = await getAllRows('ORDERS');
     const orderItems = await getAllRows('ORDER_ITEMS');
     const activeOrderIds = new Set(
       orders
-        .filter(o => o.Status !== 'Cancelled' && o.Delivered !== 'true')
+        .filter(o => o.Status !== 'Cancelled' && o.Status !== 'Pre-Sale' && o.Delivered !== 'true')
         .map(o => o.ID)
     );
     const allocMap = {};
@@ -73,7 +77,8 @@ router.get('/', async (req, res) => {
 
 // GET /api/inventory/:id/allocations — orders allocating this inventory item
 // Returns orders that contribute to the Allocated count: non-cancelled,
-// undelivered orders with at least one line item referencing this inventory.
+// non-pre-sale, undelivered orders with at least one line item referencing
+// this inventory. Guards must mirror the aggregate above.
 router.get('/:id/allocations', async (req, res) => {
   try {
     const item = await getRow('INVENTORY', req.params.id);
@@ -91,6 +96,7 @@ router.get('/:id/allocations', async (req, res) => {
       const order = orderMap[oi.OrderID];
       if (!order) continue;
       if (order.Status === 'Cancelled') continue;
+      if (order.Status === 'Pre-Sale') continue;
       if (order.Delivered === 'true') continue;
       qtyByOrder[order.ID] = (qtyByOrder[order.ID] || 0) + parseInt(oi.Quantity || '0');
     }


### PR DESCRIPTION
## Summary
Closes #451. Reverses the "pre-sales count as allocations" design decision from #295. In practice, pre-sales are recorded 30–45 days out, so counting them distorts what a user *actually* has available for current orders.

## Fix
Filter \`Status='Pre-Sale'\` out of both allocation code paths in \`routes/inventory.js\`:
- Aggregate \`Allocated\` count on \`GET /api/inventory\`
- Per-item breakdown on \`GET /api/inventory/:id/allocations\`

Pre-sales still write real \`ORDER_ITEMS\` rows (needed for edit / merge / convert / text-summary regeneration) — they just don't consume inventory anywhere.

Draft is deliberately still counted (represents a near-term order being finalized). Cancelled and Delivered orders remain excluded as before.

## Note on future work
The user mentioned they *do* want to see pre-sale demand somewhere for planning purposes ("we need to see the future inventory that's needed"). That's a separate feature — a Pre-Sale Demand column or report — and out of scope for this fix.

## Test plan
- [ ] Enter a pre-sale for a beer → Available inventory for that beer doesn't drop
- [ ] Convert the pre-sale to a Pending order → Available drops (unchanged behavior)
- [ ] Click Allocated count on inventory → pre-sales don't appear in the list
- [ ] Cancel/Delivered orders still excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)