### PR TITLE
Polish pre-sale badge: inline pill next to Available

### DIFF
--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -153,11 +153,13 @@ function renderInventory() {
                 <td class="mobile-hide">${parseInt(item.Allocated || '0') > 0
                   ? `<a href="#" class="action-link" onclick="event.preventDefault(); openInventoryAllocations('${esc(item.ID)}')">${esc(item.Allocated)}</a>`
                   : esc(item.Allocated || '0')}</td>
-                <td>${esc(item.Available || item.Units || '0')}${parseInt(item.PreSaleDemand || '0') > 0
-                  ? `<br><a href="#" class="text-muted text-sm action-link" onclick="event.preventDefault(); openInventoryPreSales('${esc(item.ID)}')" title="Open pre-sale demand for this product">
-                      ${esc(item.PreSaleOrderCount || '0')} pre-sale${parseInt(item.PreSaleOrderCount || '0') !== 1 ? 's' : ''} · ${esc(item.PreSaleDemand)}u
-                    </a>`
-                  : ''}</td>
+                <td><div class="cell-available">
+                  <span>${esc(item.Available || item.Units || '0')}</span>
+                  ${parseInt(item.PreSaleDemand || '0') > 0 ? (() => {
+                    const cnt = parseInt(item.PreSaleOrderCount || '0');
+                    return `<a href="#" class="badge badge-pre-sale badge-clickable" onclick="event.preventDefault(); openInventoryPreSales('${esc(item.ID)}')" title="${cnt} pre-sale${cnt !== 1 ? 's' : ''} · ${esc(item.PreSaleDemand)} unit${parseInt(item.PreSaleDemand) !== 1 ? 's' : ''} pre-sold — click to view">${esc(item.PreSaleDemand)}u</a>`;
+                  })() : ''}
+                </div></td>
                 <td class="mobile-hide">${item.PricePerUnit ? '$' + esc(item.PricePerUnit) : '—'}</td>
                 <td><span class="badge ${low ? 'badge-low-stock' : 'badge-ok-stock'}">${out ? 'Out' : low ? 'Low' : 'OK'}</span></td>
                 <td class="td-actions">

--- a/public/style.css
+++ b/public/style.css
@@ -767,6 +767,11 @@ tbody td {
 .badge-low-stock { background: var(--danger-bg); color: var(--danger-text); }
 .badge-ok-stock  { background: var(--success-bg); color: var(--success-text); }
 
+.badge-clickable { cursor: pointer; text-decoration: none; text-transform: none; }
+.badge-clickable:hover { filter: brightness(0.95); }
+
+.cell-available { display: inline-flex; align-items: center; gap: 6px; flex-wrap: nowrap; }
+
 /* Order status badges */
 .badge-draft     { background: #f5f5f5; color: #616161; }
 .badge-pre-sale  { background: #f3e5f5; color: #7b1fa2; }


### PR DESCRIPTION
## Summary
The pre-sale demand indicator on Stock Levels used to render *below* the Available number as a small link ("1 pre-sale · 4u"), which wrapped awkwardly in the narrow column and read as noise. Replaced with a compact purple pill sitting *next to* the Available number.

- Reuses \`badge-pre-sale\` (same purple as the pre-sale order-status pill) for visual consistency.
- Pill shows just the volume: **\`4u\`** — order count moved to the tooltip (\`3 pre-sales · 4 units pre-sold — click to view\`). One number in a pill scans faster than a compound label.
- Wrapped in \`.cell-available\` (\`inline-flex\` + \`nowrap\`) so the pill never wraps under the number, even on narrow mobile columns.
- New \`.badge-clickable\` utility (cursor pointer, no underline, hover dim) — reusable for any future drill-down badge.
- Click behavior unchanged: opens the existing pre-sales drill-down modal.

### Before
\`\`\`
4
1 pre-sale ·
4u                          ← ugly wrap
\`\`\`

### After
\`\`\`
4  [ 4u ]                   ← inline pill, purple
\`\`\`

## Test plan
- [ ] Open Stock Levels — rows with pre-sale demand show a purple \`Nu\` pill next to the Available number, on one line.
- [ ] Hover the pill — tooltip reads \`N pre-sale(s) · X unit(s) pre-sold — click to view\`.
- [ ] Click the pill — drill-down modal opens with the same list as before.
- [ ] Rows with no pre-sale demand render Available cleanly with no extra whitespace.
- [ ] Check on mobile — pill stays inline in the tight Available column, doesn't wrap under.

🤖 Generated with [Claude Code](https://claude.com/claude-code)