### PR TITLE
Fix Pre-Sales report crash from unregistered pagination key

### DIFF
--- a/public/js/core.js
+++ b/public/js/core.js
@@ -34,6 +34,7 @@ const _pagination = {
   gallonage:   { page: 1, perPage: 25 },
   salesExport: { page: 1, perPage: 25 },
   forecast:    { page: 1, perPage: 25 },
+  presaleDemand: { page: 1, perPage: 25 },
   profileOutreach: { page: 1, perPage: 10 },
   profileTodos:    { page: 1, perPage: 10 },
   profileOrders:   { page: 1, perPage: 10 },


### PR DESCRIPTION
## Summary
- Register \`presaleDemand\` in the \`_pagination\` map in \`public/js/core.js\` so \`_paginationReset('presaleDemand')\` (called from \`loadPresaleDemand()\`) doesn't blow up with *Cannot set properties of undefined (setting 'page')*.

Regression from #453 — the client-side pagination store is a hard-coded map and every view key must be registered up front. The report page was crashing on load for anyone who navigated to it.

## Test plan
- [ ] Navigate to **Reports → Pre-Sales**; page loads without error banner.
- [ ] Change page size / paginate — controls behave normally.
- [ ] Existing report pages (Forecast, Sales Export, Gallonage) still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)